### PR TITLE
 post request support multi-file upload

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -265,35 +265,35 @@ class Requests {
 	/**
 	 * Send a POST request/Support for multiple files, complex array parameters
 	 */
-        public static function post($url, $headers = [], $data = [], $files = [], $options = []) : \Requests_Response{
-            if (count($files)) {
-    
-                // replacing file paths with curlFile Object
-                array_walk($files, function ($filePath, $key) use (&$data) {
-                    if (is_array($filePath)) {
-                        array_walk($filePath, function ($subFilePath, $subKey) use (&$data, $key) {
-                            $data[$key][$subKey] = new \CURLFile(realpath($subFilePath));
-                        });
-                    } else {
-                        $data[ $key ] = new \CURLFile(realpath($filePath));
-                    }
-                });
-    
-                self::httpBuildQuery($data);
-    
-                // starting to add a hook to attach file to request
-                $hooks = new \Requests_Hooks();
-                $hooks->register('curl.before_send', function ($fp) use ($data) {
-                    curl_setopt($fp, CURLOPT_SAFE_UPLOAD, true);
-                    curl_setopt($fp, CURLOPT_POSTFIELDS, $data);
-                });
-                $options = ['hooks' => $hooks];
-                // no need to set the body, it's taken care of by hooks
-                $data = [];
-            }
-    
-            return self::request($url, $headers, $data, self::POST, $options);
+    public static function post($url, $headers = [], $data = [], $files = [], $options = []) : \Requests_Response{
+        if (count($files)) {
+
+            // replacing file paths with curlFile Object
+            array_walk($files, function ($filePath, $key) use (&$data) {
+                if (is_array($filePath)) {
+                    array_walk($filePath, function ($subFilePath, $subKey) use (&$data, $key) {
+                        $data[$key][$subKey] = new \CURLFile(realpath($subFilePath));
+                    });
+                } else {
+                    $data[ $key ] = new \CURLFile(realpath($filePath));
+                }
+            });
+
+            self::httpBuildQuery($data);
+
+            // starting to add a hook to attach file to request
+            $hooks = new \Requests_Hooks();
+            $hooks->register('curl.before_send', function ($fp) use ($data) {
+                curl_setopt($fp, CURLOPT_SAFE_UPLOAD, true);
+                curl_setopt($fp, CURLOPT_POSTFIELDS, $data);
+            });
+            $options = ['hooks' => $hooks];
+            // no need to set the body, it's taken care of by hooks
+            $data = [];
         }
+
+        return self::request($url, $headers, $data, self::POST, $options);
+    }
 	/**
 	 * Send a PUT request
 	 */
@@ -1005,15 +1005,15 @@ class Requests {
 		return false;
 	}
 	
-        protected static function httpBuildQuery(array &$data, $key = '', $value = null) {
-            foreach ($value ?? $data as $k => $v) {
-                if (is_array($v)) {
-                    self::httpBuildQuery($data, "{$key}[{$k}]", $v);
-                }else{
-                    $cur_key = $key ? "{$key}[{$k}]" : "{$k}";
-                    $data[$cur_key] = $v;
-                }
-                unset($data[$k]);
+    protected static function httpBuildQuery(array &$data, $key = '', $value = null) {
+        foreach ($value ?? $data as $k => $v) {
+            if (is_array($v)) {
+                self::httpBuildQuery($data, "{$key}[{$k}]", $v);
+            }else{
+                $cur_key = $key ? "{$key}[{$k}]" : "{$k}";
+                $data[$cur_key] = $v;
             }
+            unset($data[$k]);
         }
+    }
 }

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -258,15 +258,42 @@ class Requests {
 	 * @param string $url
 	 * @param array $headers
 	 * @param array $data
+	 * @param array $files
 	 * @param array $options
 	 * @return Requests_Response
 	 */
 	/**
-	 * Send a POST request
+	 * Send a POST request/Support for multiple files, complex array parameters
 	 */
-	public static function post($url, $headers = array(), $data = array(), $options = array()) {
-		return self::request($url, $headers, $data, self::POST, $options);
-	}
+        public static function post($url, $headers = [], $data = [], $files = [], $options = []) : \Requests_Response{
+            if (count($files)) {
+    
+                // replacing file paths with curlFile Object
+                array_walk($files, function ($filePath, $key) use (&$data) {
+                    if (is_array($filePath)) {
+                        array_walk($filePath, function ($subFilePath, $subKey) use (&$data, $key) {
+                            $data[$key][$subKey] = new \CURLFile(realpath($subFilePath));
+                        });
+                    } else {
+                        $data[ $key ] = new \CURLFile(realpath($filePath));
+                    }
+                });
+    
+                self::httpBuildQuery($data);
+    
+                // starting to add a hook to attach file to request
+                $hooks = new \Requests_Hooks();
+                $hooks->register('curl.before_send', function ($fp) use ($data) {
+                    curl_setopt($fp, CURLOPT_SAFE_UPLOAD, true);
+                    curl_setopt($fp, CURLOPT_POSTFIELDS, $data);
+                });
+                $options = ['hooks' => $hooks];
+                // no need to set the body, it's taken care of by hooks
+                $data = [];
+            }
+    
+            return self::request($url, $headers, $data, self::POST, $options);
+        }
 	/**
 	 * Send a PUT request
 	 */
@@ -977,4 +1004,16 @@ class Requests {
 
 		return false;
 	}
+	
+        protected static function httpBuildQuery(array &$data, $key = '', $value = null) {
+            foreach ($value ?? $data as $k => $v) {
+                if (is_array($v)) {
+                    self::httpBuildQuery($data, "{$key}[{$k}]", $v);
+                }else{
+                    $cur_key = $key ? "{$key}[{$k}]" : "{$k}";
+                    $data[$cur_key] = $v;
+                }
+                unset($data[$k]);
+            }
+        }
 }


### PR DESCRIPTION
Just add a $files file path array parameter, the file array can be a two-dimensional array, upload file can also support complex array request parameter request.

example：
``` php 
Requests::post($url,$header,['test' => ['a' => 'b','c' => [1,2,3 => ['cc' => ['vv' => [456,789,321]]]]]],[
        'paid_certificates' => [
            public_path('images/not_found.jpg'),
            public_path('images/abg.jpg'),
            public_path('images/bg.jpg'),
        ],
    ]);
```