### PR TITLE
Docs: Updated HTTP links with HTTPS links where applicable

### DIFF
--- a/library/Requests/Exception/HTTP/418.php
+++ b/library/Requests/Exception/HTTP/418.php
@@ -2,14 +2,14 @@
 /**
  * Exception for 418 I'm A Teapot responses
  *
- * @see http://tools.ietf.org/html/rfc2324
+ * @see https://tools.ietf.org/html/rfc2324
  * @package Requests
  */
 
 /**
  * Exception for 418 I'm A Teapot responses
  *
- * @see http://tools.ietf.org/html/rfc2324
+ * @see https://tools.ietf.org/html/rfc2324
  * @package Requests
  */
 class Requests_Exception_HTTP_418 extends Requests_Exception_HTTP {

--- a/library/Requests/Exception/HTTP/428.php
+++ b/library/Requests/Exception/HTTP/428.php
@@ -2,14 +2,14 @@
 /**
  * Exception for 428 Precondition Required responses
  *
- * @see http://tools.ietf.org/html/rfc6585
+ * @see https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 
 /**
  * Exception for 428 Precondition Required responses
  *
- * @see http://tools.ietf.org/html/rfc6585
+ * @see https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 class Requests_Exception_HTTP_428 extends Requests_Exception_HTTP {

--- a/library/Requests/Exception/HTTP/429.php
+++ b/library/Requests/Exception/HTTP/429.php
@@ -2,14 +2,14 @@
 /**
  * Exception for 429 Too Many Requests responses
  *
- * @see http://tools.ietf.org/html/draft-nottingham-http-new-status-04
+ * @see https://tools.ietf.org/html/draft-nottingham-http-new-status-04
  * @package Requests
  */
 
 /**
  * Exception for 429 Too Many Requests responses
  *
- * @see http://tools.ietf.org/html/draft-nottingham-http-new-status-04
+ * @see https://tools.ietf.org/html/draft-nottingham-http-new-status-04
  * @package Requests
  */
 class Requests_Exception_HTTP_429 extends Requests_Exception_HTTP {

--- a/library/Requests/Exception/HTTP/431.php
+++ b/library/Requests/Exception/HTTP/431.php
@@ -2,14 +2,14 @@
 /**
  * Exception for 431 Request Header Fields Too Large responses
  *
- * @see http://tools.ietf.org/html/rfc6585
+ * @see https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 
 /**
  * Exception for 431 Request Header Fields Too Large responses
  *
- * @see http://tools.ietf.org/html/rfc6585
+ * @see https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 class Requests_Exception_HTTP_431 extends Requests_Exception_HTTP {

--- a/library/Requests/Exception/HTTP/511.php
+++ b/library/Requests/Exception/HTTP/511.php
@@ -2,14 +2,14 @@
 /**
  * Exception for 511 Network Authentication Required responses
  *
- * @see http://tools.ietf.org/html/rfc6585
+ * @see https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 
 /**
  * Exception for 511 Network Authentication Required responses
  *
- * @see http://tools.ietf.org/html/rfc6585
+ * @see https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 class Requests_Exception_HTTP_511 extends Requests_Exception_HTTP {

--- a/library/Requests/IDNAEncoder.php
+++ b/library/Requests/IDNAEncoder.php
@@ -7,14 +7,14 @@
  *
  * @package Requests
  * @subpackage Utilities
- * @see http://tools.ietf.org/html/rfc3490 IDNA specification
- * @see http://tools.ietf.org/html/rfc3492 Punycode/Bootstrap specification
+ * @see https://tools.ietf.org/html/rfc3490 IDNA specification
+ * @see https://tools.ietf.org/html/rfc3492 Punycode/Bootstrap specification
  */
 class Requests_IDNAEncoder {
 	/**
 	 * ACE prefix used for IDNA
 	 *
-	 * @see http://tools.ietf.org/html/rfc3490#section-5
+	 * @see https://tools.ietf.org/html/rfc3490#section-5
 	 * @var string
 	 */
 	const ACE_PREFIX = 'xn--';
@@ -22,7 +22,7 @@ class Requests_IDNAEncoder {
 	/**#@+
 	 * Bootstrap constant for Punycode
 	 *
-	 * @see http://tools.ietf.org/html/rfc3492#section-5
+	 * @see https://tools.ietf.org/html/rfc3492#section-5
 	 * @var int
 	 */
 	const BOOTSTRAP_BASE         = 36;
@@ -333,7 +333,7 @@ class Requests_IDNAEncoder {
 	/**
 	 * Convert a digit to its respective character
 	 *
-	 * @see http://tools.ietf.org/html/rfc3492#section-5
+	 * @see https://tools.ietf.org/html/rfc3492#section-5
 	 * @throws Requests_Exception On invalid digit (`idna.invalid_digit`)
 	 *
 	 * @param int $digit Digit in the range 0-35
@@ -353,7 +353,7 @@ class Requests_IDNAEncoder {
 	/**
 	 * Adapt the bias
 	 *
-	 * @see http://tools.ietf.org/html/rfc3492#section-6.1
+	 * @see https://tools.ietf.org/html/rfc3492#section-6.1
 	 * @param int $delta
 	 * @param int $numpoints
 	 * @param bool $firsttime

--- a/library/Requests/SSL.php
+++ b/library/Requests/SSL.php
@@ -22,7 +22,7 @@ class Requests_SSL {
 	 * names, leading things like 'https://www.github.com/' to be invalid.
 	 * Instead
 	 *
-	 * @see http://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
+	 * @see https://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
 	 *
 	 * @throws Requests_Exception On not obtaining a match for the host (`fsockopen.ssl.no_match`)
 	 * @param string $host Host name to verify against

--- a/library/Requests/Session.php
+++ b/library/Requests/Session.php
@@ -175,7 +175,7 @@ class Requests_Session {
 	 * Note: Unlike {@see post} and {@see put}, `$headers` is required, as the
 	 * specification recommends that should send an ETag
 	 *
-	 * @link http://tools.ietf.org/html/rfc5789
+	 * @link https://tools.ietf.org/html/rfc5789
 	 */
 	public function patch($url, $headers, $data = array(), $options = array()) {
 		return $this->request($url, $headers, $data, Requests::PATCH, $options);

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -33,7 +33,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 	/**
 	 * Information on the current request
 	 *
-	 * @var array cURL information array, see {@see http://php.net/curl_getinfo}
+	 * @var array cURL information array, see {@see https://secure.php.net/curl_getinfo}
 	 */
 	public $info;
 
@@ -176,7 +176,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 
 		$this->process_response($response, $options);
 
-		// Need to remove the $this reference from the curl handle. 
+		// Need to remove the $this reference from the curl handle.
 		// Otherwise Requests_Transport_cURL wont be garbage collected and the curl_close() will never be called.
 		curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, null);
 		curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, null);
@@ -481,7 +481,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 	 * Format a URL given GET data
 	 *
 	 * @param string $url
-	 * @param array|object $data Data to build query using, see {@see http://php.net/http_build_query}
+	 * @param array|object $data Data to build query using, see {@see https://secure.php.net/http_build_query}
 	 * @return string URL with data
 	 */
 	protected static function format_get($url, $data) {

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -30,7 +30,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 	/**
 	 * Stream metadata
 	 *
-	 * @var array Associative array of properties, see {@see http://php.net/stream_get_meta_data}
+	 * @var array Associative array of properties, see {@see https://secure.php.net/stream_get_meta_data}
 	 */
 	public $info;
 
@@ -341,7 +341,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 	 * Format a URL given GET data
 	 *
 	 * @param array $url_parts
-	 * @param array|object $data Data to build query using, see {@see http://php.net/http_build_query}
+	 * @param array|object $data Data to build query using, see {@see https://secure.php.net/http_build_query}
 	 * @return string URL with data
 	 */
 	protected static function format_get($url_parts, $data) {
@@ -391,7 +391,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 	 * names, leading things like 'https://www.github.com/' to be invalid.
 	 * Instead
 	 *
-	 * @see http://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
+	 * @see https://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
 	 *
 	 * @throws Requests_Exception On failure to connect via TLS (`fsockopen.ssl.connect_error`)
 	 * @throws Requests_Exception On not obtaining a match for the host (`fsockopen.ssl.no_match`)


### PR DESCRIPTION
I mistakenly let these changes slip into WordPress via [r37674](https://core.trac.wordpress.org/changeset/37674), so this PR brings those same changes here to Requests.