### PR TITLE
Fix PHP 7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       env: TEST_COVERAGE=1
     - php: 7.0
     - php: hhvm
-  allow_failures:
-    - php: 7.0
 
 before_script:
  # Setup the test server

--- a/library/Requests/IRI.php
+++ b/library/Requests/IRI.php
@@ -906,7 +906,8 @@ class Requests_IRI
             }
             if (($port_start = strpos($remaining, ':', strpos($remaining, ']'))) !== false)
             {
-                if (($port = substr($remaining, $port_start + 1)) === false)
+                $port = substr($remaining, $port_start + 1);
+                if ($port === false || $port === '')
                 {
                     $port = null;
                 }

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -243,7 +243,6 @@ class Requests_Transport_cURL implements Requests_Transport {
 
 		if ($options['filename'] !== false) {
 			$this->stream_handle = fopen($options['filename'], 'wb');
-			curl_setopt($this->fp, CURLOPT_FILE, $this->stream_handle);
 		}
 
 		$this->response_data = '';


### PR DESCRIPTION
Looks like we're accidentally using `CURLOPT_FILE` still, but it was obsoleted by #147/#172.

There might be further problems too.

Fixes #171.