### PR TITLE
Mention two PHP extension dependencies in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ set of tests. We're not quite there yet, but [we're getting close][coveralls].
 
 [coveralls]: https://coveralls.io/r/rmccue/Requests?branch=master
 
-To run the test suite, simply:
+To run the test suite, first check that you have the [PHP
+JSON extension ](http://php.net/manual/en/book.json.php) enabled. Then
+simply:
 
     $ cd tests
     $ phpunit


### PR DESCRIPTION
The PHP cURL extension is needed for the library itself, as can be
seen e.g. by the use of all the CURL_FOO constants. When compiling PHP
from source, this is an optional extension, so we mention it in the
README.

The test suite requires the additional JSON extension, for the
json_decode() function called throughout the suite. This is now
mentioned in the README as well.
