### PR TITLE
Changed is_null call with direct strict comparison (for performance reasons)

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -150,7 +150,7 @@ class Requests {
 	protected static function get_transport() {
 		// Caching code, don't bother testing coverage
 		// @codeCoverageIgnoreStart
-		if (!is_null(self::$transport)) {
+		if (self::$transport !== null) {
 			return new self::$transport();
 		}
 		// @codeCoverageIgnoreEnd

--- a/library/Requests/Response/Headers.php
+++ b/library/Requests/Response/Headers.php
@@ -49,7 +49,7 @@ class Requests_Response_Headers implements ArrayAccess, IteratorAggregate {
 	 * @param string $value Header value
 	 */
 	public function offsetSet($key, $value) {
-		if (is_null($key)) {
+		if ($key === null) {
 			throw new Requests_Exception('Headers is a dictionary, not a list', 'invalidset');
 		}
 


### PR DESCRIPTION
It's interesting to use direct strict comparison instead of calling the is_null function to avoid the little overhead of calling a function (interesting in cases where the code is called thousands of times per second).

An interesting discussion about this topic in stackoverflow: http://stackoverflow.com/questions/8228837/is-nullx-vs-x-null-in-php :) .
