### PR TITLE
Fix multi-call SSL verify propagation in cURL

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -145,20 +145,6 @@ class Requests_Transport_cURL implements Requests_Transport {
 			$this->response_byte_limit = $options['max_bytes'];
 		}
 
-		if (isset($options['verify'])) {
-			if ($options['verify'] === false) {
-				curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
-				curl_setopt($this->handle, CURLOPT_SSL_VERIFYPEER, 0);
-			}
-			elseif (is_string($options['verify'])) {
-				curl_setopt($this->handle, CURLOPT_CAINFO, $options['verify']);
-			}
-		}
-
-		if (isset($options['verifyname']) && $options['verifyname'] === false) {
-			curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
-		}
-
 		curl_exec($this->handle);
 		$response = $this->response_data;
 
@@ -389,6 +375,20 @@ class Requests_Transport_cURL implements Requests_Transport {
 			curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, array(&$this, 'stream_headers'));
 			curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, array(&$this, 'stream_body'));
 			curl_setopt($this->handle, CURLOPT_BUFFERSIZE, Requests::BUFFER_SIZE);
+		}
+
+		if (isset($options['verify'])) {
+			if ($options['verify'] === false) {
+				curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
+				curl_setopt($this->handle, CURLOPT_SSL_VERIFYPEER, 0);
+			}
+			elseif (is_string($options['verify'])) {
+				curl_setopt($this->handle, CURLOPT_CAINFO, $options['verify']);
+			}
+		}
+
+		if (isset($options['verifyname']) && $options['verifyname'] === false) {
+			curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
 		}
 	}
 

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -92,6 +92,8 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 			if (isset($options['verify'])) {
 				if ($options['verify'] === false) {
 					$context_options['verify_peer'] = false;
+					$context_options['verify_peer_name'] = false;
+					$verifyname = false;
 				}
 				elseif (is_string($options['verify'])) {
 					$context_options['cafile'] = $options['verify'];

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -764,6 +764,34 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		unlink($requests['post']['options']['filename']);
 	}
 
+	public function testMultipleWithNoVerify() {
+		if ($this->skip_https) {
+			$this->markTestSkipped('SSL support is not available.');
+			return;
+		}
+
+		$requests = array(
+			'test1' => array(
+				'url' => 'https://wrong.host.badssl.com/',
+				'options' => array('verify' => false),
+			),
+			'test2' => array(
+				'url' => 'https://wrong.host.badssl.com/'
+			),
+		);
+
+		$responses = Requests::request_multiple($requests, $this->getOptions());
+
+		// test1
+		$this->assertNotEmpty($responses['test1']);
+		$this->assertInstanceOf('Requests_Response', $responses['test1']);
+		$this->assertEquals(200, $responses['test1']->status_code);
+
+		// test2
+		$this->assertNotEmpty($responses['test2']);
+		$this->assertInstanceOf('Requests_Exception', $responses['test2']);
+	}
+
 	public function testAlternatePort() {
 		$request = Requests::get('http://portquiz.net:8080/', array(), $this->getOptions());
 		$this->assertEquals(200, $request->status_code);


### PR DESCRIPTION
The `request_multi` method does not take into account the verify option,
unlike `request`. Moved the verify logic into `setup_handler` which does
all the `curl_setopt` calls anyway and is called from both the multiple
and single request options.

With tests. Contigent on #310 for fsockopen verify fix.

Fixes #294