### PR TITLE
Add Content-* headers for empty POST requests

### DIFF
--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -160,7 +160,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 				$request_body = $data;
 			}
 
-			if (!empty($data)) {
+			if (!empty($data) || $options['type'] === Requests::POST) {
 				if (!isset($case_insensitive_headers['Content-Length'])) {
 					$headers['Content-Length'] = strlen($request_body);
 				}

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -145,6 +145,15 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('test', $result['data']);
 	}
 
+	public function testEmptyPOST() {
+		$request = Requests::post(httpbin('/post'), array(), null, $this->getOptions());
+		$this->assertEquals(200, $request->status_code);
+
+		$result = json_decode($request->body, true);
+		// Heroku appears to add this on incoming requests even if we don't send it
+		$this->assertArrayHasKey( 'content-length', $result['headers'] ); 
+	}
+
 	public function testFormPost() {
 		$data = 'test=true&test2=test';
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());


### PR DESCRIPTION
Sends the `Content-Length` and `Content-Type` headers even for empty POST requests.

The test passes regardless, as it seems that the Heroku test app adds the `Content-Length` headers on incoming requests regardless of if it's sent. Testing against `http://httpbin.org/post` shows that the header isn't/is sent though.

Fixes #248 
