### PR TITLE
Restrict CURLOPT_PROTOCOLS on `defined()` instead of `version_compare()`

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -68,8 +68,11 @@ class Requests_Transport_cURL implements Requests_Transport {
 		if (version_compare($this->version, '7.10.5', '>=')) {
 			curl_setopt($this->fp, CURLOPT_ENCODING, '');
 		}
-		if (version_compare($this->version, '7.19.4', '>=')) {
+		if (defined('CURLOPT_PROTOCOLS')) {
 			curl_setopt($this->fp, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+		}
+		if (defined('CURLOPT_REDIR_PROTOCOLS')) {
+			curl_setopt($this->fp, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 		}
 	}
 


### PR DESCRIPTION
Instead of setting `CURLOPT_PROTOCOLS` upon a `version_compare()`, why not simply do it upon a `defined`? 

Besides of being simpler, it might
- cope with potential weird builds of libcurl showing a recent version but not implement that option?
- fix the Travis errors when using HHVM ?
