### PR TITLE
Add support for various deflate compression levels

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -821,7 +821,9 @@ class Requests {
 	 * @return string Decompressed string
 	 */
 	public static function decompress($data) {
-		if (substr($data, 0, 2) !== "\x1f\x8b" && substr($data, 0, 2) !== "\x78\x9c") {
+		// All valid deflate, gzip header magic markers
+		$valid_magic = array("\x1f\x8b", "\x78\x01", "\x78\x5e", "\x78\x9c", "\x78\xda");
+		if (!in_array(substr($data, 0, 2), $valid_magic)) {
 			// Not actually compressed. Probably cURL ruining this for us.
 			return $data;
 		}


### PR DESCRIPTION
Different compression levels yield a specific second byte in the magic
header for the deflate encoding. All of them can be decoded by the same
functions without any issues. Let them through, as they've been seen in
the wild.

Fixes #301