### PR TITLE
QA: lint PHP files in this repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
  - phpenv local $( phpenv versions | grep 5.6 | tail -1 )
  - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then composer remove phpunit/phpunit --dev; fi
  - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then export PHPUNIT_BIN="phpunit";
-   else export PHPUNIT_BIN="../vendor/bin/phpunit";
+   else export PHPUNIT_BIN="$(pwd)/vendor/bin/phpunit";
    fi
  - composer install --dev --no-interaction
  - TESTPHPBIN=$(phpenv which php)
@@ -62,10 +62,8 @@ before_script:
  - PHPBIN=$TESTPHPBIN PORT=8080 vendor/bin/start.sh
  - export REQUESTS_TEST_HOST_HTTP="localhost:8080"
 
- # Work out of the tests directory
- - cd tests
- - PROXYBIN="$HOME/.local/bin/mitmdump" PORT=9002 utils/proxy/start.sh
- - PROXYBIN="$HOME/.local/bin/mitmdump" PORT=9003 AUTH="test:pass" utils/proxy/start.sh
+ - PROXYBIN="$HOME/.local/bin/mitmdump" PORT=9002 tests/utils/proxy/start.sh
+ - PROXYBIN="$HOME/.local/bin/mitmdump" PORT=9003 AUTH="test:pass" tests/utils/proxy/start.sh
  - export REQUESTS_HTTP_PROXY="localhost:9002"
  - export REQUESTS_HTTP_PROXY_AUTH="localhost:9003"
  - export REQUESTS_HTTP_PROXY_AUTH_USER="test"
@@ -73,11 +71,23 @@ before_script:
 
  # Ensure the HTTPS test instance on Heroku is spun up
  - curl -s -I http://requests-php-tests.herokuapp.com/ > /dev/null
- 
+
  # Environment checks
  - $PHPUNIT_BIN --version
 
 script:
+ # Lint PHP files against parse errors.
+ - |
+   if [ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]; then
+     if find $(pwd)/ -path $(pwd)/vendor -prune -o -path $(pwd)/ examples/cookie_jar.php -prune -o -path $(pwd)/tests/phpunit6-compat.php -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi
+   elif [ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]; then
+     if find $(pwd)/ -path $(pwd)/vendor -prune -o -path $(pwd)/ examples/cookie_jar.php -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi
+   else
+     if find $(pwd)/ -path $(pwd)/vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi
+   fi
+
+ # Run the unit tests.
+ - cd tests
  - |
    if [ "$TEST_COVERAGE" == '1' ]; then
      $PHPUNIT_BIN --coverage-clover clover.xml;


### PR DESCRIPTION
This PR adds linting of the PHP files in the repo against every supported PHP version to the Travis build.

The `vendor` directory is excluded by default.
For PHP 5.2, the `tests/phpunit6-compat.php` file is excluded as it uses namespaces and is only loaded on PHP 7+ anyway.
For PHP < 5.4, the `examples/cookie_jar.php` file is excluded as it uses short arrays.