### PR TITLE
specify autoload information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
 	},
 	"type": "library",
 	"autoload": {
-            "psr-0": {"Requests": "library/"}
-        }
+		"psr-0": {"Requests": "library/"}
+	}
 }


### PR DESCRIPTION
As far I see the autoload attribute in a form you specified in [Install with Composer](https://github.com/rmccue/Requests#install-with-composer) actually must be added into your library.

Currently, to make Requests works with composer's autoload the one must specify full path in the project's composer.json file, i.e.:

```
"autoload": {
    "psr-0": {"Requests": "vendor/rmccue/requests/library/"}
}
```
