### PR TITLE
Only include the port number in the `Host` header when it differs from default

### DIFF
--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -171,7 +171,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		if (!isset($case_insensitive_headers['Host'])) {
 			$out .= sprintf('Host: %s', $url_parts['host']);
 
-			if (( 'http' === $url_parts['scheme'] && $url_parts['port'] !== 80 ) || ( 'https' === $url_parts['scheme'] && $url_parts['port'] !== 443 )) {
+			if (( 'http' === strtolower($url_parts['scheme']) && $url_parts['port'] !== 80 ) || ( 'https' === strtolower($url_parts['scheme']) && $url_parts['port'] !== 443 )) {
 				$out .= ':' . $url_parts['port'];
 			}
 			$out .= "\r\n";

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -171,7 +171,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		if (!isset($case_insensitive_headers['Host'])) {
 			$out .= sprintf('Host: %s', $url_parts['host']);
 
-			if ($url_parts['port'] !== 80) {
+			if (( 'http' === $url_parts['scheme'] && $url_parts['port'] !== 80 ) || ( 'https' === $url_parts['scheme'] && $url_parts['port'] !== 443 )) {
 				$out .= ':' . $url_parts['port'];
 			}
 			$out .= "\r\n";


### PR DESCRIPTION
Based on @amandato in https://core.trac.wordpress.org/ticket/37991