### PR TITLE
Enforce host-only flag in `normalize_attribute`

### DIFF
--- a/library/Requests/Cookie.php
+++ b/library/Requests/Cookie.php
@@ -291,6 +291,7 @@ class Requests_Cookie {
 				// Domain normalization, as per RFC 6265 section 5.2.3
 				if ($value[0] === '.') {
 					$value = substr($value, 1);
+					$this->flags['host-only'] = false;
 				}
 
 				return $value;

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -229,6 +229,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$attributes = new Requests_Utility_CaseInsensitiveDictionary();
 		$attributes['domain'] = $original;
 		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
+		$cookie->flags['host-only'] = true;
 		$this->assertEquals($matches, $cookie->domain_matches($check));
 	}
 
@@ -238,10 +239,8 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	public function testDomainMatch($original, $check, $matches, $domain_matches) {
 		$attributes = new Requests_Utility_CaseInsensitiveDictionary();
 		$attributes['domain'] = $original;
-		$flags = array(
-			'host-only' => false
-		);
-		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
+		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
+		$cookie->flags['host-only'] = false;
 		$this->assertEquals($domain_matches, $cookie->domain_matches($check));
 	}
 

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -34,6 +34,14 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($cookie->attributes['httponly']);
 	}
 
+	public function testHostOnlyInference() {
+		$cookie = Requests_Cookie::parse('foo=bar; Domain=example.org');
+		$this->assertTrue($cookie->flags['host-only']);
+
+		$cookie = Requests_Cookie::parse('foo=bar; Domain=.example.org');
+		$this->assertFalse($cookie->flags['host-only']);
+	}
+
 	public function testCookieJarSetter() {
 		$jar1 = new Requests_Cookie_Jar();
 		$jar1['requests-testcookie'] = 'testvalue';


### PR DESCRIPTION
When a non host-only flag domain is supplied, during its normalization
(as per RFC 6265 section 5.2.3) not only should the dot be removed but
the host-only flag should be set to false.

This fixes weird behavior in `Requests_Cookie::parse()`

See #306

Tests included.