### PR TITLE
Bail from cURL when either `curl_init()` OR `curl_exec()` are unavailable

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -524,7 +524,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 	 * @return boolean True if the transport is valid, false otherwise.
 	 */
 	public static function test($capabilities = array()) {
-		if (!function_exists('curl_init') && !function_exists('curl_exec')) {
+		if (!function_exists('curl_init') || !function_exists('curl_exec')) {
 			return false;
 		}
 


### PR DESCRIPTION
Some hosts disable cURL by adding `disable_functions = curl_exec` to their `php.ini` file without also adding `curl_init` to the same declaration.
Request's logic appears incorrect here, bailing only if BOTH `curl_init()` AND `curl_exec()` are disabled.