### PR TITLE
Fixes bug in rfc2616 #3.6.1 implementation.

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -749,7 +749,7 @@ class Requests {
 	 * @return string Decoded body
 	 */
 	protected static function decode_chunked($data) {
-		if (!preg_match('/^([0-9a-f]+)[^\r\n]*\r\n/i', trim($data))) {
+		if (!preg_match('/^([0-9a-f]+)(?:;[^\r\n]*)*\r\n/i', trim($data))) {
 			return $data;
 		}
 
@@ -757,7 +757,7 @@ class Requests {
 		$encoded = $data;
 
 		while (true) {
-			$is_chunked = (bool) preg_match('/^([0-9a-f]+)[^\r\n]*\r\n/i', $encoded, $matches);
+			$is_chunked = (bool) preg_match('/^([0-9a-f]+)(?:;[^\r\n]*)*\r\n/i', $encoded, $matches);
 			if (!$is_chunked) {
 				// Looks like it's not chunked after all
 				return $data;

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -749,15 +749,17 @@ class Requests {
 	 * @return string Decoded body
 	 */
 	protected static function decode_chunked($data) {
-		if (!preg_match('/^([0-9a-f]+)(?:;[^\r\n]*)*\r\n/i', trim($data))) {
+		if (!preg_match('/^([0-9a-f]+)(?:;(?:[\w-]*)(?:=(?:(?:[\w-]*)*|"(?:[^\r\n])*"))?)*\r\n/i', trim($data))) {
 			return $data;
 		}
+
+
 
 		$decoded = '';
 		$encoded = $data;
 
 		while (true) {
-			$is_chunked = (bool) preg_match('/^([0-9a-f]+)(?:;[^\r\n]*)*\r\n/i', $encoded, $matches);
+			$is_chunked = (bool) preg_match('/^([0-9a-f]+)(?:;(?:[\w-]*)(?:=(?:(?:[\w-]*)*|"(?:[^\r\n])*"))?)*\r\n/i', $encoded, $matches);
 			if (!$is_chunked) {
 				// Looks like it's not chunked after all
 				return $data;

--- a/tests/ChunkedEncoding.php
+++ b/tests/ChunkedEncoding.php
@@ -15,6 +15,10 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 				"02\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
 				"abra\ncadabra\nall we got\n"
 			),
+			array(
+				"02;foo=bar;hello=world\r\nab\r\n04;foo=baz\r\nra\nc\r\n06;justfoo\r\nadabra\r\n0c\r\n\nall we got\n",
+				"abra\ncadabra\nall we got\n"
+			),
 		);
 	}
 
@@ -39,7 +43,7 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 	 */
 	public function testNotActuallyChunked() {
 		$transport = new MockTransport();
-		$transport->body = 'Hello! This is a non-chunked response!';
+		$transport->body = "Believe me\r\nthis looks chunked, but it isn't.";
 		$transport->chunked = true;
 
 		$options = array(
@@ -49,6 +53,7 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($transport->body, $response->body);
 	}
+
 
 	/**
 	 * Response says it's chunked and starts looking like it is, but turns out

--- a/tests/ChunkedEncoding.php
+++ b/tests/ChunkedEncoding.php
@@ -19,6 +19,14 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 				"02;foo=bar;hello=world\r\nab\r\n04;foo=baz\r\nra\nc\r\n06;justfoo\r\nadabra\r\n0c\r\n\nall we got\n",
 				"abra\ncadabra\nall we got\n"
 			),
+			array(
+				"02;foo=\"quoted value\"\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
+				"abra\ncadabra\nall we got\n"
+			),
+			array(
+				"02;foo-bar=baz\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
+				"abra\ncadabra\nall we got\n"
+			),
 		);
 	}
 
@@ -38,12 +46,24 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($expected, $response->body);
 	}
 
+	public static function notChunkedProvider() {
+		return array(
+			'invalid chunk size' => array( 'Hello! This is a non-chunked response!' ),
+			'invalid chunk extension' => array( '1BNot chunked\r\nLooks chunked but it is not\r\n' ),
+			'unquoted chunk-ext-val with space' => array( "02;foo=unquoted with space\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n" ),
+			'unquoted chunk-ext-val with forbidden character' => array( "02;foo={unquoted}\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n" ),
+			'invalid chunk-ext-name' => array( "02;{foo}=bar\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n" ),
+			'incomplete quote for chunk-ext-value' => array( "02;foo=\"no end quote\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n" ),
+		);
+	}
+
 	/**
 	 * Response says it's chunked, but actually isn't
+	 * @dataProvider notChunkedProvider
 	 */
-	public function testNotActuallyChunked() {
+	public function testNotActuallyChunked($body) {
 		$transport = new MockTransport();
-		$transport->body = "Believe me\r\nthis looks chunked, but it isn't.";
+		$transport->body = $body;
 		$transport->chunked = true;
 
 		$options = array(


### PR DESCRIPTION
A chunk size must be followed by either optional chunk extension(s) (which begin with a semicolon) or \r\n. The current implementation just allows anything from the chunk size to the \r\n.

This was causing a bug in my [Events](http://wordpress.org/plugins/event-organiser/) plugin: a Google iCal feed was *sometimes* mistaken for being chunked (Google claims it is in the header: it isn't).

The starting line is 

```
BEGIN:VCALENDAR
```

which is mistakenly interpreted as a chunk header with size `BE`. *If*, it just so happens the rest of the feed is interpreted as chunked you end up with a mutilated iCal feed.

Of course, Google shouldn't claim it is chunked, but the current implementation fails to detect that it is not a valid encoding.