### PR TITLE
Actually check cookie expirations

### DIFF
--- a/library/Requests/Cookie.php
+++ b/library/Requests/Cookie.php
@@ -82,6 +82,32 @@ class Requests_Cookie {
 	}
 
 	/**
+	 * Check if a cookie is expired.
+	 *
+	 * Checks the age against $this->reference_time to determine if the cookie
+	 * is expired.
+	 *
+	 * @return boolean True if expired, false if time is valid.
+	 */
+	public function is_expired() {
+		// RFC6265, s. 4.1.2.2:
+		// If a cookie has both the Max-Age and the Expires attribute, the Max-
+		// Age attribute has precedence and controls the expiration date of the
+		// cookie.
+		if (isset($this->attributes['max-age'])) {
+			$max_age = $this->attributes['max-age'];
+			return $max_age < $this->reference_time;
+		}
+
+		if (isset($this->attributes['expires'])) {
+			$expires = $this->attributes['expires'];
+			return $expires < $this->reference_time;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Check if a cookie is valid for a given URI
 	 *
 	 * @param Requests_IRI $uri URI to check

--- a/library/Requests/Cookie.php
+++ b/library/Requests/Cookie.php
@@ -425,10 +425,10 @@ class Requests_Cookie {
 			// Default domain/path attributes
 			if (empty($parsed->attributes['domain']) && !empty($origin)) {
 				$parsed->attributes['domain'] = $origin->host;
-				$parsed->flags['host-only'] = false;
+				$parsed->flags['host-only'] = true;
 			}
 			else {
-				$parsed->flags['host-only'] = true;
+				$parsed->flags['host-only'] = false;
 			}
 
 			$path_is_valid = (!empty($parsed->attributes['path']) && $parsed->attributes['path'][0] === '/');

--- a/library/Requests/Cookie.php
+++ b/library/Requests/Cookie.php
@@ -45,13 +45,23 @@ class Requests_Cookie {
 	public $flags = array();
 
 	/**
+	 * Reference time for relative calculations
+	 *
+	 * This is used in place of `time()` when calculating Max-Age expiration and
+	 * checking time validity.
+	 *
+	 * @var int
+	 */
+	public $reference_time = 0;
+
+	/**
 	 * Create a new cookie object
 	 *
 	 * @param string $name
 	 * @param string $value
 	 * @param array $attributes Associative array of attribute data
 	 */
-	public function __construct($name, $value, $attributes = array(), $flags = array()) {
+	public function __construct($name, $value, $attributes = array(), $flags = array(), $reference_time = null) {
 		$this->name = $name;
 		$this->value = $value;
 		$this->attributes = $attributes;
@@ -62,6 +72,11 @@ class Requests_Cookie {
 			'host-only' => true,
 		);
 		$this->flags = array_merge($default_flags, $flags);
+
+		$this->reference_time = time();
+		if ($reference_time !== null) {
+			$this->reference_time = $reference_time;
+		}
 
 		$this->normalize();
 	}
@@ -246,7 +261,7 @@ class Requests_Cookie {
 					$expiry_time = 0;
 				}
 				else {
-					$expiry_time = time() + $delta_seconds;
+					$expiry_time = $this->reference_time + $delta_seconds;
 				}
 
 				return $expiry_time;
@@ -321,7 +336,7 @@ class Requests_Cookie {
 	 * @param string Cookie header value (from a Set-Cookie header)
 	 * @return Requests_Cookie Parsed cookie object
 	 */
-	public static function parse($string, $name = '') {
+	public static function parse($string, $name = '', $reference_time = null) {
 		$parts = explode(';', $string);
 		$kvparts = array_shift($parts);
 
@@ -362,7 +377,7 @@ class Requests_Cookie {
 			}
 		}
 
-		return new Requests_Cookie($name, $value, $attributes);
+		return new Requests_Cookie($name, $value, $attributes, array(), $reference_time);
 	}
 
 	/**

--- a/library/Requests/Cookie.php
+++ b/library/Requests/Cookie.php
@@ -412,7 +412,7 @@ class Requests_Cookie {
 	 * @param Requests_Response_Headers $headers
 	 * @return array
 	 */
-	public static function parseFromHeaders(Requests_Response_Headers $headers, Requests_IRI $origin = null) {
+	public static function parseFromHeaders(Requests_Response_Headers $headers, Requests_IRI $origin = null, $reference_time = null) {
 		$cookie_headers = $headers->getValues('Set-Cookie');
 		if (empty($cookie_headers)) {
 			return array();
@@ -420,7 +420,7 @@ class Requests_Cookie {
 
 		$cookies = array();
 		foreach ($cookie_headers as $header) {
-			$parsed = self::parse($header);
+			$parsed = self::parse($header, '', $reference_time);
 
 			// Default domain/path attributes
 			if (empty($parsed->attributes['domain']) && !empty($origin)) {

--- a/library/Requests/Cookie.php
+++ b/library/Requests/Cookie.php
@@ -458,7 +458,7 @@ class Requests_Cookie {
 			}
 
 			// Reject invalid cookie domains
-			if (!$parsed->domainMatches($origin->host)) {
+			if (!empty($origin) && !$parsed->domainMatches($origin->host)) {
 				continue;
 			}
 

--- a/library/Requests/Cookie/Jar.php
+++ b/library/Requests/Cookie/Jar.php
@@ -131,6 +131,11 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 			foreach ($this->cookies as $key => $cookie) {
 				$cookie = $this->normalizeCookie($cookie, $key);
 
+				// Skip expired cookies
+				if ($cookie->is_expired()) {
+					continue;
+				}
+
 				if ( $cookie->domainMatches( $url->host ) ) {
 					$cookies[] = $cookie->formatForHeader();
 				}

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -124,6 +124,23 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('testvalue1', $data['requests-testcookie1']);
 	}
 
+	/**
+	 * @depends testSendingCookie
+	 */
+	public function testCookieExpiration() {
+		$options = array(
+			'follow_redirects' => true,
+		);
+		$url = httpbin('/cookies/set/testcookie/testvalue');
+		$url .= '?expiry=1';
+
+		$response = Requests::get($url, array(), $options);
+		$response->throw_for_status();
+
+		$data = json_decode($response->body, true);
+		$this->assertEmpty($data['cookies']);
+	}
+
 	public function testSendingCookieWithJar() {
 		$cookies = new Requests_Cookie_Jar(array(
 			'requests-testcookie1' => 'testvalue1',

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -222,6 +222,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 
 	public function pathMatchProvider() {
 		return array(
+			array('/',      '',       true),
 			array('/',      '/',      true),
 
 			array('/',      '/test',  true),

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -495,4 +495,40 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 			}
 		}
 	}
+
+	/**
+	 * @dataProvider parseResultProvider
+	 */
+	public function testParsingHeaderObject($header, $expected, $expected_attributes = array(), $expected_flags = array()) {
+		$headers = new Requests_Response_Headers();
+		$headers['Set-Cookie'] = $header;
+
+		// Set the reference time to 2014-01-01 00:00:00
+		$reference_time = gmmktime( 0, 0, 0, 1, 1, 2014 );
+
+		$parsed = Requests_Cookie::parseFromHeaders($headers, null, $reference_time);
+		$this->assertCount(1, $parsed);
+
+		$cookie = reset($parsed);
+		if (isset($expected['name'])) {
+			$this->assertArrayHasKey($expected['name'], $parsed);
+			$this->assertEquals($expected['name'], $cookie->name);
+		}
+		if (isset($expected['value'])) {
+			$this->assertEquals($expected['value'], $cookie->value);
+		}
+		if (isset($expected['expired'])) {
+			$this->assertEquals($expected['expired'], $cookie->is_expired());
+		}
+		if (isset($expected_attributes)) {
+			foreach ($expected_attributes as $attr_key => $attr_val) {
+				$this->assertEquals($attr_val, $cookie->attributes[$attr_key]);
+			}
+		}
+		if (isset($expected_flags)) {
+			foreach ($expected_flags as $flag_key => $flag_val) {
+				$this->assertEquals($flag_val, $cookie->attributes[$flag_key]);
+			}
+		}
+	}
 }

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -343,4 +343,131 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($cookie->uriMatches(new Requests_IRI('http://example.net/test')));
 		$this->assertTrue($cookie->uriMatches(new Requests_IRI('http://example.net/test/')));
 	}
+
+	public static function parseResultProvider() {
+		return array(
+			// Basic parsing
+			array(
+				'foo=bar',
+				array( 'name' => 'foo', 'value' => 'bar' ),
+			),
+			array(
+				'bar',
+				array( 'name' => '', 'value' => 'bar' ),
+			),
+
+			// Expiration
+			array(
+				// RFC 822, updated by RFC 1123
+				'foo=bar; Expires=Fri, 5-Dec-2014 04:50:12 GMT',
+				array(),
+				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2014 ) ),
+			),
+			array(
+				// RFC 850, obsoleted by RFC 1036
+				'foo=bar; Expires=Friday, 5-Dec-2014 04:50:12 GMT',
+				array(),
+				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2014 ) ),
+			),
+			array(
+				// asctime()
+				'foo=bar; Expires=Fri Dec  5 04:50:12 2014',
+				array(),
+				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2014 ) ),
+			),
+			array(
+				// Invalid
+				'foo=bar; Expires=never',
+				array(),
+				array( 'expires' => null ),
+			),
+
+			// Max-Age
+			array(
+				'foo=bar; Max-Age=10',
+				array(),
+				array( 'max-age' => gmmktime( 0, 0, 10, 1, 1, 2014 ) ),
+			),
+			array(
+				'foo=bar; Max-Age=3660',
+				array(),
+				array( 'max-age' => gmmktime( 1, 1, 0, 1, 1, 2014 ) ),
+			),
+			array(
+				'foo=bar; Max-Age=0',
+				array(),
+				array( 'max-age' => 0 ),
+			),
+			array(
+				'foo=bar; Max-Age=-1000',
+				array(),
+				array( 'max-age' => 0 ),
+			),
+			array(
+				// Invalid (non-digit character)
+				'foo=bar; Max-Age=1e6',
+				array(),
+				array( 'max-age' => null ),
+			)
+		);
+	}
+
+	/**
+	 * @dataProvider parseResultProvider
+	 */
+	public function testParsingHeader($header, $expected, $expected_attributes = array(), $expected_flags = array()) {
+		// Set the reference time to 2014-01-01 00:00:00
+		$reference_time = gmmktime( 0, 0, 0, 1, 1, 2014 );
+
+		$cookie = Requests_Cookie::parse($header, null, $reference_time);
+
+		if (isset($expected['name'])) {
+			$this->assertEquals($expected['name'], $cookie->name);
+		}
+		if (isset($expected['value'])) {
+			$this->assertEquals($expected['value'], $cookie->value);
+		}
+		if (isset($expected_attributes)) {
+			foreach ($expected_attributes as $attr_key => $attr_val) {
+				$this->assertEquals($attr_val, $cookie->attributes[$attr_key]);
+			}
+		}
+		if (isset($expected_flags)) {
+			foreach ($expected_flags as $flag_key => $flag_val) {
+				$this->assertEquals($flag_val, $cookie->attributes[$flag_key]);
+			}
+		}
+	}
+
+	/**
+	 * Double-normalizes the cookie data to ensure we catch any issues there
+	 *
+	 * @dataProvider parseResultProvider
+	 */
+	public function testParsingHeaderDouble($header, $expected, $expected_attributes = array(), $expected_flags = array()) {
+		// Set the reference time to 2014-01-01 00:00:00
+		$reference_time = gmmktime( 0, 0, 0, 1, 1, 2014 );
+
+		$cookie = Requests_Cookie::parse($header, null, $reference_time);
+
+		// Normalize the value again
+		$cookie->normalize();
+
+		if (isset($expected['name'])) {
+			$this->assertEquals($expected['name'], $cookie->name);
+		}
+		if (isset($expected['value'])) {
+			$this->assertEquals($expected['value'], $cookie->value);
+		}
+		if (isset($expected_attributes)) {
+			foreach ($expected_attributes as $attr_key => $attr_val) {
+				$this->assertEquals($attr_val, $cookie->attributes[$attr_key]);
+			}
+		}
+		if (isset($expected_flags)) {
+			foreach ($expected_flags as $flag_key => $flag_val) {
+				$this->assertEquals($flag_val, $cookie->attributes[$flag_key]);
+			}
+		}
+	}
 }

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -431,15 +431,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider parseResultProvider
-	 */
-	public function testParsingHeader($header, $expected, $expected_attributes = array(), $expected_flags = array()) {
-		// Set the reference time to 2014-01-01 00:00:00
-		$reference_time = gmmktime( 0, 0, 0, 1, 1, 2014 );
-
-		$cookie = Requests_Cookie::parse($header, null, $reference_time);
-
+	protected function check_parsed_cookie($cookie, $expected, $expected_attributes, $expected_flags = array()) {
 		if (isset($expected['name'])) {
 			$this->assertEquals($expected['name'], $cookie->name);
 		}
@@ -451,14 +443,25 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		}
 		if (isset($expected_attributes)) {
 			foreach ($expected_attributes as $attr_key => $attr_val) {
-				$this->assertEquals($attr_val, $cookie->attributes[$attr_key]);
+				$this->assertEquals($attr_val, $cookie->attributes[$attr_key], "$attr_key should match supplied");
 			}
 		}
 		if (isset($expected_flags)) {
 			foreach ($expected_flags as $flag_key => $flag_val) {
-				$this->assertEquals($flag_val, $cookie->attributes[$flag_key]);
+				$this->assertEquals($flag_val, $cookie->flags[$flag_key], "$flag_key should match supplied");
 			}
 		}
+	}
+
+	/**
+	 * @dataProvider parseResultProvider
+	 */
+	public function testParsingHeader($header, $expected, $expected_attributes = array(), $expected_flags = array()) {
+		// Set the reference time to 2014-01-01 00:00:00
+		$reference_time = gmmktime( 0, 0, 0, 1, 1, 2014 );
+
+		$cookie = Requests_Cookie::parse($header, null, $reference_time);
+		$this->check_parsed_cookie($cookie, $expected, $expected_attributes);
 	}
 
 	/**
@@ -475,25 +478,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		// Normalize the value again
 		$cookie->normalize();
 
-		if (isset($expected['name'])) {
-			$this->assertEquals($expected['name'], $cookie->name);
-		}
-		if (isset($expected['value'])) {
-			$this->assertEquals($expected['value'], $cookie->value);
-		}
-		if (isset($expected['expired'])) {
-			$this->assertEquals($expected['expired'], $cookie->is_expired());
-		}
-		if (isset($expected_attributes)) {
-			foreach ($expected_attributes as $attr_key => $attr_val) {
-				$this->assertEquals($attr_val, $cookie->attributes[$attr_key]);
-			}
-		}
-		if (isset($expected_flags)) {
-			foreach ($expected_flags as $flag_key => $flag_val) {
-				$this->assertEquals($flag_val, $cookie->attributes[$flag_key]);
-			}
-		}
+		$this->check_parsed_cookie($cookie, $expected, $expected_attributes, $expected_flags);
 	}
 
 	/**
@@ -510,25 +495,6 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$this->assertCount(1, $parsed);
 
 		$cookie = reset($parsed);
-		if (isset($expected['name'])) {
-			$this->assertArrayHasKey($expected['name'], $parsed);
-			$this->assertEquals($expected['name'], $cookie->name);
-		}
-		if (isset($expected['value'])) {
-			$this->assertEquals($expected['value'], $cookie->value);
-		}
-		if (isset($expected['expired'])) {
-			$this->assertEquals($expected['expired'], $cookie->is_expired());
-		}
-		if (isset($expected_attributes)) {
-			foreach ($expected_attributes as $attr_key => $attr_val) {
-				$this->assertEquals($attr_val, $cookie->attributes[$attr_key]);
-			}
-		}
-		if (isset($expected_flags)) {
-			foreach ($expected_flags as $flag_key => $flag_val) {
-				$this->assertEquals($flag_val, $cookie->attributes[$flag_key]);
-			}
-		}
+		$this->check_parsed_cookie($cookie, $expected, $expected_attributes, $expected_flags);
 	}
 }

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -360,20 +360,35 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 			),
 
 			// Expiration
+			// RFC 822, updated by RFC 1123
 			array(
-				// RFC 822, updated by RFC 1123
+				'foo=bar; Expires=Thu, 5-Dec-2013 04:50:12 GMT',
+				array( 'expired' => true ),
+				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2013 ) ),
+			),
+			array(
 				'foo=bar; Expires=Fri, 5-Dec-2014 04:50:12 GMT',
 				array( 'expired' => false ),
 				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2014 ) ),
 			),
+			// RFC 850, obsoleted by RFC 1036
 			array(
-				// RFC 850, obsoleted by RFC 1036
+				'foo=bar; Expires=Thursday, 5-Dec-2013 04:50:12 GMT',
+				array( 'expired' => true ),
+				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2013 ) ),
+			),
+			array(
 				'foo=bar; Expires=Friday, 5-Dec-2014 04:50:12 GMT',
 				array( 'expired' => false ),
 				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2014 ) ),
 			),
+			// asctime()
 			array(
-				// asctime()
+				'foo=bar; Expires=Thu Dec  5 04:50:12 2013',
+				array( 'expired' => true ),
+				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2013 ) ),
+			),
+			array(
 				'foo=bar; Expires=Fri Dec  5 04:50:12 2014',
 				array( 'expired' => false ),
 				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2014 ) ),

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -363,19 +363,19 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 			array(
 				// RFC 822, updated by RFC 1123
 				'foo=bar; Expires=Fri, 5-Dec-2014 04:50:12 GMT',
-				array(),
+				array( 'expired' => false ),
 				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2014 ) ),
 			),
 			array(
 				// RFC 850, obsoleted by RFC 1036
 				'foo=bar; Expires=Friday, 5-Dec-2014 04:50:12 GMT',
-				array(),
+				array( 'expired' => false ),
 				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2014 ) ),
 			),
 			array(
 				// asctime()
 				'foo=bar; Expires=Fri Dec  5 04:50:12 2014',
-				array(),
+				array( 'expired' => false ),
 				array( 'expires' => gmmktime( 4, 50, 12, 12, 5, 2014 ) ),
 			),
 			array(
@@ -388,28 +388,28 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 			// Max-Age
 			array(
 				'foo=bar; Max-Age=10',
-				array(),
+				array( 'expired' => false ),
 				array( 'max-age' => gmmktime( 0, 0, 10, 1, 1, 2014 ) ),
 			),
 			array(
 				'foo=bar; Max-Age=3660',
-				array(),
+				array( 'expired' => false ),
 				array( 'max-age' => gmmktime( 1, 1, 0, 1, 1, 2014 ) ),
 			),
 			array(
 				'foo=bar; Max-Age=0',
-				array(),
+				array( 'expired' => true ),
 				array( 'max-age' => 0 ),
 			),
 			array(
 				'foo=bar; Max-Age=-1000',
-				array(),
+				array( 'expired' => true ),
 				array( 'max-age' => 0 ),
 			),
 			array(
 				// Invalid (non-digit character)
 				'foo=bar; Max-Age=1e6',
-				array(),
+				array( 'expired' => false ),
 				array( 'max-age' => null ),
 			)
 		);
@@ -429,6 +429,9 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		}
 		if (isset($expected['value'])) {
 			$this->assertEquals($expected['value'], $cookie->value);
+		}
+		if (isset($expected['expired'])) {
+			$this->assertEquals($expected['expired'], $cookie->is_expired());
 		}
 		if (isset($expected_attributes)) {
 			foreach ($expected_attributes as $attr_key => $attr_val) {
@@ -461,6 +464,9 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		}
 		if (isset($expected['value'])) {
 			$this->assertEquals($expected['value'], $cookie->value);
+		}
+		if (isset($expected['expired'])) {
+			$this->assertEquals($expected['expired'], $cookie->is_expired());
 		}
 		if (isset($expected_attributes)) {
 			foreach ($expected_attributes as $attr_key => $attr_val) {


### PR DESCRIPTION
Fixes #129.

* [x] Parse `Expires` attribute from cookie header
* [x] Parse `Max-Age` attribute from cookie header
* [x] Add ability to check cookie time validity
* [x] Check cookies are valid before sending