### PR TITLE
Tests discrepancies and an attempt to fix them

### DIFF
--- a/tests/Auth/Basic.php
+++ b/tests/Auth/Basic.php
@@ -74,7 +74,7 @@ class RequestsTest_Auth_Basic extends PHPUnit_Framework_TestCase {
 		$auth = explode(' ', $auth);
 
 		$this->assertEquals(base64_encode('user:passwd'), $auth[1]);
-        $this->assertEquals('test', $result->data);
+		$this->assertEquals('', $result->form->test);
 	}
 
 	/**

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -110,7 +110,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals('test', $result['data']);
+		$this->assertEquals('', $result['form']['test']);
 	}
 
 	public function testFormPost() {
@@ -155,7 +155,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals('test', $result['data']);
+		$this->assertEquals('', $result['form']['test']);
 	}
 
 	public function testFormPUT() {
@@ -185,7 +185,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals('test', $result['data']);
+		$this->assertEquals('', $result['form']['test']);
 	}
 
 	public function testFormPATCH() {
@@ -555,7 +555,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		// post
 		$this->assertEquals(200, $responses['post']->status_code);
 		$result = json_decode($responses['post']->body, true);
-		$this->assertEquals('test', $result['data']);
+		$this->assertEquals('', $result['form']['test']);
 	}
 
 	/**
@@ -653,7 +653,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		// POST request
 		$contents = file_get_contents($requests['post']['options']['filename']);
 		$result = json_decode($contents, true);
-		$this->assertEquals('test', $result['data']);
+		$this->assertEquals('', $result['form']['test']);
 		unlink($requests['post']['options']['filename']);
 	}
 

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -30,7 +30,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
@@ -39,7 +38,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/get?test=true&test2=test'), $result['url']);
 		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
 	}
 
@@ -52,7 +50,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/get?test=true&test2=test'), $result['url']);
 		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
 	}
 
@@ -68,7 +65,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/get?test=true&test2%5Btest3%5D=test&test2%5Btest4%5D=test-too'), $result['url']);
 		$this->assertEquals(array('test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'), $result['args']);
 	}
 
@@ -80,7 +76,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/get?test=true&test2=test'), $result['url']);
 		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
 	}
 
@@ -100,7 +95,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/stream/1'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
@@ -220,7 +214,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/delete'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
@@ -233,7 +226,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/delete?test=true&test2=test'), $result['url']);
 		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
 	}
 
@@ -395,7 +387,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 
 		$contents = file_get_contents($options['filename']);
 		$result = json_decode($contents, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 
 		unlink($options['filename']);
@@ -427,8 +418,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		// Disable, since httpbin always returns http
-		// $this->assertEquals(httpbin('/get', true), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
@@ -536,7 +525,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $responses['test1']->status_code);
 
 		$result = json_decode($responses['test1']->body, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 
 		// test2
@@ -545,7 +533,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $responses['test2']->status_code);
 
 		$result = json_decode($responses['test2']->body, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
@@ -660,14 +647,12 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		// GET request
 		$contents = file_get_contents($requests['get']['options']['filename']);
 		$result = json_decode($contents, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 		unlink($requests['get']['options']['filename']);
 
 		// POST request
 		$contents = file_get_contents($requests['post']['options']['filename']);
 		$result = json_decode($contents, true);
-		$this->assertEquals(httpbin('/post'), $result['url']);
 		$this->assertEquals('test', $result['data']);
 		unlink($requests['post']['options']['filename']);
 	}

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -307,11 +307,16 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	 * @dataProvider statusCodeSuccessProvider
 	 */
 	public function testStatusCode($code, $success) {
+		$transport = new MockTransport();
+		$transport->code = $code;
+		
 		$url = sprintf(httpbin('/status/%d'), $code);
+
 		$options = array(
 			'follow_redirects' => false,
+			'transport' => $transport,
 		);
-		$request = Requests::get($url, array(), $this->getOptions($options));
+		$request = Requests::get($url, array(), $options);
 		$this->assertEquals($code, $request->status_code);
 		$this->assertEquals($success, $request->success);
 	}
@@ -320,9 +325,13 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	 * @dataProvider statusCodeSuccessProvider
 	 */
 	public function testStatusCodeThrow($code, $success) {
+		$transport = new MockTransport();
+		$transport->code = $code;
+
 		$url = sprintf(httpbin('/status/%d'), $code);
 		$options = array(
 			'follow_redirects' => false,
+			'transport' => $transport,
 		);
 
 		if (!$success) {
@@ -333,7 +342,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 				$this->setExpectedException('Requests_Exception');
 			}
 		}
-		$request = Requests::get($url, array(), $this->getOptions($options));
+		$request = Requests::get($url, array(), $options);
 		$request->throw_for_status(false);
 	}
 
