### PR TITLE
Updated exception message to specify both http + https

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -483,7 +483,7 @@ class Requests {
 	 */
 	protected static function set_defaults(&$url, &$headers, &$data, &$type, &$options) {
 		if (!preg_match('/^http(s)?:\/\//i', $url, $matches)) {
-			throw new Requests_Exception('Only HTTP requests are handled.', 'nonhttp', $url);
+			throw new Requests_Exception('Only HTTP(S) requests are handled.', 'nonhttp', $url);
 		}
 
 		if (empty($options['hooks'])) {


### PR DESCRIPTION
Updated exception message for when url does not conform to HTTP or
HTTPS to clarify that both HTTP and HTTPS requests are handled.
#161