### PR TITLE
CS: fix up comment indentation and style

### DIFF
--- a/library/Requests/IDNAEncoder.php
+++ b/library/Requests/IDNAEncoder.php
@@ -227,15 +227,15 @@ class Requests_IDNAEncoder {
 	 */
 	public static function punycode_encode($input) {
 		$output = '';
-#		let n = initial_n
+		// let n = initial_n
 		$n = self::BOOTSTRAP_INITIAL_N;
-#		let delta = 0
+		// let delta = 0
 		$delta = 0;
-#		let bias = initial_bias
+		// let bias = initial_bias
 		$bias = self::BOOTSTRAP_INITIAL_BIAS;
-#		let h = b = the number of basic code points in the input
+		// let h = b = the number of basic code points in the input
 		$h = $b = 0; // see loop
-#		copy them to the output in order
+		// copy them to the output in order
 		$codepoints = self::utf8_to_codepoints($input);
 		$extended = array();
 
@@ -260,35 +260,35 @@ class Requests_IDNAEncoder {
 		$extended = array_keys($extended);
 		sort($extended);
 		$b = $h;
-#		[copy them] followed by a delimiter if b > 0
+		// [copy them] followed by a delimiter if b > 0
 		if (strlen($output) > 0) {
 			$output .= '-';
 		}
-#		{if the input contains a non-basic code point < n then fail}
-#		while h < length(input) do begin
+		// {if the input contains a non-basic code point < n then fail}
+		// while h < length(input) do begin
 		while ($h < count($codepoints)) {
-#			let m = the minimum code point >= n in the input
+			// let m = the minimum code point >= n in the input
 			$m = array_shift($extended);
 			//printf('next code point to insert is %s' . PHP_EOL, dechex($m));
-#			let delta = delta + (m - n) * (h + 1), fail on overflow
+			// let delta = delta + (m - n) * (h + 1), fail on overflow
 			$delta += ($m - $n) * ($h + 1);
-#			let n = m
+			// let n = m
 			$n = $m;
-#			for each code point c in the input (in order) do begin
+			// for each code point c in the input (in order) do begin
 			for ($num = 0; $num < count($codepoints); $num++) {
 				$c = $codepoints[$num];
-#				if c < n then increment delta, fail on overflow
+				// if c < n then increment delta, fail on overflow
 				if ($c < $n) {
 					$delta++;
 				}
-#				if c == n then begin
+				// if c == n then begin
 				elseif ($c === $n) {
-#					let q = delta
+					// let q = delta
 					$q = $delta;
-#					for k = base to infinity in steps of base do begin
+					// for k = base to infinity in steps of base do begin
 					for ($k = self::BOOTSTRAP_BASE; ; $k += self::BOOTSTRAP_BASE) {
-#						let t = tmin if k <= bias {+ tmin}, or
-#								tmax if k >= bias + tmax, or k - bias otherwise
+						// let t = tmin if k <= bias {+ tmin}, or
+						// 		tmax if k >= bias + tmax, or k - bias otherwise
 						if ($k <= ($bias + self::BOOTSTRAP_TMIN)) {
 							$t = self::BOOTSTRAP_TMIN;
 						}
@@ -298,34 +298,30 @@ class Requests_IDNAEncoder {
 						else {
 							$t = $k - $bias;
 						}
-#						if q < t then break
+						// if q < t then break
 						if ($q < $t) {
 							break;
 						}
-#						output the code point for digit t + ((q - t) mod (base - t))
+						// output the code point for digit t + ((q - t) mod (base - t))
 						$digit = $t + (($q - $t) % (self::BOOTSTRAP_BASE - $t));
 						$output .= self::digit_to_char($digit);
-#						let q = (q - t) div (base - t)
+						// let q = (q - t) div (base - t)
 						$q = floor(($q - $t) / (self::BOOTSTRAP_BASE - $t));
-#					end
-					}
-#					output the code point for digit q
+					} // end
+					// output the code point for digit q
 					$output .= self::digit_to_char($q);
-#					let bias = adapt(delta, h + 1, test h equals b?)
+					// let bias = adapt(delta, h + 1, test h equals b?)
 					$bias = self::adapt($delta, $h + 1, $h === $b);
-#					let delta = 0
+					// let delta = 0
 					$delta = 0;
-#					increment h
+					// increment h
 					$h++;
-#				end
-				}
-#			end
-			}
-#			increment delta and n
+				} // end
+			} // end
+			// increment delta and n
 			$delta++;
 			$n++;
-#		end
-		}
+		} // end
 
 		return $output;
 	}
@@ -358,31 +354,31 @@ class Requests_IDNAEncoder {
 	 * @param int $numpoints
 	 * @param bool $firsttime
 	 * @return int New bias
+	 *
+	 * function adapt(delta,numpoints,firsttime):
 	 */
 	protected static function adapt($delta, $numpoints, $firsttime) {
-#	function adapt(delta,numpoints,firsttime):
-#		if firsttime then let delta = delta div damp
+		// if firsttime then let delta = delta div damp
 		if ($firsttime) {
 			$delta = floor($delta / self::BOOTSTRAP_DAMP);
 		}
-#		else let delta = delta div 2
+		// else let delta = delta div 2
 		else {
 			$delta = floor($delta / 2);
 		}
-#		let delta = delta + (delta div numpoints)
+		// let delta = delta + (delta div numpoints)
 		$delta += floor($delta / $numpoints);
-#		let k = 0
+		// let k = 0
 		$k = 0;
-#		while delta > ((base - tmin) * tmax) div 2 do begin
+		// while delta > ((base - tmin) * tmax) div 2 do begin
 		$max = floor(((self::BOOTSTRAP_BASE - self::BOOTSTRAP_TMIN) * self::BOOTSTRAP_TMAX) / 2);
 		while ($delta > $max) {
-#			let delta = delta div (base - tmin)
+			// let delta = delta div (base - tmin)
 			$delta = floor($delta / (self::BOOTSTRAP_BASE - self::BOOTSTRAP_TMIN));
-#			let k = k + base
+			// let k = k + base
 			$k += self::BOOTSTRAP_BASE;
-#		end
-		}
-#		return k + (((base - tmin + 1) * delta) div (delta + skew))
+		} // end
+		// return k + (((base - tmin + 1) * delta) div (delta + skew))
 		return $k + floor(((self::BOOTSTRAP_BASE - self::BOOTSTRAP_TMIN + 1) * $delta) / ($delta + self::BOOTSTRAP_SKEW));
 	}
 }


### PR DESCRIPTION
_[This PR is part of a series to introduce code style checking to the repo]_

Use PHP native comment style, rather than Perl comment style and align the start of the comments with the code.