### PR TITLE
IDNAEncoder, Requests: changes to avoid PHP7 compatibility issues

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -186,8 +186,9 @@ class Requests {
 		$cap_string = serialize($capabilities);
 
 		// Don't search for a transport if it's already been done for these $capabilities
-		if (isset(self::$transport[$cap_string]) && self::$transport[$cap_string] !== null) {
-			return new self::$transport[$cap_string]();
+        $transport = self::$transport;
+        if (isset($transport[$cap_string]) && $transport[$cap_string] !== null) {
+			return new $transport[$cap_string]();
 		}
 		// @codeCoverageIgnoreEnd
 
@@ -206,15 +207,15 @@ class Requests {
 
 			$result = call_user_func(array($class, 'test'), $capabilities);
 			if ($result) {
-				self::$transport[$cap_string] = $class;
+				$transport[$cap_string] = $class;
 				break;
 			}
 		}
-		if (self::$transport[$cap_string] === null) {
+		if ($transport[$cap_string] === null) {
 			throw new Requests_Exception('No working transports found', 'notransport', self::$transports);
 		}
 
-		return new self::$transport[$cap_string]();
+		return new $transport[$cap_string]();
 	}
 
 	/**#@+

--- a/library/Requests/IDNAEncoder.php
+++ b/library/Requests/IDNAEncoder.php
@@ -42,9 +42,13 @@ class Requests_IDNAEncoder {
 	 */
 	public static function encode($string) {
 		$parts = explode('.', $string);
-		foreach ($parts as &$part) {
-			$part = self::to_ascii($part);
-		}
+        $parts = array_map(
+            function ($part) {
+                return Requests_IDNAEncoder::to_ascii($part);
+            },
+            $parts
+        );
+
 		return implode('.', $parts);
 	}
 


### PR DESCRIPTION
Fixes for:  

library/Requests.php
* variableInterpolation
 * Line 169: `			return new self::$transport[$cap_string]();`
 * Line 192: `		return new self::$transport[$cap_string]();`

library/Requests/IDNAEncoder.php
* foreachByReference
 * Line 42: `		foreach ($parts as &$part) {`

