### PR TITLE
handle no domain in a PHP7.4 compatable way

### DIFF
--- a/library/Requests/Cookie.php
+++ b/library/Requests/Cookie.php
@@ -289,7 +289,7 @@ class Requests_Cookie {
 
 			case 'domain':
 				// Domains are not required as per RFC 6265 section 5.2.3
-				if (is_null( $value ) || false === $value){
+				if (empty($value)) {
 					return null;
 				}
 

--- a/library/Requests/Cookie.php
+++ b/library/Requests/Cookie.php
@@ -288,6 +288,11 @@ class Requests_Cookie {
 				return $expiry_time;
 
 			case 'domain':
+				// Domains are not required as per RFC 6265 section 5.2.3
+				if (is_null( $value ) || false === $value){
+					return null;
+				}
+
 				// Domain normalization, as per RFC 6265 section 5.2.3
 				if ($value[0] === '.') {
 					$value = substr($value, 1);

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -600,6 +600,13 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 				array( 'invalid' => false ),
 			),
 
+			# Empty Domain	
+			array(
+				'name=value; domain=',
+				'http://example.com/test/',
+				array(),
+			),
+
 			# Subdomain cookies
 			array(
 				'name=value; domain=test.example.com',


### PR DESCRIPTION
PHP 7.4 introduces a "Trying to access array offset on value of type ..." warning for accessing null/bool/int/float/resource (everything but array, string and object) as if it were an array.

Fixes #369