### PR TITLE
Add support for sending POST with multipart/form-data

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -313,6 +313,11 @@ class Requests_Transport_cURL implements Requests_Transport {
 		if ( ! isset( $headers['Connection'] ) ) {
 			$headers['Connection'] = 'close';
 		}
+        if(isset($headers['Content-Type']) && $headers['Content-Type']==='multipart/form-data') {
+            $is_multipart_form = true;
+        }
+        else
+            $is_multipart_form = false;
 
 		$headers = Requests::flatten($headers);
 
@@ -323,7 +328,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 				$url = self::format_get($url, $data);
 				$data = '';
 			}
-			elseif (!is_string($data)) {
+            elseif (!is_string($data) && !$is_multipart_form) {
 				$data = http_build_query($data, null, '&');
 			}
 		}

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -313,11 +313,11 @@ class Requests_Transport_cURL implements Requests_Transport {
 		if ( ! isset( $headers['Connection'] ) ) {
 			$headers['Connection'] = 'close';
 		}
-        if(isset($headers['Content-Type']) && $headers['Content-Type']==='multipart/form-data') {
-            $is_multipart_form = true;
-        }
-        else
-            $is_multipart_form = false;
+		if(isset($headers['Content-Type']) && $headers['Content-Type']==='multipart/form-data') {
+			$is_multipart_form = true;
+		}
+		else
+			$is_multipart_form = false;
 
 		$headers = Requests::flatten($headers);
 
@@ -328,7 +328,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 				$url = self::format_get($url, $data);
 				$data = '';
 			}
-            elseif (!is_string($data) && !$is_multipart_form) {
+			elseif (!is_string($data) && !$is_multipart_form) {
 				$data = http_build_query($data, null, '&');
 			}
 		}

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -154,20 +154,20 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 
 		if ($options['type'] !== Requests::TRACE) {
 			if (is_array($data)) {
-			    if (isset($case_insensitive_headers['Content-Type']) && $case_insensitive_headers['Content-Type']==='multipart/form-data')
-                {
-                    $boundary = '------------------------'.substr(md5(rand()), 0, 16);
-                    $headers['Content-Type'] = sprintf('multipart/form-data; boundary=%s', $boundary);
+				if (isset($case_insensitive_headers['Content-Type']) && $case_insensitive_headers['Content-Type']==='multipart/form-data')
+				{
+					$boundary = '------------------------'.substr(md5(rand()), 0, 16);
+					$headers['Content-Type'] = sprintf('multipart/form-data; boundary=%s', $boundary);
 
-                    foreach ($data as $key=>$value)
-                    {
-                        $request_body .= '--'.$boundary."\r\n";
-                        $request_body .= sprintf("Content-Disposition: form-data; name=\"%s\"\r\n\r\n%s\r\n", $key, $value);
-                    }
-                    $request_body .= '--'.$boundary."--\r\n";
-                }
-			    else
-				    $request_body = http_build_query($data, null, '&');
+					foreach ($data as $key=>$value)
+					{
+						$request_body .= '--'.$boundary."\r\n";
+						$request_body .= sprintf("Content-Disposition: form-data; name=\"%s\"\r\n\r\n%s\r\n", $key, $value);
+					}
+					$request_body .= '--'.$boundary."--\r\n";
+				}
+				else
+					$request_body = http_build_query($data, null, '&');
 			}
 			else {
 				$request_body = $data;

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -154,7 +154,20 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 
 		if ($options['type'] !== Requests::TRACE) {
 			if (is_array($data)) {
-				$request_body = http_build_query($data, null, '&');
+			    if (isset($case_insensitive_headers['Content-Type']) && $case_insensitive_headers['Content-Type']==='multipart/form-data')
+                {
+                    $boundary = '------------------------'.substr(md5(rand()), 0, 16);
+                    $headers['Content-Type'] = sprintf('multipart/form-data; boundary=%s', $boundary);
+
+                    foreach ($data as $key=>$value)
+                    {
+                        $request_body .= '--'.$boundary."\r\n";
+                        $request_body .= sprintf("Content-Disposition: form-data; name=\"%s\"\r\n\r\n%s\r\n", $key, $value);
+                    }
+                    $request_body .= '--'.$boundary."--\r\n";
+                }
+			    else
+				    $request_body = http_build_query($data, null, '&');
 			}
 			else {
 				$request_body = $data;

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -204,15 +204,15 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testPOSTWithMultipartData() {
-        $data = array(
-            'test' => 'true',
-            'test2' => 'test',
-        );
-        $request = Requests::post('http://httpbin.org/post', array('Content-Type'=>'multipart/form-data'), $data, $this->getOptions());
-        $this->assertEquals(200, $request->status_code);
-        $result = json_decode($request->body, true);
-        $this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
-    }
+		$data = array(
+			'test' => 'true',
+			'test2' => 'test',
+		);
+		$request = Requests::post('http://httpbin.org/post', array('Content-Type'=>'multipart/form-data'), $data, $this->getOptions());
+		$this->assertEquals(200, $request->status_code);
+		$result = json_decode($request->body, true);
+		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+	}
 
 	public function testRawPUT() {
 		$data = 'test';

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -203,6 +203,17 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'), $result['form']);
 	}
 
+	public function testPOSTWithMultipartData() {
+        $data = array(
+            'test' => 'true',
+            'test2' => 'test',
+        );
+        $request = Requests::post('http://httpbin.org/post', array('Content-Type'=>'multipart/form-data'), $data, $this->getOptions());
+        $this->assertEquals(200, $request->status_code);
+        $result = json_decode($request->body, true);
+        $this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+    }
+
 	public function testRawPUT() {
 		$data = 'test';
 		$request = Requests::put(httpbin('/put'), array(), $data, $this->getOptions());


### PR DESCRIPTION
Some sites require POST requests to be sent as multipart/form-data.
When passing an array as POST-data cURL defaults to multipart/form-data, but Requests will flatten and urlencode it. To avoid this I check if a Content-Type header containing multipart/form-data is set in the arguments to Requests::post.
I have implemented this for both cURL and fsockopen.