### PR TITLE
Prevent cURL transport from leaking on Exception

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -174,12 +174,14 @@ class Requests_Transport_cURL implements Requests_Transport {
 			$response = $this->response_data;
 		}
 
-		$this->process_response($response, $options);
+		if (true === $options['blocking']) {
+			// Need to remove the $this reference from the curl handle.
+			// Otherwise Requests_Transport_cURL wont be garbage collected and the curl_close() will never be called.
+			curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, null);
+			curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, null);
+		}
 
-		// Need to remove the $this reference from the curl handle.
-		// Otherwise Requests_Transport_cURL wont be garbage collected and the curl_close() will never be called.
-		curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, null);
-		curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, null);
+		$this->process_response($response, $options);
 
 		return $this->headers;
 	}


### PR DESCRIPTION
The `CURLOPT_HEADERFUNCTION` and `CURLOPT_WRITEFUNCTION` options are not
being reset if a cURL handle error occurs (which throws a
`Requests_Exception` and stops execution). The destructor is not called
due to lingering instance method callbacks in the two options.

Move `CURLOPT_HEADERFUNCTION` and `CURLOPT_WRITEFUNCTION` cleanup before
any exceptions can happen.