### PR TITLE
Fix tests (mitmproxy error)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
  - phpenv local --unset
 
  # Setup the proxy
- - pip install --user mitmproxy
+ - pip install --user mitmproxy~=0.15
 
 before_script:
  - PHPBIN=$TESTPHPBIN PORT=8080 vendor/bin/start.sh

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -132,7 +132,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testTRACE() {
-		$request = Requests::trace(httpbin('/get'), array(), $this->getOptions());
+		$request = Requests::trace(httpbin('/trace'), array(), $this->getOptions());
 		$this->assertEquals(200, $request->status_code);
 	}
 
@@ -242,7 +242,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testOPTIONS() {
-		$request = Requests::options(httpbin('/post'), array(), array(), $this->getOptions());
+		$request = Requests::options(httpbin('/options'), array(), array(), $this->getOptions());
 		$this->assertEquals(200, $request->status_code);
 	}
 

--- a/tests/utils/proxy/proxy.py
+++ b/tests/utils/proxy/proxy.py
@@ -1,5 +1,5 @@
 def request(context, flow):
-	flow.request.headers["x-requests-proxy"] = ["http"]
+	flow.request.headers["x-requests-proxy"] = "http"
 
 def response(context, flow):
-	flow.response.headers["x-requests-proxied"] = ["http"]
+	flow.response.headers[b"x-requests-proxied"] = "http"


### PR DESCRIPTION
mitmproxy changed the format for scripts, and we're just using the latest, so the tests are now broken. This updates to the latest and corrects the script, but fixes it at this version to avoid this in the future.