### PR TITLE
Add a before_redirect hook to alter redirects

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -657,6 +657,15 @@ class Requests {
 					$location = Requests_IRI::absolutize($url, $location);
 					$location = $location->uri;
 				}
+
+				$hook_args = array(
+					&$location,
+					&$req_headers,
+					&$req_data,
+					&$options,
+					$return
+				);
+				$options['hooks']->dispatch('requests.before_redirect', $hook_args);
 				$redirected = self::request($location, $req_headers, $req_data, $options['type'], $options);
 				$redirected->history[] = $return;
 				return $redirected;


### PR DESCRIPTION
This allows implementing things like browser-compatible redirect handling:
```
$hooks->register( 'requests-requests.before_redirect', function ( $location, $headers, $data, &$options, $original ) {
	// Browser compat
	if ( $original->status_code === 301 || $original->status_code === 302 ) {
		$options['type'] = Requests::GET;
	}
});
```

Fixes #201, see #178.