### PR TITLE
added support fot HTTP Digest Authorization

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -266,6 +266,9 @@ class Requests {
 	 *    (string|boolean, default: false)
 	 * - `auth`: Authentication handler or array of user/password details to use
 	 *    for Basic authentication
+     *    (Requests_Auth|array|boolean, default: false)*
+     * - `auth_digest`: Authentication handler or array of user/password details to use
+   	 *    for Digest authentication*
 	 *    (Requests_Auth|array|boolean, default: false)
 	 * - `proxy`: Proxy details to use for proxy by-passing and authentication
 	 *    (Requests_Proxy|array|boolean, default: false)
@@ -451,6 +454,7 @@ class Requests {
 			'type' => self::GET,
 			'filename' => false,
 			'auth' => false,
+			'auth_digest' => false,
 			'proxy' => false,
 			'cookies' => false,
 			'idn' => true,
@@ -490,6 +494,13 @@ class Requests {
 		if ($options['auth'] !== false) {
 			$options['auth']->register($options['hooks']);
 		}
+
+        if (is_array($options['auth_digest'])) {
+            $options['auth_digest'] = new Requests_Auth_Digest($options['auth_digest']);
+        }
+        if ($options['auth_digest'] !== false) {
+            $options['auth_digest']->register($options['hooks']);
+        }
 
 		if (!empty($options['proxy'])) {
 			$options['proxy'] = new Requests_Proxy_HTTP($options['proxy']);

--- a/library/Requests/Auth/Digest.php
+++ b/library/Requests/Auth/Digest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Digest Authentication provider
+ *
+ * Provides a handler for Basic HTTP authentication via the Authorization
+ * header.
+ *
+ * @package Requests
+ * @subpackage Authentication
+ */
+class Requests_Auth_Digest implements Requests_Auth {
+	/**
+	 * Username
+	 *
+	 * @var string
+	 */
+	public $user;
+
+	/**
+	 * Password
+	 *
+	 * @var string
+	 */
+	public $pass;
+
+	/**
+	 * Constructor
+	 *
+	 * @throws Requests_Exception On incorrect number of arguments (`authdigestbadargs`)
+	 * @param array|null $args Array of user and password. Must have exactly two elements
+	 */
+	public function __construct($args = null) {
+		if (is_array($args)) {
+			if (count($args) !== 2) {
+				throw new Requests_Exception('Invalid number of arguments', 'authdigestbadargs');
+			}
+
+			list($this->user, $this->pass) = $args;
+		}
+	}
+
+	/**
+	 * Register the necessary callbacks
+	 *
+	 * @see curl_before_send
+	 * @see fsockopen_header
+	 * @param Requests_Hooks $hooks Hook system
+	 */
+	public function register(Requests_Hooks &$hooks) {
+		$hooks->register('curl.before_send', array(&$this, 'curl_before_send'));
+		$hooks->register('fsockopen.after_headers', array(&$this, 'fsockopen_header'));
+	}
+
+	/**
+	 * Set cURL parameters before the data is sent
+	 *
+	 * @param resource $handle cURL resource
+	 */
+	public function curl_before_send(&$handle) {
+		curl_setopt($handle, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+		curl_setopt($handle, CURLOPT_USERPWD, $this->getAuthString());
+	}
+
+	/**
+	 * Add extra headers to the request before sending
+	 *
+	 * @param string $out HTTP header string
+	 */
+	public function fsockopen_header(&$out) {
+		$out .= "Authorization: Digest " . base64_encode($this->getAuthString()) . "\r\n";
+	}
+
+	/**
+	 * Get the authentication string (user:pass)
+	 *
+	 * @return string
+	 */
+	public function getAuthString() {
+		return $this->user . ':' . $this->pass;
+	}
+}


### PR DESCRIPTION
Hello. I really like your library, its amazing. I'm using it on my work and I found that it has no http digest auth support (only http basic)
I've added missing Digest HTTP Auth support. Just small update in Requests.php and new file (copy-paste Basic.php -> Digest.php with a little updates).
