### PR TITLE
Travis: test against PHP 7.3 and 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
      env: COMPOSER_PHPUNIT=true
    - php: 7.2
      env: COMPOSER_PHPUNIT=true
+   - php: 7.3
+     env: COMPOSER_PHPUNIT=true
+   - php: 7.4snapshot
+     env: COMPOSER_PHPUNIT=true
    - php: nightly
      env: COMPOSER_PHPUNIT=true
   allow_failures:


### PR DESCRIPTION
As `Request` is supposed to work cross-version, testing against PHP 7.3 (out since dec 2018) and PHP 7.4 (expected end of november 2019) would be a good idea.