### PR TITLE
Round up to at least 1 second timeouts for cURL

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -304,6 +304,8 @@ class Requests {
 	 * options:
 	 *
 	 * - `timeout`: How long should we wait for a response?
+	 *    Note: for cURL, a minimum of 1 second applies, as DNS resolution
+	 *    operates at second-resolution only.
 	 *    (float, seconds with a millisecond precision, default: 10, example: 0.01)
 	 * - `connect_timeout`: How long should we wait while trying to connect?
 	 *    (float, seconds with a millisecond precision, default: 10, example: 0.01)

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -349,11 +349,17 @@ class Requests_Transport_cURL implements Requests_Transport {
 				break;
 		}
 
-		if (is_int($options['timeout']) || $this->version < self::CURL_7_16_2) {
-			curl_setopt($this->handle, CURLOPT_TIMEOUT, ceil($options['timeout']));
+		// cURL requires a minimum timeout of 1 second when using the system
+		// DNS resolver (getaddrinfo). There's no way to detect which DNS
+		// resolver is being used from our end, so we need to round up
+		// regardless of the supplied timeout.
+		$timeout = min($options['timeout'], 1);
+
+		if (is_int($timeout) || $this->version < self::CURL_7_16_2) {
+			curl_setopt($this->handle, CURLOPT_TIMEOUT, ceil($timeout));
 		}
 		else {
-			curl_setopt($this->handle, CURLOPT_TIMEOUT_MS, round($options['timeout'] * 1000));
+			curl_setopt($this->handle, CURLOPT_TIMEOUT_MS, round($timeout * 1000));
 		}
 
 		if (is_int($options['connect_timeout']) || $this->version < self::CURL_7_16_2) {

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -350,9 +350,11 @@ class Requests_Transport_cURL implements Requests_Transport {
 		}
 
 		// cURL requires a minimum timeout of 1 second when using the system
-		// DNS resolver (getaddrinfo). There's no way to detect which DNS
-		// resolver is being used from our end, so we need to round up
-		// regardless of the supplied timeout.
+		// DNS resolver, as it uses `alarm()`, which is second resolution only.
+		// There's no way to detect which DNS resolver is being used from our
+		// end, so we need to round up regardless of the supplied timeout.
+		//
+		// https://github.com/curl/curl/blob/4f45240bc84a9aa648c8f7243be7b79e9f9323a5/lib/hostip.c#L606-L609
 		$timeout = max($options['timeout'], 1);
 
 		if (is_int($timeout) || $this->version < self::CURL_7_16_2) {

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -353,7 +353,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 		// DNS resolver (getaddrinfo). There's no way to detect which DNS
 		// resolver is being used from our end, so we need to round up
 		// regardless of the supplied timeout.
-		$timeout = min($options['timeout'], 1);
+		$timeout = max($options['timeout'], 1);
 
 		if (is_int($timeout) || $this->version < self::CURL_7_16_2) {
 			curl_setopt($this->handle, CURLOPT_TIMEOUT, ceil($timeout));


### PR DESCRIPTION
cURL sucks, `getaddrinfo` sucks, and everything in general sucks.