### PR TITLE
Add Content-* headers for empty POST requests

### DIFF
--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -162,6 +162,8 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 				$request_body = $data;
 			}
 
+			// Always include Content-length on POST requests to prevent
+			// 411 errors from some servers when the body is empty.
 			if (!empty($data) || $options['type'] === Requests::POST) {
 				if (!isset($case_insensitive_headers['Content-Length'])) {
 					$headers['Content-Length'] = strlen($request_body);
@@ -169,12 +171,6 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 
 				if (!isset($case_insensitive_headers['Content-Type'])) {
 					$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
-				}
-			}
-			elseif($options['type'] === Requests::POST) {
-				if (!isset($case_insensitive_headers['Content-Length'])) {
-					// Prevent 411 errors from some servers
-					$headers['Content-Length'] = 0;
 				}
 			}
 		}

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -162,7 +162,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 				$request_body = $data;
 			}
 
-			if (!empty($data)) {
+			if (!empty($data) || $options['type'] === Requests::POST) {
 				if (!isset($case_insensitive_headers['Content-Length'])) {
 					$headers['Content-Length'] = strlen($request_body);
 				}

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -171,6 +171,12 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 					$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
 				}
 			}
+			elseif($options['type'] === Requests::POST) {
+				if (!isset($case_insensitive_headers['Content-Length'])) {
+					// Prevent 411 errors from some servers
+					$headers['Content-Length'] = 0;
+				}
+			}
 		}
 
 		if (!isset($case_insensitive_headers['Host'])) {

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -168,13 +168,26 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('test', $result['data']);
 	}
 
+	/**
+	 * Issue #248.
+	 */
 	public function testEmptyPOST() {
 		$request = Requests::post(httpbin('/post'), array(), null, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		// Heroku appears to add this on incoming requests even if we don't send it
-		$this->assertArrayHasKey( 'content-length', $result['headers'] ); 
+
+		/*
+		 * Heroku appears to add this on incoming requests even if we don't send it.
+		 * If Heroku added it, the key will be lowercase, otherwise, uppercase.
+		 */
+		if (isset($result['headers']['Content-Length'])) {
+			$this->assertArrayHasKey('Content-Length', $result['headers']);
+			$this->assertSame('0', $result['headers']['Content-Length']);
+		} else {
+			$this->assertArrayHasKey('content-length', $result['headers']);
+			$this->assertSame('0', $result['headers']['content-length']);
+		}
 	}
 
 	public function testFormPost() {

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -168,6 +168,15 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('test', $result['data']);
 	}
 
+	public function testEmptyPOST() {
+		$request = Requests::post(httpbin('/post'), array(), null, $this->getOptions());
+		$this->assertEquals(200, $request->status_code);
+
+		$result = json_decode($request->body, true);
+		// Heroku appears to add this on incoming requests even if we don't send it
+		$this->assertArrayHasKey( 'content-length', $result['headers'] ); 
+	}
+
 	public function testFormPost() {
 		$data    = 'test=true&test2=test';
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());

--- a/tests/Transport/fsockopen.php
+++ b/tests/Transport/fsockopen.php
@@ -2,4 +2,15 @@
 
 class RequestsTest_Transport_fsockopen extends RequestsTest_Transport_Base {
 	protected $transport = 'Requests_Transport_fsockopen';
+
+	public function testContentLengthHeader() {
+		$hooks = new Requests_Hooks();
+		$hooks->register('fsockopen.after_headers', array($this, 'checkContentLengthHeader'));
+
+		$request = Requests::post(httpbin('/post'), array(), array(), $this->getOptions(array('hooks' => $hooks)));
+	}
+
+	public function checkContentLengthHeader($headers) {
+		$this->assertContains('Content-Length: 0', $headers);
+	}
 }

--- a/tests/Transport/fsockopen.php
+++ b/tests/Transport/fsockopen.php
@@ -3,6 +3,9 @@
 class RequestsTest_Transport_fsockopen extends RequestsTest_Transport_Base {
 	protected $transport = 'Requests_Transport_fsockopen';
 
+	/**
+	 * Issue #248.
+	 */
 	public function testContentLengthHeader() {
 		$hooks = new Requests_Hooks();
 		$hooks->register('fsockopen.after_headers', array($this, 'checkContentLengthHeader'));
@@ -10,6 +13,9 @@ class RequestsTest_Transport_fsockopen extends RequestsTest_Transport_Base {
 		$request = Requests::post(httpbin('/post'), array(), array(), $this->getOptions(array('hooks' => $hooks)));
 	}
 
+	/**
+	 * Issue #248.
+	 */
 	public function checkContentLengthHeader($headers) {
 		$this->assertContains('Content-Length: 0', $headers);
 	}


### PR DESCRIPTION
This PR consolidates the work done by @dd32 in PR #249 and @soulseekah in PR #318 which both addressed the same issue.

Fixes #248
Closes #249
Closes #318