### PR TITLE
Unit tests: attempt to make the build more stable

### DIFF
--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -765,7 +765,20 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testAlternatePort() {
-		$request = Requests::get('http://portquiz.net:8080/', array(), $this->getOptions());
+		try {
+			$request = Requests::get('http://portquiz.net:8080/', array(), $this->getOptions());
+		} catch( Requests_Exception $e ) {
+			// Retry the request as it often times-out.
+			try {
+				$request = Requests::get('http://portquiz.net:8080/', array(), $this->getOptions());
+			} catch( Requests_Exception $e ) {
+				// If it still times out, mark the test as skipped.
+				$this->markTestSkipped(
+					$e->getMessage()
+				);
+			}
+		}
+
 		$this->assertEquals(200, $request->status_code);
 		$num = preg_match('#You have reached this page on port <b>(\d+)</b>#i', $request->body, $matches);
 		$this->assertEquals(1, $num, 'Response should contain the port number');

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="bootstrap.php">
+<phpunit bootstrap="bootstrap.php" verbose="true">
 	<testsuites>
 		<testsuite name="Authentication">
 			<directory suffix=".php">Auth</directory>


### PR DESCRIPTION
The `testAlternatePort` tests for both Curl as well as fsockopen often time out and cause builds to fail.

This PR attempts to make the builds more stable, by:
1. Retrying the request a second time if the first request timed out.
2. Skipping the unit test if the second request timed out as well.

Adding `verbose=true` to the PHPUnit config will make sure that if the tests are skipped, the skip reason will always be displayed when running the tests.