### PR TITLE
Disable OpenSSL's internal peer_name checking when `verifyname` is disabled.

### DIFF
--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -97,6 +97,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 			}
 
 			if (isset($options['verifyname']) && $options['verifyname'] === false) {
+				$context_options['verify_peer_name'] = false;
 				$verifyname = false;
 			}
 


### PR DESCRIPTION
Even with `verify_peer` disabled, OpensSSL will still perform peer_name checking, for example:

```
stream_socket_client(): Peer certificate CN=`dev.dd32.id.au' did not match expected CN=`test-vm'
stream_socket_client(): Failed to enable crypto
stream_socket_client(): unable to connect to ssl://test-vm:8443 (Unknown error)
```


