### PR TITLE
Remove explicit autoload in Composer installation instructions

### DIFF
--- a/index.md
+++ b/index.md
@@ -62,9 +62,6 @@ dependencies, you can add Requests with it.
     {
         "require": {
             "rmccue/requests": ">=1.0"
-        },
-        "autoload": {
-            "psr-0": {"Requests": "library/"}
         }
     }
 


### PR DESCRIPTION
Same as #86, only on the website.
