### PR TITLE
Make Requests_Transport_cURL::stream_body() public

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -459,7 +459,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 	 * @param string $data Body data
 	 * @return integer Length of provided data
 	 */
-	protected function stream_body($handle, $data) {
+	public function stream_body($handle, $data) {
 		$this->hooks->dispatch('request.progress', array($data, $this->response_bytes, $this->response_byte_limit));
 		$data_length = strlen($data);
 


### PR DESCRIPTION
Fixes a "cannot access protected method Requests_Transport_cURL::stream_body()" error when using PHPUnit and PHP-VCR.

Related issues: #157 and php-vcr/php-vcr#109