### PR TITLE
QA: remove dead code

### DIFF
--- a/tests/phpunit6-compat.php
+++ b/tests/phpunit6-compat.php
@@ -14,25 +14,4 @@ if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner
 	class_alias( 'PHPUnit\Framework\TestListener', 'PHPUnit_Framework_TestListener' );
 	class_alias( 'PHPUnit\Util\GlobalState', 'PHPUnit_Util_GlobalState' );
 	class_alias( 'PHPUnit\Util\Getopt', 'PHPUnit_Util_Getopt' );
-
-	class PHPUnit_Util_Test extends PHPUnit\Util\Test {
-
-		public static function getTickets( $className, $methodName ) {
-			$annotations = self::parseTestMethodAnnotations( $className, $methodName );
-
-			$tickets = array();
-
-			if ( isset( $annotations['class']['ticket'] ) ) {
-				$tickets = $annotations['class']['ticket'];
-			}
-
-			if ( isset( $annotations['method']['ticket'] ) ) {
-				$tickets = array_merge( $tickets, $annotations['method']['ticket'] );
-			}
-
-			return array_unique( $tickets );
-		}
-
-	}
-
 }


### PR DESCRIPTION
Looks like this code is never used anywhere and it causes issues with PHPUnit cross-version compatibility as the `PHPUnit\Util\Test` class has become `final`.