### PR TITLE
PHP compatibility: don't use short arrays

### DIFF
--- a/examples/cookie_jar.php
+++ b/examples/cookie_jar.php
@@ -7,13 +7,13 @@ include('../library/Requests.php');
 Requests::register_autoloader();
 
 // Say you need to fake a login cookie
-$c = new Requests_Cookie_Jar(['login_uid' =>  'something']);
+$c = new Requests_Cookie_Jar(array('login_uid' => 'something'));
 
 // Now let's make a request!
 $request = Requests::get(
 	'http://httpbin.org/cookies', // Url
-	[],  // No need to set the headers the Jar does this for us
-	['cookies' => $c] // Pass in the Jar as an option
+	array(),  // No need to set the headers the Jar does this for us
+	array('cookies' => $c) // Pass in the Jar as an option
 );
 
 // Check what we received


### PR DESCRIPTION
Short arrays were introduced in PHP 5.4.
As this package is supposed to be compatible with PHP 5.2 and up, they cannot be used and IMO, even the example code should comply with that.