### PR TITLE
Readme fix related to PSR-0 class loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Alternatively, you can fetch a [tarball][] or [zipball][]:
 If you're using a class loader (e.g., [Symfony Class Loader][]) for
 [PSR-0][]-style class loading:
 
-    $loader->registerNamespace('Requests', 'path/to/vendor/Requests/library');
+    $loader->registerPrefix('Requests', 'path/to/vendor/Requests/library');
 
 [Symfony Class Loader]: https://github.com/symfony/ClassLoader
 [PSR-0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md


### PR DESCRIPTION
Hello,

I've added today Requests to an existing app that already uses the Symfony Class Loader.

According to the documentation I have to use:

```
$loader->registerNamespace('Requests', 'path/to/vendor/Requests/library');
```

However this doesn't work, as Requests doesn't use namespaces. I figured out that the proper way to initialize Requests with the class loader is to use the `registerPrefix` method instead:

```
$loader->registerPrefix('Requests', 'path/to/vendor/Requests/library');
```

I fixed it in the README
