### PR TITLE
Use wrong.host.badssl.com for SSL domain check test

### DIFF
--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -507,10 +507,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test that SSL fails with a bad certificate
 	 *
-	 * This is defined as invalid by
-	 * https://onlinessl.netlock.hu/en/test-center/invalid-ssl-certificate.html
-	 * and is used in testing in PhantomJS. That said, expect this to break.
-	 *
 	 * @expectedException Requests_Exception
 	 */
 	public function testBadDomain() {
@@ -519,7 +515,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			return;
 		}
 
-		$request = Requests::get('https://tv.eurosport.com/', array(), $this->getOptions());
+		$request = Requests::get('https://wrong.host.badssl.com/', array(), $this->getOptions());
 	}
 
 	/**


### PR DESCRIPTION
This replaces tv.eurosport.com, which I've never liked, although it is used in other test suites. badssl.com is specifically for SSL testing, and is used in Chrome to test SSL.