### PR TITLE
Force closing keep-alive connections on old cURL

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -309,6 +309,11 @@ class Requests_Transport_cURL implements Requests_Transport {
 	protected function setup_handle($url, $headers, $data, $options) {
 		$options['hooks']->dispatch('curl.before_request', array(&$this->handle));
 
+		// Force closing the connection for old versions of cURL (<7.22).
+		if ( ! isset( $headers['Connection'] ) ) {
+			$headers['Connection'] = 'close';
+		}
+
 		$headers = Requests::flatten($headers);
 
 		if (!empty($data)) {


### PR DESCRIPTION
cURL <7.22 seems to hold the request open if the connection is
keep-alive and the buffer hasn't been filled. Changing to single
connections is slightly less efficient (although unnoticable in most
uses), but should fix this issue.

If you need keep-alive, set the Connection header manually.