### PR TITLE
CS: remove stray debug code

### DIFF
--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -608,7 +608,6 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'timeout' => 1,
 		);
 		$request = Requests::get(httpbin('/delay/10'), array(), $this->getOptions($options));
-		var_dump($request);
 	}
 
 	public function testMultiple() {


### PR DESCRIPTION
_[This PR is part of a series to introduce code style checking to the repo]_

This test should work fine without the `var_dump()`.