### PR TITLE
Travis: remove `sudo: false`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ matrix:
     - php: nightly
       env: COMPOSER_PHPUNIT=true
 
-# Use new container infrastructure
-sudo: false
-
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
The switch to containers via `sudo` is no longer supported by Travis.

See: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration