### PR TITLE
GET request should respect query data parameter

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -189,14 +189,15 @@ class Requests {
 	 * @see request()
 	 * @param string $url
 	 * @param array $headers
+	 * @param array $data
 	 * @param array $options
 	 * @return Requests_Response
 	 */
 	/**
 	 * Send a GET request
 	 */
-	public static function get($url, $headers = array(), $options = array()) {
-		return self::request($url, $headers, null, self::GET, $options);
+	public static function get($url, $headers = array(), $data = array(), $options = array()) {
+		return self::request($url, $headers, $data, self::GET, $options);
 	}
 
 	/**


### PR DESCRIPTION
GET seems to ignore any data that gets passed. It should be able to process query strings for the URL.