### PR TITLE
Fix/Rationalize transports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Ignore coverage report
 tests/coverage/*
+
+# Ignore composer related files
+/composer.lock
+/vendor

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -594,11 +594,12 @@ class Requests {
 		// Unfold headers (replace [CRLF] 1*( SP | HT ) with SP) as per RFC 2616 (section 2.2)
 		$headers = preg_replace('/\n[ \t]/', ' ', $headers);
 		$headers = explode("\n", $headers);
-		preg_match('#^HTTP/1\.\d[ \t]+(\d+)#i', array_shift($headers), $matches);
+		preg_match('#^HTTP/(1\.\d)[ \t]+(\d+)#i', array_shift($headers), $matches);
 		if (empty($matches)) {
 			throw new Requests_Exception('Response could not be parsed', 'noversion', $headers);
 		}
-		$return->status_code = (int) $matches[1];
+		$return->protocol_version = (float) $matches[1];
+		$return->status_code = (int) $matches[2];
 		if ($return->status_code >= 200 && $return->status_code < 300) {
 			$return->success = true;
 		}

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -55,6 +55,20 @@ class Requests {
 	const DELETE = 'DELETE';
 
 	/**
+	 * OPTIONS method
+	 *
+	 * @var string
+	 */
+	const OPTIONS = 'OPTIONS';
+
+	/**
+	 * TRACE method
+	 *
+	 * @var string
+	 */
+	const TRACE = 'TRACE';
+
+	/**
 	 * PATCH method
 	 *
 	 * @link http://tools.ietf.org/html/rfc5789
@@ -181,7 +195,7 @@ class Requests {
 		if (self::$transport[$cap_string] === null) {
 			throw new Requests_Exception('No working transports found', 'notransport', self::$transports);
 		}
-		
+
 		return new self::$transport[$cap_string]();
 	}
 
@@ -233,6 +247,20 @@ class Requests {
 	 */
 	public static function put($url, $headers = array(), $data = array(), $options = array()) {
 		return self::request($url, $headers, $data, self::PUT, $options);
+	}
+
+	/**
+	 * Send an OPTIONS request
+	 */
+	public static function options($url, $headers = array(), $data = array(), $options = array()) {
+		return self::request($url, $headers, $data, self::OPTIONS, $options);
+	}
+
+	/**
+	 * Send a TRACE request
+	 */
+	public static function trace($url, $headers = array(), $data = array(), $options = array()) {
+		return self::request($url, $headers, $data, self::TRACE, $options);
 	}
 
 	/**
@@ -450,6 +478,7 @@ class Requests {
 			'timeout' => 10,
 			'connect_timeout' => 10,
 			'useragent' => 'php-requests/' . self::VERSION,
+			'protocol_version' => 1.1,
 			'redirected' => 0,
 			'redirects' => 10,
 			'follow_redirects' => true,
@@ -518,6 +547,10 @@ class Requests {
 			$iri = new Requests_IRI($url);
 			$iri->host = Requests_IDNAEncoder::encode($iri->ihost);
 			$url = $iri->uri;
+		}
+
+		if (!isset($options['data_as_query'])) {
+			$options['data_as_query'] = in_array($options['type'], array(Requests::HEAD, Requests::GET, Requests::DELETE));
 		}
 	}
 

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -549,8 +549,8 @@ class Requests {
 			$url = $iri->uri;
 		}
 
-		if (!isset($options['data_as_query'])) {
-			$options['data_as_query'] = in_array($options['type'], array(Requests::HEAD, Requests::GET, Requests::DELETE));
+		if (!isset($options['data_format'])) {
+			$options['data_format'] = 'default';
 		}
 	}
 

--- a/library/Requests/Response.php
+++ b/library/Requests/Response.php
@@ -45,6 +45,12 @@ class Requests_Response {
 	public $status_code = false;
 
 	/**
+	 * Protocol version, false if non-blocking
+	 * @var float|boolean
+	 */
+	public $protocol_version = false;
+
+	/**
 	 * Whether the request succeeded or not
 	 * @var boolean
 	 */

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -231,7 +231,18 @@ class Requests_Transport_cURL implements Requests_Transport {
 		$headers = Requests::flatten($headers);
 
 		if (!empty($data)) {
-			if ($options['data_as_query']) {
+			$data_format = $options['data_format'];
+
+			if ($data_format === 'default') {
+				if (in_array($options['type'], array(Requests::HEAD, Requests::GET, Requests::DELETE))) {
+					$data_format = 'query';
+				}
+				else {
+					$data_format = 'body';
+				}
+			}
+
+			if ($data_format === 'query') {
 				$url = self::format_get($url, $data);
 				$data = '';
 			}

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -234,7 +234,8 @@ class Requests_Transport_cURL implements Requests_Transport {
 			if ($options['data_as_query']) {
 				$url = self::format_get($url, $data);
 				$data = '';
-			} elseif (!is_string($data)) {
+			}
+			elseif (!is_string($data)) {
 				$data = http_build_query($data, null, '&');
 			}
 		}
@@ -274,7 +275,13 @@ class Requests_Transport_cURL implements Requests_Transport {
 		curl_setopt($this->fp, CURLOPT_REFERER, $url);
 		curl_setopt($this->fp, CURLOPT_USERAGENT, $options['useragent']);
 		curl_setopt($this->fp, CURLOPT_HTTPHEADER, $headers);
-		curl_setopt($this->fp, CURLOPT_HTTP_VERSION, $options['protocol_version'] == 1.1 ? CURL_HTTP_VERSION_1_1 : CURL_HTTP_VERSION_1_0);
+
+		if ($options['protocol_version'] === 1.1) {
+			curl_setopt($this->fp, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+		}
+		else {
+			curl_setopt($this->fp, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+		}
 
 		if (true === $options['blocking']) {
 			curl_setopt($this->fp, CURLOPT_HEADERFUNCTION, array(&$this, 'stream_headers'));

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -48,7 +48,8 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 	 * @param array $options Request options, see {@see Requests::response()} for documentation
 	 * @return string Raw HTTP result
 	 */
-	public function request($url, $headers = array(), $data = array(), $options = array()) {
+	public function request($url, $headers = array(), $data = array(), $options = array())
+	{
 		$options['hooks']->dispatch('fsockopen.before_request');
 
 		$url_parts = parse_url($url);
@@ -89,13 +90,12 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 			}
 
 			stream_context_set_option($context, array('ssl' => $context_options));
-		}
-		else {
+		} else {
 			$remote_socket = 'tcp://' . $host;
 		}
 
-		$proxy = isset( $options['proxy'] );
-		$proxy_auth = $proxy && isset( $options['proxy_username'] ) && isset( $options['proxy_password'] );
+		$proxy = isset($options['proxy']);
+		$proxy_auth = $proxy && isset($options['proxy_username']) && isset($options['proxy_password']);
 
 		if (!isset($url_parts['port'])) {
 			$url_parts['port'] = 80;
@@ -110,10 +110,8 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 
 		restore_error_handler();
 
-		if ($verifyname) {
-			if (!$this->verify_certificate_from_context($host, $context)) {
-				throw new Requests_Exception('SSL certificate did not match the requested domain name', 'ssl.no_match');
-			}
+		if ($verifyname && !$this->verify_certificate_from_context($host, $context)) {
+			throw new Requests_Exception('SSL certificate did not match the requested domain name', 'ssl.no_match');
 		}
 
 		if (!$fp) {
@@ -121,51 +119,39 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 				// Connection issue
 				throw new Requests_Exception(rtrim($this->connect_error), 'fsockopen.connect_error');
 			}
-			else {
-				throw new Requests_Exception($errstr, 'fsockopenerror');
-				return;
-			}
+
+			throw new Requests_Exception($errstr, 'fsockopenerror');
 		}
 
 		$request_body = '';
 		$out = '';
-		switch ($options['type']) {
-			case Requests::POST:
-			case Requests::PUT:
-			case Requests::PATCH:
-				if (isset($url_parts['path'])) {
-					$path = $url_parts['path'];
-					if (isset($url_parts['query'])) {
-						$path .= '?' . $url_parts['query'];
-					}
-				}
-				else {
-					$path = '/';
-				}
 
-				$options['hooks']->dispatch( 'fsockopen.remote_host_path', array( &$path, $url ) );
-				$out = $options['type'] . " $path HTTP/1.0\r\n";
+		if ($options['data_as_query']) {
+			$path = self::format_get($url_parts, $data);
+			$data = '';
+		} else {
+			$path = self::format_get($url_parts, array());
+		}
 
-				if (is_array($data)) {
-					$request_body = http_build_query($data, null, '&');
-				}
-				else {
-					$request_body = $data;
-				}
+		$options['hooks']->dispatch('fsockopen.remote_host_path', array(&$path, $url));
+		$out = $options['type'] . " $path HTTP/" . $options['protocol_version'] . "\r\n";
+
+		if ($options['type'] !== Requests::TRACE) {
+			if (is_array($data)) {
+				$request_body = http_build_query($data, null, '&');
+			} else {
+				$request_body = $data;
+			}
+
+			if (!empty($data)) {
 				if (empty($headers['Content-Length'])) {
 					$headers['Content-Length'] = strlen($request_body);
 				}
+
 				if (empty($headers['Content-Type'])) {
 					$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
 				}
-				break;
-			case Requests::HEAD:
-			case Requests::GET:
-			case Requests::DELETE:
-				$path = self::format_get($url_parts, $data);
-				$options['hooks']->dispatch('fsockopen.remote_host_path', array(&$path, $url));
-				$out = $options['type'] . " $path HTTP/1.0\r\n";
-				break;
+			}
 		}
 		$out .= "Host: {$url_parts['host']}";
 
@@ -174,7 +160,12 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		}
 		$out .= "\r\n";
 
-		$out .= "User-Agent: {$options['useragent']}\r\n";
+		$lowerHeaders = array_change_key_case($headers);
+
+		if (!isset($lowerHeaders['user-agent'])) {
+			$out .= "User-Agent: {$options['useragent']}\r\n";
+		}
+
 		$accept_encoding = $this->accept_encoding();
 		if (!empty($accept_encoding)) {
 			$out .= "Accept-Encoding: $accept_encoding\r\n";
@@ -192,7 +183,11 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 			$out .= "\r\n";
 		}
 
-		$out .= "Connection: Close\r\n\r\n" . $request_body;
+		if (!isset($lowerHeaders['connection'])) {
+			$out .= "Connection: Close\r\n";
+		}
+
+		$out .= "\r\n" . $request_body;
 
 		$options['hooks']->dispatch('fsockopen.before_send', array(&$out));
 

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -125,8 +125,18 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 			throw new Requests_Exception($errstr, 'fsockopenerror');
 		}
 
+		$data_format = $options['data_format'];
 
-		if ($options['data_as_query']) {
+		if ($data_format === 'default') {
+			if (in_array($options['type'], array(Requests::HEAD, Requests::GET, Requests::DELETE))) {
+				$data_format = 'query';
+			}
+			else {
+				$data_format = 'body';
+			}
+		}
+
+		if ($data_format === 'query') {
 			$path = self::format_get($url_parts, $data);
 			$data = '';
 		}

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -147,7 +147,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		$options['hooks']->dispatch('fsockopen.remote_host_path', array(&$path, $url));
 
 		$request_body = '';
-		$out = $options['type'] . " $path HTTP/" . $options['protocol_version'] . "\r\n";
+		$out = $options['type'] . " $path HTTP/" . sprintf('%.1f', $options['protocol_version']) . "\r\n";
 
 		if ($options['type'] !== Requests::TRACE) {
 			if (is_array($data)) {

--- a/library/Requests/Utility/CaseInsensitiveDictionary.php
+++ b/library/Requests/Utility/CaseInsensitiveDictionary.php
@@ -21,6 +21,17 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	protected $data = array();
 
 	/**
+	 * Creates a case insensitive dictionary.
+	 *
+	 * @param array $data Item data
+	 */
+	public function __construct(array $data = array()) {
+		foreach ($data as $key => $value) {
+			$this->offsetSet($key, $value);
+		}
+	}
+
+	/**
 	 * Check if the given item exists
 	 *
 	 * @param string $key Item key

--- a/tests/Requests.php
+++ b/tests/Requests.php
@@ -51,6 +51,20 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 		}
 	}
 
+	public function testProtocolVersionParsing() {
+		$transport = new RawTransport();
+		$transport->data =
+			"HTTP/1.0 200 OK\r\n".
+			"Host: localhost\r\n\r\n";
+
+		$options = array(
+			'transport' => $transport
+		);
+
+		$response = Requests::get('http://example.com/', array(), $options);
+		$this->assertEquals(1.0, $response->protocol_version);
+	}
+
 	public function testRawAccess() {
 		$transport = new RawTransport();
 		$transport->data =

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -710,13 +710,23 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEmpty($result2['args']);
 	}
 
-	public function testDataAsQuery() {
+	public function testQueryDataFormat() {
 		$data = array('test' => 'true', 'test2' => 'test');
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions(array('data_as_query' => true)));
+		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions(array('data_format' => 'query')));
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
 		$this->assertEquals(httpbin('/post').'?test=true&test2=test', $result['url']);
 		$this->assertEquals('', $result['data']);
+	}
+
+	public function testBodyDataFormat() {
+		$data = array('test' => 'true', 'test2' => 'test');
+		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions(array('data_format' => 'body')));
+		$this->assertEquals(200, $request->status_code);
+
+		$result = json_decode($request->body, true);
+		$this->assertEquals(httpbin('/post'), $result['url']);
+		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
 	}
 }

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -110,6 +110,11 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('', $request->body);
 	}
 
+	public function testTRACE() {
+		$request = Requests::trace(httpbin('/get'), array(), $this->getOptions());
+		$this->assertEquals(200, $request->status_code);
+	}
+
 	public function testRawPOST() {
 		$data = 'test';
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
@@ -213,6 +218,11 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 
 		$result = json_decode($request->body, true);
 		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+	}
+
+	public function testOPTIONS() {
+		$request = Requests::options(httpbin('/post'), array(), array(), $this->getOptions());
+		$this->assertEquals(200, $request->status_code);
 	}
 
 	public function testDELETE() {
@@ -679,5 +689,34 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$portXpath = new DOMXPath($responseDoc);
 		$portXpathMatches = $portXpath->query('//p/b');
 		$this->assertEquals(8080, $portXpathMatches->item(0)->nodeValue);
+	}
+
+	public function testReusableTransport() {
+		$options = $this->getOptions(array('transport' => new $this->transport()));
+
+		$request1 = Requests::get(httpbin('/get'), array(), $options);
+		$request2 = Requests::get(httpbin('/get'), array(), $options);
+
+		$this->assertEquals(200, $request1->status_code);
+		$this->assertEquals(200, $request2->status_code);
+
+		$result1 = json_decode($request1->body, true);
+		$result2 = json_decode($request2->body, true);
+
+		$this->assertEquals(httpbin('/get'), $result1['url']);
+		$this->assertEquals(httpbin('/get'), $result2['url']);
+
+		$this->assertEmpty($result1['args']);
+		$this->assertEmpty($result2['args']);
+	}
+
+	public function testDataAsQuery() {
+		$data = array('test' => 'true', 'test2' => 'test');
+		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions(array('data_as_query' => true)));
+		$this->assertEquals(200, $request->status_code);
+
+		$result = json_decode($request->body, true);
+		$this->assertEquals(httpbin('/post').'?test=true&test2=test', $result['url']);
+		$this->assertEquals('', $result['data']);
 	}
 }


### PR DESCRIPTION
Hey!

This PR rationalizes/fixes some issues I encounter with the curl/fsockopen transports + add some new features.

### Context

I'm currently integrating this library in an http adapter (See egeloen/ivory-http-adapter#80). This library has a pretty robust test suite which have spotted some issues. This PR tries to fix all of them :)

### Issues

 * The curl transport initializes a curl resource at initialization. Then, if this resource is closed, the transport is not usable anymore. Instead of creating it at initialization, I have moved it in the `setup_handle` method which fixes the issue.
 * The curl transport merges the data in the uri for `DELETE` request but some service like AWS needs some extra info in `DELETE` request which needs to be passed by message body. According to #91, I have added the `data_as_query` option and updated the transport accordingly.
 * The fsockopen transport added arbitrary headers without looking for existence in the passed headers. This result of a duplication of headers.

### New features

 * Added support for the `OPTIONS` and `TRACE` http verbs.
 * Added support for `1.0` and `1.1` protocol versions in request/response.

Btw, this PR fixes #133, #137, #142 and #91. 

Waiting your feedbacks!