@@ -341,9 +350,13 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	 * @dataProvider statusCodeSuccessProvider
 	 */
 	public function testStatusCodeThrowAllowRedirects($code, $success) {
+		$transport = new MockTransport();
+		$transport->code = $code;
+
 		$url = sprintf(httpbin('/status/%d'), $code);
 		$options = array(
 			'follow_redirects' => false,
+			'transport' => $transport,
 		);
 
 		if (!$success) {
@@ -351,12 +364,19 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 				$this->setExpectedException('Requests_Exception_HTTP_' . $code, $code);
 			}
 		}
-		$request = Requests::get($url, array(), $this->getOptions($options));
+		$request = Requests::get($url, array(), $options);
 		$request->throw_for_status(true);
 	}
 
 	public function testStatusCodeUnknown(){
-		$request = Requests::get(httpbin('/status/599'), array(), $this->getOptions());
+		$transport = new MockTransport();
+		$transport->code = 599;
+
+		$options = array(
+			'transport' => $transport,
+		);
+
+		$request = Requests::get(httpbin('/status/599'), array(), $options);
 		$this->assertEquals(599, $request->status_code);
 		$this->assertEquals(false, $request->success);
 	}
@@ -365,7 +385,14 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception_HTTP_Unknown
 	 */
 	public function testStatusCodeThrowUnknown(){
-		$request = Requests::get(httpbin('/status/599'), array(), $this->getOptions());
+		$transport = new MockTransport();
+		$transport->code = 599;
+
+		$options = array(
+			'transport' => $transport,
+		);
+
+		$request = Requests::get(httpbin('/status/599'), array(), $options);
 		$request->throw_for_status(true);
 	}
 

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -657,8 +657,8 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		unlink($requests['post']['options']['filename']);
 	}
 
-	public function testHostHeader() {
-		$request = Requests::get('http://portquiz.positon.org:8080/', array(), $this->getOptions());
+	public function testAlternatePort() {
+		$request = Requests::get('http://portquiz.net:8080/', array(), $this->getOptions());
 		$responseDoc = new DOMDocument;
 		$responseDoc->loadHTML($request->body);
 		$portXpath = new DOMXPath($responseDoc);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -74,16 +74,21 @@ class MockTransport implements Requests_Transport {
 		415 => '415 Unsupported Media Type',
 		416 => '416 Requested Range Not Satisfiable',
 		417 => '417 Expectation Failed',
+		418 => '418 I\'m a teapot',
+		428 => '428 Precondition Required',
+		429 => '429 Too Many Requests',
+		431 => '431 Request Header Fields Too Large',
 		500 => '500 Internal Server Error',
 		501 => '501 Not Implemented',
 		502 => '502 Bad Gateway',
 		503 => '503 Service Unavailable',
 		504 => '504 Gateway Timeout',
 		505 => '505 HTTP Version Not Supported',
+		511 => '511 Network Authentication Required',
 	);
 
 	public function request($url, $headers = array(), $data = array(), $options = array()) {
-		$status = self::$messages[$this->code];
+		$status = isset(self::$messages[$this->code]) ? self::$messages[$this->code] : $this->code . ' unknown';
 		$response = "HTTP/1.0 $status\r\n";
 		$response .= "Content-Type: text/plain\r\n";
 		if ($this->chunked) {


### PR DESCRIPTION
Requests has a pretty awesome test suite, but several test are unreliable because they give different results on Travis than when run locally.

## What this PR covers

In this PR, all tests pass when run locally. Travis will probably screw them because of the server shim that's used.
```sh
-/planetozh/Requests/tests unreliable_tests
$ phpunit
PHPUnit 4.6.4 by Sebastian Bergmann and contributors.

Configuration read from D:\home\planetozh\Requests\tests\phpunit.xml.dist

..............................................................  62 / 814 (  7%)
.............................................................. 124 / 814 ( 15%)
.............................................................. 186 / 814 ( 22%)
.............................................................. 248 / 814 ( 30%)
.............................................................. 310 / 814 ( 38%)
.............................................................. 372 / 814 ( 45%)
.............................................................. 434 / 814 ( 53%)
.............................................................. 496 / 814 ( 60%)
.............................................................. 558 / 814 ( 68%)
.............................................................. 620 / 814 ( 76%)
.............................................................. 682 / 814 ( 83%)
.............................................................. 744 / 814 ( 91%)
.............................................................. 806 / 814 ( 99%)
........

Time: 2.93 minutes, Memory: 26.75Mb

OK (814 tests, 1195 assertions)

Generating code coverage report in HTML format ... done
```

I think that directives and scripts from `.travis.yml` and the composer file **should not** give different results when running these tests.

## What this PR does not cover

~~There are more [than 260 queries](https://github.com/rmccue/Requests/blob/master/tests/Transport/Base.php#L265-L377) sent to httpbin.org that are IMHO unnecessary: they test more httpbin return values than the behavior of Requests itself. These queries should be rewritten to use a mock just to test return values without issuing an actual external request~~ Added in commit 5, this obviously dramatically improve test suite runtime while preserving the functionality of tests.

Also, `RequestsTest_Transport_Base::setUp()` is run 46*2=92 times, it should be `setUpBeforeClass()` instead, to be run once before all tests run (`setUp()` runs before each and every test of the class)

So....

Thoughts?