### PR TITLE
Ignore locale when creating the HTTP version string from a float

### DIFF
--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -150,7 +150,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		$options['hooks']->dispatch('fsockopen.remote_host_path', array(&$path, $url));
 
 		$request_body = '';
-		$out = sprintf("%s %s HTTP/%.1f\r\n", $options['type'], $path, $options['protocol_version']);
+		$out = sprintf("%s %s HTTP/%.1F\r\n", $options['type'], $path, $options['protocol_version']);
 
 		if ($options['type'] !== Requests::TRACE) {
 			if (is_array($data)) {


### PR DESCRIPTION
This should fix #335.

Rather than using `%f`, this should use the non-locale aware `%F`. That way PHP will always use a period (`.`) for the decimal separator in the HTTP version, and never fallback to a comma (`,`).

I wasn’t sure how to add a test for this, as I’d want to intercept the socket message somehow. But to illustrate the issue:

```
php > echo setlocale(LC_NUMERIC, 0);
C
php > echo sprintf("%s %s HTTP/%.1f\r\n", 'GET', '/', 1.1);
GET / HTTP/1.1
php > echo setlocale(LC_NUMERIC, 'de_DE');
de_DE
php > echo sprintf("%s %s HTTP/%.1f\r\n", 'GET', '/', 1.1);
GET / HTTP/1,1
php > echo sprintf("%s %s HTTP/%.1F\r\n", 'GET', '/', 1.1);
GET / HTTP/1.1
```