### PR TITLE
Trying to use void return value

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -415,7 +415,7 @@ class Requests {
 			// correct response
 			if (is_string($response)) {
 				$request = $requests[$id];
-				$response = self::parse_multiple($response, $request);
+				self::parse_multiple($response, $request);
 				$request['options']['hooks']->dispatch('multiple.request.complete', array(&$response, $id));
 			}
 		}


### PR DESCRIPTION
self::parse_multiple() doesn't return anything. It sets the response via the by-ref $response arg
