### PR TITLE
CS: review of all include and require statements

### DIFF
--- a/examples/basic-auth.php
+++ b/examples/basic-auth.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-include('../library/Requests.php');
+require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/cookie.php
+++ b/examples/cookie.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-include('../library/Requests.php');
+require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/cookie_jar.php
+++ b/examples/cookie_jar.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-include('../library/Requests.php');
+require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/get.php
+++ b/examples/get.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-include('../library/Requests.php');
+require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/multiple.php
+++ b/examples/multiple.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-include('../library/Requests.php');
+require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/post.php
+++ b/examples/post.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-include('../library/Requests.php');
+require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/proxy.php
+++ b/examples/proxy.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-include('../library/Requests.php');
+require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/session.php
+++ b/examples/session.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-include('../library/Requests.php');
+require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/timeout.php
+++ b/examples/timeout.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-include('../library/Requests.php');
+require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -143,7 +143,7 @@ class Requests {
 
 		$file = str_replace('_', '/', $class);
 		if (file_exists(dirname(__FILE__) . '/' . $file . '.php')) {
-			require_once(dirname(__FILE__) . '/' . $file . '.php');
+			require_once dirname(__FILE__) . '/' . $file . '.php';
 		}
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,7 +28,7 @@ define_from_env('REQUESTS_HTTP_PROXY_AUTH');
 define_from_env('REQUESTS_HTTP_PROXY_AUTH_USER');
 define_from_env('REQUESTS_HTTP_PROXY_AUTH_PASS');
 
-include(dirname(dirname(__FILE__)) . '/library/Requests.php');
+require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 Requests::register_autoloader();
 
 function autoload_tests($class) {
@@ -39,7 +39,7 @@ function autoload_tests($class) {
 	$class = substr($class, 13);
 	$file = str_replace('_', '/', $class);
 	if (file_exists(dirname(__FILE__) . '/' . $file . '.php')) {
-		require_once(dirname(__FILE__) . '/' . $file . '.php');
+		require_once dirname(__FILE__) . '/' . $file . '.php';
 	}
 }
 


### PR DESCRIPTION
_[This PR is part of a series to introduce code style checking to the repo]_

`include` and `require` are language constructs, not functions.

With that in mind there are a number of best practices surrounding them:
* There is no need to use parenthesis and not doing so will be, albeit marginally, faster.
* Always pass an absolute path for maximum portability.
    Using `dirname(__FILE__)` instead of `__DIR__` to maintain compatibility with PHP 5.2.
* Use `require_once` instead of `include` when the file is _required_ for the rest of the script to be able to function.