### PR TITLE
Fix unit tests by aliasing PHPUnit_Framework_TestCase with namespaced name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ matrix:
   fast_finish: true
   include:
     - php: 5.2
+      dist: precise
     - php: 5.3
+      dist: precise
     - php: 5.4
     - php: 5.5
     - php: 5.6
@@ -22,6 +24,7 @@ cache:
 
 install:
  # Setup the test server
+ - phpenv install --releases
  - phpenv local 5.5
  - composer install --dev --no-interaction
  - TESTPHPBIN=$(phpenv which php)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
     - php: 5.6
       env: TEST_COVERAGE=1
     - php: 7.0
-    - php: hhvm
 
 # Use new container infrastructure
 sudo: false
@@ -28,7 +27,11 @@ install:
  - phpenv local --unset
 
  # Setup the proxy
- - pip install --user mitmproxy~=0.15
+ - pip install --user mitmproxy==0.18.2
+
+ # Display relevant versions for our custom pieces.
+ - python --version
+ - mitmproxy --version
 
 before_script:
  - PHPBIN=$TESTPHPBIN PORT=8080 vendor/bin/start.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - php: 5.6
       env: TEST_COVERAGE=1
     - php: 7.0
+    - php: 7.1
 
 # Use new container infrastructure
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,10 @@ cache:
 
 install:
  # Setup the test server
- - phpenv install --releases
- - phpenv local 5.5
+ - phpenv global 5.5
  - composer install --dev --no-interaction
  - TESTPHPBIN=$(phpenv which php)
- - phpenv local --unset
+ - phpenv global "$TRAVIS_PHP_VERSION"
 
  # Setup the proxy
  - pip install --user mitmproxy==0.18.2

--- a/tests/IRI.php
+++ b/tests/IRI.php
@@ -387,11 +387,11 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 	/**
 	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
-	public function testNonexistantProperty()
+	public function testNonexistentProperty()
 	{
 		$iri = new Requests_IRI();
-		$this->assertFalse(isset($iri->nonexistant_prop));
-		$should_fail = $iri->nonexistant_prop;
+		$this->assertFalse(isset($iri->nonexistent_prop));
+		$should_fail = $iri->nonexistent_prop;
 	}
 
 	public function testBlankHost()

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -413,6 +413,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			}
 		}
 		$request = Requests::get($url, array(), $options);
+		$this->assertEquals($code, $request->status_code);
 		$request->throw_for_status(false);
 	}
 
@@ -435,6 +436,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			}
 		}
 		$request = Requests::get($url, array(), $options);
+		$this->assertEquals($code, $request->status_code);
 		$request->throw_for_status(true);
 	}
 

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -1,6 +1,20 @@
 <?php
 
 abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
+	/**
+	 * Backwards compatibility shim for PHPUnit 6+
+	 *
+	 * @param string $class Class to expect exception instance of.
+	 */
+	public function setExpectedException($class) {
+		if (method_exists($this, 'expectException')) {
+			return $this->expectException($class);
+		}
+		else {
+			return parent::setExpectedException($class);
+		}
+	}
+
 	public function setUp() {
 		$callback = array($this->transport, 'test');
 		$supported = call_user_func($callback);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,7 +24,8 @@ define_from_env('REQUESTS_HTTP_PROXY_AUTH_PASS');
 // Fixes https://github.com/rmccue/Requests/issues/279 by aliasing PHPUnit_Framework_TestCase to PHPUnit\Framework\TestCase
 // (Designed to work in php 5.2+)
 if (function_exists('class_exists') && !class_exists('PHPUnit_Framework_TestCase') && PHP_VERSION_ID >= 70000 && class_exists('PHPUnit\Framework\TestCase')) {
-    class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+	class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+	class_alias('PHPUnit\Framework\Error\Notice', 'PHPUnit_Framework_Error_Notice');
 }
 
 include(dirname(dirname(__FILE__)) . '/library/Requests.php');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,12 @@ define_from_env('REQUESTS_HTTP_PROXY_AUTH');
 define_from_env('REQUESTS_HTTP_PROXY_AUTH_USER');
 define_from_env('REQUESTS_HTTP_PROXY_AUTH_PASS');
 
+// Fixes https://github.com/rmccue/Requests/issues/279 by aliasing PHPUnit_Framework_TestCase to PHPUnit\Framework\TestCase
+// (Designed to work in php 5.2+)
+if (function_exists('class_exists') && !class_exists('PHPUnit_Framework_TestCase') && PHP_VERSION_ID >= 70000 && class_exists('PHPUnit\Framework\TestCase')) {
+    class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+}
+
 include(dirname(dirname(__FILE__)) . '/library/Requests.php');
 Requests::register_autoloader();
 

--- a/tests/utils/proxy/proxy.py
+++ b/tests/utils/proxy/proxy.py
@@ -1,5 +1,5 @@
-def request(context, flow):
+def request(flow):
 	flow.request.headers["x-requests-proxy"] = "http"
 
-def response(context, flow):
+def response(flow):
 	flow.response.headers[b"x-requests-proxied"] = "http"


### PR DESCRIPTION
This change is intended to work in php 5.2+, the lowest version .travis.yml
indicates this supports.

If PHPUnit_Framework_TestCase does not exist, check if
PHPUnit\Framework\TestCase does exist, and if so, alias it.

- Different versions of phpunit may be required for different php
  versions, so don't try standardizing for now.

Fixes #279