### PR TITLE
Remove explicit autoload in Composer installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ dependencies, you can add Requests with it.
     {
         "require": {
             "rmccue/requests": ">=1.0"
-        },
-        "autoload": {
-            "psr-0": {"Requests": "library/"}
         }
     }
 


### PR DESCRIPTION
Composer will use the autoload instructions from the project's
internal composer.json.
