### PR TITLE
Verify SSL certificate when using cURL

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -68,8 +68,6 @@ class Requests_Transport_cURL implements Requests_Transport {
 		if (version_compare($this->version, '7.10.5', '>=')) {
 			curl_setopt($this->fp, CURLOPT_ENCODING, '');
 		}
-		curl_setopt ($this->fp, CURLOPT_SSL_VERIFYHOST, 0);
-		curl_setopt ($this->fp, CURLOPT_SSL_VERIFYPEER, 0);
 	}
 
 	/**
@@ -91,6 +89,20 @@ class Requests_Transport_cURL implements Requests_Transport {
 		if ($options['filename'] !== false) {
 			$this->stream_handle = fopen($options['filename'], 'wb');
 			curl_setopt($this->fp, CURLOPT_FILE, $this->stream_handle);
+		}
+
+		if (isset($options['verify'])) {
+			if ($options['verify'] === false) {
+				curl_setopt($this->fp, CURLOPT_SSL_VERIFYHOST, 0);
+				curl_setopt($this->fp, CURLOPT_SSL_VERIFYPEER, 0);
+
+			} elseif (is_string($options['verify'])) {
+				curl_setopt($this->fp, CURLOPT_CAINFO, $options['verify']);
+			}
+		}
+
+		if (isset($options['verifyname']) && $options['verifyname'] === false) {
+			curl_setopt($this->fp, CURLOPT_SSL_VERIFYHOST, 0);
 		}
 
 		$response = curl_exec($this->fp);


### PR DESCRIPTION
I feel that silently disabling SSL verification by default (as it is done in the cURL transport) is a very, very bad idea.  

This requests re-enables the verification by default. If for some reason the user needs to disable the check, it can be done via the `verify` option (as it is done in the Python Requests library). The verify option can be set either to `false` (to disable the checks) or to path to a file containing trusted CA certificates (`CURLOPT_CAINFO`).

I also added another option, not present in the python library - `verifyname`. If set to `false`, it won't check whether the certificate holder name equals to the remote host name (`CURLOPT_SSL_VERIFYHOST` option).

I didn't add the support of these options to the `multi_request` method, since I don't know how to do it - the `curl_ multi_ setopt` function is not documented at all.
