### PR TITLE
Add autoload to the howto install with Composer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ dependencies, you can add Requests with it.
     {
         "require": {
             "rmccue/requests": ">=1.0"
+        },
+        "autoload": {
+            "psr-0": {"Requests": "library/"}
         }
     }
 


### PR DESCRIPTION
This commit shows users how to autoload Requests when using composer, as Requests doesn't have an autoload entry in its composer.json
