### PR TITLE
Fix unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,10 @@ before_script:
  - ../vendor/bin/phpunit --version
 
 script:
- - ../vendor/bin/phpunit --coverage-clover clover.xml
+ - if [[ $(phpenv version-name:0:1) == "5" ]];
+   then phpunit --coverage-clover clover.xml;
+   else ../vendor/bin/phpunit --coverage-clover clover.xml;
+   fi
 
 after_script:
  - utils/proxy/stop.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,10 @@ before_script:
  - curl -s -I http://requests-php-tests.herokuapp.com/ > /dev/null
  
  # Environment checks
- - phpunit --version
+ - ../vendor/bin/phpunit --version
 
 script:
- - phpunit --coverage-clover clover.xml
+ - ../vendor/bin/phpunit --coverage-clover clover.xml
 
 after_script:
  - utils/proxy/stop.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,26 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.2
-      dist: precise
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
-      env: TEST_COVERAGE=1
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
-    - php: nightly
+   - php: 5.2
+     dist: precise
+     env: COMPOSER_PHPUNIT=false
+   - php: 5.3
+     dist: precise
+     env: COMPOSER_PHPUNIT=false
+   - php: 5.4
+     env: COMPOSER_PHPUNIT=false
+   - php: 5.5
+     env: COMPOSER_PHPUNIT=false
+   - php: 5.6
+     env: TEST_COVERAGE=1 COMPOSER_PHPUNIT=true
+   - php: 7.0
+     env: COMPOSER_PHPUNIT=true
+   - php: 7.1
+     env: COMPOSER_PHPUNIT=true
+   - php: 7.2
+     env: COMPOSER_PHPUNIT=true
+   - php: nightly
+     env: COMPOSER_PHPUNIT=true
 
 allow_failures:
   - php: nightly
@@ -30,6 +38,7 @@ cache:
 install:
  # Setup the test server
  - phpenv local $( phpenv versions | grep 5.6 | tail -1 )
+ - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then composer remove phpunit/phpunit --dev; fi
  - composer install --dev --no-interaction
  - TESTPHPBIN=$(phpenv which php)
  - phpenv local --unset
@@ -54,11 +63,10 @@ before_script:
  - curl -s -I http://requests-php-tests.herokuapp.com/ > /dev/null
  
  # Environment checks
- - ../vendor/bin/phpunit --version
+ - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then phpunit --version; else ../vendor/bin/phpunit --version; fi
 
 script:
- - if [[ $(phpenv version-name:0:1) == "5" ]];
-   then phpunit --coverage-clover clover.xml;
+ - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then phpunit --coverage-clover clover.xml;
    else ../vendor/bin/phpunit --coverage-clover clover.xml;
    fi
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"php": ">=5.2"
 	},
 	"require-dev": {
-		"requests/test-server": "dev-master"
+		"requests/test-server": "dev-master",
+		"phpunit/phpunit": "^6.0"
 	},
 	"type": "library",
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	},
 	"require-dev": {
 		"requests/test-server": "dev-master",
-		"phpunit/phpunit": "^6.0"
+		"phpunit/phpunit": "^5.0"
 	},
 	"type": "library",
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	},
 	"require-dev": {
 		"requests/test-server": "dev-master",
-		"phpunit/phpunit": "^5.0"
+		"phpunit/phpunit": "<6.0"
 	},
 	"type": "library",
 	"autoload": {

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -29,7 +29,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			parent::setExpectedException( $exception, $message, $code );
 		} else {
 			$this->expectException( $exception );
-			if ( '' !== $message ) {
+			if ( null !== $message ) {
 				$this->expectExceptionMessage( $message );
 			}
 			if ( null !== $code ) {

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -414,10 +414,10 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 
 		if (!$success) {
 			if ($code >= 400) {
-				$this->setExpectedException('Requests_Exception_HTTP_' . $code, '', $code);
+				$this->setExpectedException('Requests_Exception_HTTP_' . $code, null, $code);
 			}
 			elseif ($code >= 300 && $code < 400) {
-				$this->setExpectedException('Requests_Exception');
+				$this->setExpectedException('Requests_Exception', null);
 			}
 		}
 		$request = Requests::get($url, array(), $options);
@@ -439,7 +439,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 
 		if (!$success) {
 			if ($code >= 400 || $code === 304 || $code === 305 || $code === 306) {
-				$this->setExpectedException('Requests_Exception_HTTP_' . $code, '', $code);
+				$this->setExpectedException('Requests_Exception_HTTP_' . $code, null, $code);
 			}
 		}
 		$request = Requests::get($url, array(), $options);


### PR DESCRIPTION
The tests currently use an empty string or the default value for checking exception message which means empty message. The message is not empty and causes the tests to fail. I changed this to null so the message is not checked and those tests pass.