### PR TITLE
Changed the way the request separates body and headers

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -510,7 +510,7 @@ class Requests {
 			}
 
 			$headers = substr($return->raw, 0, $pos);
-            $return->body = substr($return->raw, $pos + strlen("\n\r\n\r"));
+			$return->body = substr($return->raw, $pos + strlen("\n\r\n\r"));
 		}
 		else {
 			$return->body = '';


### PR DESCRIPTION
I was GETing a .csv file from a web service and strangely the response body was being chopped. I came to this conclusion after using a `var_dump($response)` that the size of `$response->body` and the size of `$response->headers` wasn't equal (or even came close) to the size of `$response->raw`. I believe that one of the uses of `explode()` or `array_pop()` would cause data loss. Now using `substr()` and it seems that the issue was resolved.
