### PR TITLE
Ignore coverage report files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore coverage report
+tests/coverage/*


### PR DESCRIPTION
Just a simple fix to get a cleaner `git status` without the gazillion coverage files