### PR TITLE
Travis: various fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-dist: trusty
+dist: xenial
 language: php
-matrix:
+jobs:
   fast_finish: true
   include:
    - php: 5.2
@@ -10,8 +10,10 @@ matrix:
      dist: precise
      env: COMPOSER_PHPUNIT=false
    - php: 5.4
+     dist: trusty
      env: COMPOSER_PHPUNIT=false
    - php: 5.5
+     dist: trusty
      env: COMPOSER_PHPUNIT=false
    - php: 5.6
      env: TEST_COVERAGE=1 COMPOSER_PHPUNIT=true
@@ -47,11 +49,11 @@ install:
 
  # Setup the test server
  - phpenv local $( phpenv versions | grep 5.6 | tail -1 )
- - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then composer remove phpunit/phpunit --dev; fi
+ - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then travis_retry composer remove phpunit/phpunit --dev; fi
  - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then export PHPUNIT_BIN="phpunit";
    else export PHPUNIT_BIN="$(pwd)/vendor/bin/phpunit";
    fi
- - composer install --dev --no-interaction
+ - travis_retry composer install --dev --no-interaction
  - TESTPHPBIN=$(phpenv which php)
  - phpenv local --unset
 


### PR DESCRIPTION
1. The `trusty` environment is no longer supported. The default distro is now `xenial`.
    Switching over is a good idea as the PHP `nightly` version used on `trusty` is from last January, so is not representative of PHP 8.
2. `matrix` has been renamed `jobs`, so let's use that name.
3. A lot of repos have been seeing issues with `peer fingerprint` mismatches for calls to Packagist. Prefixing the `composer install/require/remove` etc command with `travis_retry` gets round that in most cases.