### PR TITLE
Fixed exception on relative redirects by adding the scheme://host back into the request

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -417,8 +417,8 @@ class Requests {
 				$options['redirected']++;
 				$location = $return->headers['location'];
 				if (strpos ($location, '/') === 0) {
-					// relative redirect, add the scheme://user:pass@hostname back in
-					$location = join ('/', array_slice (explode ('/', $url), 0, 3)) . $location;
+					// relative redirect, for compatibility make it absolute
+					$location = Requests_IRI::absolutize($url, $location);
 				}
 				$redirected = self::request($location, $req_headers, $req_data, false, $options);
 				$redirected->history[] = $return;


### PR DESCRIPTION
Relative redirects (e.g., `/redirect/here`) were triggering a Requests_Exception "Only HTTP requests
are handled." because it's verifying http(s) is present. This adds the missing scheme up to the
hostname back into the URL before redirecting.
