### PR TITLE
Return the $info from the transport in the <transport>.after_request event

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,7 +45,9 @@ Available Hooks
 
     Alter the raw HTTP response before returning for parsing
 
-    Parameters: `string &$response`
+    Parameters: `string &$response, array &$info`
+
+    `$info` contains the associated array as defined in [curl-getinfo-returnvalues](http://php.net/manual/en/function.curl-getinfo.php#refsect1-function.curl-getinfo-returnvalues)
 
 * `fsockopen.before_request`
 
@@ -71,7 +73,9 @@ Available Hooks
 
     Alter the raw HTTP response before returning for parsing
 
-    Parameters: `string &$response`
+    Parameters: `string &$response, array &$info`
+
+    `$info` contains the associated array as defined in [stream-get-meta-data-returnvalues](http://php.net/manual/en/function.stream-get-meta-data.php#refsect1-function.stream-get-meta-data-returnvalues)
 
 
 Registering Hooks

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -388,7 +388,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 		}
 		$this->info = curl_getinfo($this->handle);
 
-		$options['hooks']->dispatch('curl.after_request', array(&$this->headers));
+		$options['hooks']->dispatch('curl.after_request', array(&$this->headers, &$this->info));
 		return $this->headers;
 	}
 

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -284,7 +284,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		}
 		fclose($socket);
 
-		$options['hooks']->dispatch('fsockopen.after_request', array(&$this->headers));
+		$options['hooks']->dispatch('fsockopen.after_request', array(&$this->headers, &$this->info));
 		return $this->headers;
 	}
 

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -747,6 +747,26 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$response = Requests::get(httpbin('/get'), array(), $options);
 	}
 
+	public function testAfterRequestCallback()
+	{
+		$mock = $this->getMockBuilder('stdClass')->methods(array('after_request'))->getMock();
+		$mock->expects($this->atLeastOnce())
+			->method('after_request')
+			->with(
+				$this->isType('string'),
+				$this->logicalAnd($this->isType('array'), $this->logicalNot($this->isEmpty()))
+			);
+		$hooks = new Requests_Hooks();
+		$hooks->register('curl.after_request', array($mock, 'after_request'));
+		$hooks->register('fsockopen.after_request', array($mock, 'after_request'));
+		$options = array(
+			'hooks' => $hooks,
+		);
+		$options = $this->getOptions($options);
+
+		$response = Requests::get(httpbin('/get'), array(), $options);
+	}
+
 	public function testReusableTransport() {
 		$options = $this->getOptions(array('transport' => new $this->transport()));
 


### PR DESCRIPTION
Handles issue #191 
- Returns $this->info from the current $transport on blocking transports only
- Updated documentation to show the new API to the hooks
- Added a test case to validate that it is used at least once and that it's a non-empty array.

I couldn't get phpunit to run on the test, it threw errors about autoloading the base test files. I did download and include the phpunit.phar, but I utilized most of the test from the progress test a few lines above, so it should not have any issues.