### PR TITLE
Fix PHP cross-version compatibility issue (PHP 7)

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -187,7 +187,8 @@ class Requests {
 
 		// Don't search for a transport if it's already been done for these $capabilities
 		if (isset(self::$transport[$cap_string]) && self::$transport[$cap_string] !== null) {
-			return new self::$transport[$cap_string]();
+			$class = self::$transport[$cap_string];
+			return new $class();
 		}
 		// @codeCoverageIgnoreEnd
 
@@ -214,7 +215,8 @@ class Requests {
 			throw new Requests_Exception('No working transports found', 'notransport', self::$transports);
 		}
 
-		return new self::$transport[$cap_string]();
+		$class = self::$transport[$cap_string];
+		return new $class();
 	}
 
 	/**#@+


### PR DESCRIPTION
I'm a little aghast that nobody has come across this before and that no bug reports have come in about this (or maybe they have, but I haven't identified them as such), but the code as was, was not cross-version compatible with PHP 5 vs PHP 7 due to the [Uniform Variable Syntax](https://wiki.php.net/rfc/uniform_variable_syntax) introduced in PHP 7.0.

A detailed code sample demonstrating the issue can be found here: https://3v4l.org/T3MDQ

The current fix maintains the pre-PHP 7.0 behaviour, which I believe, as this is an older codebase, is the intended behaviour.