### PR TITLE
QA: remove unnecessary references

### DIFF
--- a/docs/authentication-custom.md
+++ b/docs/authentication-custom.md
@@ -20,7 +20,7 @@ class MySoftware_Auth_Hotdog implements Requests_Auth {
 	}
 
 	public function register(Requests_Hooks &$hooks) {
-		$hooks->register('requests.before_request', array(&$this, 'before_request'));
+		$hooks->register('requests.before_request', array($this, 'before_request'));
 	}
 
 	public function before_request(&$url, &$headers, &$data, &$type, &$options) {

--- a/library/Requests/Auth.php
+++ b/library/Requests/Auth.php
@@ -29,5 +29,5 @@ interface Requests_Auth {
 	 * @see Requests_Hooks::register
 	 * @param Requests_Hooks $hooks Hook system
 	 */
-	public function register(Requests_Hooks &$hooks);
+	public function register(Requests_Hooks $hooks);
 }

--- a/library/Requests/Auth/Basic.php
+++ b/library/Requests/Auth/Basic.php
@@ -53,7 +53,7 @@ class Requests_Auth_Basic implements Requests_Auth {
 	 * @see fsockopen_header
 	 * @param Requests_Hooks $hooks Hook system
 	 */
-	public function register(Requests_Hooks &$hooks) {
+	public function register(Requests_Hooks $hooks) {
 		$hooks->register('curl.before_send', array(&$this, 'curl_before_send'));
 		$hooks->register('fsockopen.after_headers', array(&$this, 'fsockopen_header'));
 	}

--- a/library/Requests/Auth/Basic.php
+++ b/library/Requests/Auth/Basic.php
@@ -54,8 +54,8 @@ class Requests_Auth_Basic implements Requests_Auth {
 	 * @param Requests_Hooks $hooks Hook system
 	 */
 	public function register(Requests_Hooks $hooks) {
-		$hooks->register('curl.before_send', array(&$this, 'curl_before_send'));
-		$hooks->register('fsockopen.after_headers', array(&$this, 'fsockopen_header'));
+		$hooks->register('curl.before_send', array($this, 'curl_before_send'));
+		$hooks->register('fsockopen.after_headers', array($this, 'fsockopen_header'));
 	}
 
 	/**

--- a/library/Requests/Cookie/Jar.php
+++ b/library/Requests/Cookie/Jar.php
@@ -162,7 +162,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @var Requests_Response $response
 	 */
-	public function before_redirect_check(Requests_Response &$return) {
+	public function before_redirect_check(Requests_Response $return) {
 		$url = $return->url;
 		if (!$url instanceof Requests_IRI) {
 			$url = new Requests_IRI($url);

--- a/library/Requests/IRI.php
+++ b/library/Requests/IRI.php
@@ -419,7 +419,7 @@ class Requests_IRI {
 	 */
 	protected function replace_invalid_with_pct_encoding($string, $extra_chars, $iprivate = false) {
 		// Normalize as many pct-encoded sections as possible
-		$string = preg_replace_callback('/(?:%[A-Fa-f0-9]{2})+/', array(&$this, 'remove_iunreserved_percent_encoded'), $string);
+		$string = preg_replace_callback('/(?:%[A-Fa-f0-9]{2})+/', array($this, 'remove_iunreserved_percent_encoded'), $string);
 
 		// Replace invalid percent characters
 		$string = preg_replace('/%(?![A-Fa-f0-9]{2})/', '%25', $string);

--- a/library/Requests/Proxy.php
+++ b/library/Requests/Proxy.php
@@ -31,5 +31,5 @@ interface Requests_Proxy {
 	 * @see Requests_Hooks::register
 	 * @param Requests_Hooks $hooks Hook system
 	 */
-	public function register(Requests_Hooks &$hooks);
+	public function register(Requests_Hooks $hooks);
 }

--- a/library/Requests/Proxy/HTTP.php
+++ b/library/Requests/Proxy/HTTP.php
@@ -82,7 +82,7 @@ class Requests_Proxy_HTTP implements Requests_Proxy {
 	 * @see fsockopen_header
 	 * @param Requests_Hooks $hooks Hook system
 	 */
-	public function register(Requests_Hooks &$hooks) {
+	public function register(Requests_Hooks $hooks) {
 		$hooks->register('curl.before_send', array(&$this, 'curl_before_send'));
 
 		$hooks->register('fsockopen.remote_socket', array(&$this, 'fsockopen_remote_socket'));

--- a/library/Requests/Proxy/HTTP.php
+++ b/library/Requests/Proxy/HTTP.php
@@ -83,12 +83,12 @@ class Requests_Proxy_HTTP implements Requests_Proxy {
 	 * @param Requests_Hooks $hooks Hook system
 	 */
 	public function register(Requests_Hooks $hooks) {
-		$hooks->register('curl.before_send', array(&$this, 'curl_before_send'));
+		$hooks->register('curl.before_send', array($this, 'curl_before_send'));
 
-		$hooks->register('fsockopen.remote_socket', array(&$this, 'fsockopen_remote_socket'));
-		$hooks->register('fsockopen.remote_host_path', array(&$this, 'fsockopen_remote_host_path'));
+		$hooks->register('fsockopen.remote_socket', array($this, 'fsockopen_remote_socket'));
+		$hooks->register('fsockopen.remote_host_path', array($this, 'fsockopen_remote_host_path'));
 		if ($this->use_authentication) {
-			$hooks->register('fsockopen.after_headers', array(&$this, 'fsockopen_header'));
+			$hooks->register('fsockopen.after_headers', array($this, 'fsockopen_header'));
 		}
 	}
 

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -386,8 +386,8 @@ class Requests_Transport_cURL implements Requests_Transport {
 		}
 
 		if (true === $options['blocking']) {
-			curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, array(&$this, 'stream_headers'));
-			curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, array(&$this, 'stream_body'));
+			curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, array($this, 'stream_headers'));
+			curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, array($this, 'stream_body'));
 			curl_setopt($this->handle, CURLOPT_BUFFERSIZE, Requests::BUFFER_SIZE);
 		}
 	}


### PR DESCRIPTION
### QA: remove unnecessary references [1]

Objects are always passed by reference since PHP 5.0, so when a method contains typehint for a parameter saying it expects an object of a certain type, declaring that parameter as a reference is unnecessary.

### QA: remove unnecessary references [2]

Objects are always passed by reference since PHP 5.0, so passing `$this` by reference is an unnecessary PHP-4 practice.

--- 

Note: these commits _may_ (or may not) prevent some potential issue on PHP 8, but either way, they don't do any harm.