### PR TITLE
Tests: enable the `Encoding` tests

### DIFF
--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -13,6 +13,7 @@
 		<testsuite name="General">
 			<file>ChunkedEncoding.php</file>
 			<file>Cookies.php</file>
+			<file>Encoding.php</file>
 			<file>IDNAEncoder.php</file>
 			<file>IRI.php</file>
 			<file>Requests.php</file>


### PR DESCRIPTION
Looks like these have never run as they weren't included in any of the testsuites.