### PR TITLE
Illegal offset type in isset or empty

### DIFF
--- a/library/Requests/IRI.php
+++ b/library/Requests/IRI.php
@@ -800,7 +800,7 @@ class Requests_IRI
         {
             return true;
         }
-        elseif (isset($cache[$iri]))
+        elseif (isset($cache[(string)$iri]))
         {
             list($this->scheme,
                  $this->iuserinfo,
@@ -822,7 +822,7 @@ class Requests_IRI
                 && $this->set_query($parsed['query'])
                 && $this->set_fragment($parsed['fragment']);
 
-            $cache[$iri] = array($this->scheme,
+            $cache[(string)$iri] = array($this->scheme,
                                  $this->iuserinfo,
                                  $this->ihost,
                                  $this->port,


### PR DESCRIPTION
When you try to recursively load microsoft.com, you get a error 
Illegal offset type in lines 803 and 825

This dirty hack fixes the problem.

However every now and then the requests runs into a loop, producing IRI as object not string.

here's the callstack
5   0.0116  800464  Requests::request( )    ..\Requests.php:194
6   0.3851  1256920 Requests::parse_response( ) ..\Requests.php:313
7   0.3882  1289184 Requests::request( )    ..\Requests.php:562
8   0.3883  1290208 Requests::set_defaults( )   ..\Requests.php:295
9   0.3883  1290920 Requests_IRI->__construct( )    ..\Requests.php:477
10  0.3883  1290920 Requests_IRI->set_iri( )    ..\IRI.php:250
