### PR TITLE
Allow size limit of data read

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -63,11 +63,11 @@ class Requests {
 	const PATCH = 'PATCH';
 
 	/**
-	 * Default size of buffer chunk size to read streams
+	 * Default size of buffer size to read streams
 	 *
 	 * @var integer
 	 */
-	const CHUNK = 1160;
+	const BUFFER_SIZE = 1160;
 
 	/**
 	 * Current version of Requests

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -104,7 +104,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 		if ($options['response_byte_limit'] !== false) {
 			$this->response_byte_limit = $options['response_byte_limit'];
 			$this->partial_response = '';
-			curl_setopt($this->fp, CURLOPT_BUFFERSIZE, Requests::CHUNK);
+			curl_setopt($this->fp, CURLOPT_BUFFERSIZE, Requests::BUFFER_SIZE);
 			curl_setopt($this->fp, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($this->fp, CURLOPT_WRITEFUNCTION, array($this,'response_limit_cb'));
 		}

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -223,7 +223,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 					throw new Requests_Exception('fsocket timed out', 'timeout');
 				}
 
-				$this->headers .= fread($fp, Requests::CHUNK);
+				$this->headers .= fread($fp, Requests::BUFFER_SIZE);
 			}
 		}
 		else {
@@ -236,7 +236,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 					throw new Requests_Exception('fsocket timed out', 'timeout');
 				}
 
-				$block = fread($fp, Requests::CHUNK);
+				$block = fread($fp, Requests::BUFFER_SIZE);
 				if ($doingbody) {
 					fwrite($download, $block);
 				}


### PR DESCRIPTION
This PR allows to fetch the XXX first bytes of a remote URL

Changes:
* New option: `response_byte_limit` to limit response body (integer | false)
* New constant: `CHUNK`, used to define the buffer chunk size, that was hardcoded in the socket transport class as 1160 and is now used also in the cURL class
* New test that passes with both transport

Key concept with cURL:
```php
<?php
$url  = 'http://httpbin.org/';
$html ='';

$ch = curl_init();
curl_setopt($ch, CURLOPT_URL,$url);

// These 3 settings
curl_setopt($ch, CURLOPT_BUFFERSIZE, 10); // smaller chunks = more progress checks
curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
curl_setopt($ch, CURLOPT_WRITEFUNCTION, 'write_function');

// callback : returns either strlen of data read (and continues) or 0 and halts with an error
function write_function($handle, $data) {
    global $html;
    $html .= $data;
    if (strlen($html) > 100) { // max size we want + one buffer size
        return 0;
    }
    else {
        return strlen($data);
    }
}


$res = curl_exec($ch);
curl_close($ch);
var_dump( $res, $html );
// $res = false, because we caused an error
// $html = the 100 first byte of the URL response
```

Key concept with sockets is obvious, instead of reading till `feof($fp)` you check the size of downloaded stuff so far.