### PR TITLE
Explicitly unset the Curl handler (for PHP 8)

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -114,6 +114,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 		if (is_resource($this->handle)) {
 			curl_close($this->handle);
 		}
+		unset($this->handle);
 	}
 
 	/**


### PR DESCRIPTION
In PHP 8 and later, Curl handlers are `CurlHandle` objects.
See https://php.watch/versions/8.0/resource-CurlHandle

This change makes `curl_close()` a no-op, so to properly close the Curl handle immediately (as opposed to waiting for GC to unset it), additional `unset()` call is handled to the Curl wrapper destructor.