### PR TITLE
RFC / WIP (do not merge): surface cURL errors

### DIFF
--- a/library/Requests/Exception/Transport.php
+++ b/library/Requests/Exception/Transport.php
@@ -1,0 +1,5 @@
+<?php
+
+class Requests_Exception_Transport extends Requests_Exception {
+
+}

--- a/library/Requests/Exception/Transport/cURL.php
+++ b/library/Requests/Exception/Transport/cURL.php
@@ -1,0 +1,56 @@
+<?php
+
+class Requests_Exception_Transport_cURL extends Requests_Exception_Transport {
+
+	const EASY = 'cURLEasy';
+	const MULTI = 'cURLMulti';
+	const SHARE = 'cURLShare';
+
+	/**
+	 * cURL error code
+	 *
+	 * @var integer
+	 */
+	protected $code = -1;
+
+	/**
+	 * Which type of cURL error
+	 *
+	 * EASY|MULTI|SHARE
+	 *
+	 * @var string
+	 */
+	protected $type = 'Unknown';
+
+	/**
+	 * Clear text error message
+	 *
+	 * @var string
+	 */
+	protected $reason = 'Unknown';
+
+	public function __construct($message, $type, $data = null, $code = 0) {
+		if ($type !== null) {
+			$this->type = $type;
+		}
+
+		if ($code !== null) {
+			$this->code = $code;
+		}
+
+		if ($message !== null) {
+			$this->reason = $message;
+		}
+
+		$message = sprintf('%d %s', $this->code, $this->reason);
+		parent::__construct($message, $this->type, $data, $this->code);
+	}
+
+	/**
+	 * Get the error message
+	 */
+	public function getReason() {
+		return $this->reason;
+	}
+
+}


### PR DESCRIPTION
This is a work in progress, but I wanted to get comments sooner rather than later, since this is mostly complete.

I have a couple use cases involved here:

1. I have a need to detect different kinds of cURL errors from multi-requests, specifically CURLE_OPERATION_TIMEDOUT (28), since I have subrequests using timeouts.  These currently manifest as 'requests.no_crlf_separator' due to nothing being returned from curl_multi_getcontent in request_multiple resulting in a parse error.  These are detectable from the code in $done['code'], but none of this is exposed anywhere I can get to.
1. I want to be able to capture the time when an error has finished, and have the code available there.  I've added this as a separate hook to not break existing parse_response implementations, but I'm open to suggestions here.

Please take a look and tell me what you think.