### PR TITLE
CURLOPT_HTTPHEADER在php7接受空数组导致php-fpm奔溃

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -790,9 +790,6 @@ class Requests {
 	 * @return array List of headers
 	 */
 	public static function flatten($array) {
-		if (empty($array)) {
-			return null;
-		}
 		$return = array();
 		foreach ($array as $key => $value) {
 			$return[] = sprintf('%s: %s', $key, $value);

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -790,6 +790,9 @@ class Requests {
 	 * @return array List of headers
 	 */
 	public static function flatten($array) {
+		if(empty($array)){
+			return null;
+		}
 		$return = array();
 		foreach ($array as $key => $value) {
 			$return[] = sprintf('%s: %s', $key, $value);

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -790,7 +790,7 @@ class Requests {
 	 * @return array List of headers
 	 */
 	public static function flatten($array) {
-		if(empty($array)){
+		if (empty($array)) {
 			return null;
 		}
 		$return = array();

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -373,8 +373,9 @@ class Requests_Transport_cURL implements Requests_Transport {
 		curl_setopt($this->handle, CURLOPT_URL, $url);
 		curl_setopt($this->handle, CURLOPT_REFERER, $url);
 		curl_setopt($this->handle, CURLOPT_USERAGENT, $options['useragent']);
-		curl_setopt($this->handle, CURLOPT_HTTPHEADER, $headers);
-
+		if (!empty($headers)) {
+			curl_setopt($this->handle, CURLOPT_HTTPHEADER, $headers);
+		}
 		if ($options['protocol_version'] === 1.1) {
 			curl_setopt($this->handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 		}


### PR DESCRIPTION
If give a empty array to CURLOPT_HTTPHEADER, the PHP will crash.