### PR TITLE
Fix for memleak and curl_close() never being called

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -176,6 +176,11 @@ class Requests_Transport_cURL implements Requests_Transport {
 
 		$this->process_response($response, $options);
 
+		// Need to remove the $this reference from the curl handle. 
+		// Otherwise Requests_Transport_cURL wont be garbage collected and the curl_close() will never be called.
+		curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, null);
+		curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, null);
+
 		return $this->headers;
 	}
 


### PR DESCRIPTION
Curl spammed the file descriptor list with CLOSE_WAIT connections and the Requests_Transport_cURL Instances where never actually destroyed because of a $this reference in the curl handle.
This resulted in a memleak and failing requests after a few 100 being made.
I fixed this by removing the reference from the file handle again after each request.