### PR TITLE
cURL: Support custom HTTP methods

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -333,13 +333,6 @@ class Requests_Transport_cURL implements Requests_Transport {
 				curl_setopt($this->handle, CURLOPT_POST, true);
 				curl_setopt($this->handle, CURLOPT_POSTFIELDS, $data);
 				break;
-			case Requests::PATCH:
-			case Requests::PUT:
-			case Requests::DELETE:
-			case Requests::OPTIONS:
-				curl_setopt($this->handle, CURLOPT_CUSTOMREQUEST, $options['type']);
-				curl_setopt($this->handle, CURLOPT_POSTFIELDS, $data);
-				break;
 			case Requests::HEAD:
 				curl_setopt($this->handle, CURLOPT_CUSTOMREQUEST, $options['type']);
 				curl_setopt($this->handle, CURLOPT_NOBODY, true);
@@ -347,6 +340,10 @@ class Requests_Transport_cURL implements Requests_Transport {
 			case Requests::TRACE:
 				curl_setopt($this->handle, CURLOPT_CUSTOMREQUEST, $options['type']);
 				break;
+			case Requests::PATCH:
+			case Requests::PUT:
+			case Requests::DELETE:
+			case Requests::OPTIONS:
 			default:
 				curl_setopt($this->handle, CURLOPT_CUSTOMREQUEST, $options['type']);
 				if (!empty($data)) {

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -347,6 +347,11 @@ class Requests_Transport_cURL implements Requests_Transport {
 			case Requests::TRACE:
 				curl_setopt($this->handle, CURLOPT_CUSTOMREQUEST, $options['type']);
 				break;
+			default:
+				curl_setopt($this->handle, CURLOPT_CUSTOMREQUEST, $options['type']);
+				if (!empty($data)) {
+					curl_setopt($this->handle, CURLOPT_POSTFIELDS, $data);
+				}
 		}
 
 		// cURL requires a minimum timeout of 1 second when using the system

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -268,6 +268,24 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
 	}
 
+	public function testPURGE() {
+		$request = Requests::request(httpbin('/purge'), array(), array(), 'PURGE', $this->getOptions());
+		$this->assertEquals(200, $request->status_code);
+	}
+
+	public function testPURGEWithData() {
+		$data = array(
+			'test' => 'true',
+			'test2' => 'test',
+		);
+		$request = Requests::request(httpbin('/purge'), array(), $data, 'PURGE', array_merge(array('data_format'=>'query'),$this->getOptions()));
+		$this->assertEquals(200, $request->status_code);
+
+		$result = json_decode($request->body, true);
+		$this->assertEquals(httpbin('/purge?test=true&test2=test'), $result['url']);
+		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
+	}
+
 	public function testRedirects() {
 		$request = Requests::get(httpbin('/redirect/6'), array(), $this->getOptions());
 		$this->assertEquals(200, $request->status_code);

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -268,22 +268,21 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
 	}
 
-	public function testPURGE() {
-		$request = Requests::request(httpbin('/purge'), array(), array(), 'PURGE', $this->getOptions());
+	public function testLOCK() {
+		$request = Requests::request(httpbin('/lock'), array(), array(), 'LOCK', $this->getOptions());
 		$this->assertEquals(200, $request->status_code);
 	}
 
-	public function testPURGEWithData() {
+	public function testLOCKWithData() {
 		$data = array(
 			'test' => 'true',
 			'test2' => 'test',
 		);
-		$request = Requests::request(httpbin('/purge'), array(), $data, 'PURGE', array_merge(array('data_format'=>'query'),$this->getOptions()));
+		$request = Requests::request(httpbin('/lock'), array(), $data, 'LOCK', $this->getOptions());
 		$this->assertEquals(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/purge?test=true&test2=test'), $result['url']);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
+		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
 	}
 
 	public function testRedirects() {


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/37503 for background.

The test doesn't work (yet) because there is no /purge endpoint.