### PR TITLE
FIX adding a transport method should prioritize that method

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -169,7 +169,7 @@ class Requests {
 			);
 		}
 
-		self::$transports = array_merge(self::$transports, array($transport));
+		self::$transports = array_merge(array($transport), self::$transports);
 	}
 
 	/**


### PR DESCRIPTION
before adding a Requests_Transport method with Requests::add_transport()
had no effect to the actual transport method being used for the
connection (if the user did not delete the Requests_Transport_cURL and
Requests_Transport_fsockopen classes manually)