### PR TITLE
CS: align multiple subsequent assignment statements

### DIFF
--- a/bin/create_pear_package.php
+++ b/bin/create_pear_package.php
@@ -33,11 +33,11 @@ $context = array(
 );
 
 $context['files'] = '';
-$path = realpath(dirname(__FILE__) . '/../library/Requests');
+$path             = realpath(dirname(__FILE__) . '/../library/Requests');
 foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path), RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
 	if (preg_match('/\.php$/', $file)) {
-		$name = str_replace($path . DIRECTORY_SEPARATOR, '', $file);
-		$name = str_replace(DIRECTORY_SEPARATOR, '/', $name);
+		$name               = str_replace($path . DIRECTORY_SEPARATOR, '', $file);
+		$name               = str_replace(DIRECTORY_SEPARATOR, '/', $name);
 		$context['files'][] = "\t\t\t\t\t" . '<file install-as="Requests/' . $name . '" name="' . $name . '" role="php" />';
 	}
 }
@@ -45,7 +45,7 @@ foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path), Re
 $context['files'] = implode("\n", $context['files']);
 
 $template = file_get_contents(dirname(__FILE__) . '/../package.xml.tpl');
-$content = preg_replace_callback('/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/', 'replace_parameters', $template);
+$content  = preg_replace_callback('/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/', 'replace_parameters', $template);
 file_put_contents(dirname(__FILE__) . '/../package.xml', $content);
 
 function replace_parameters($matches) {

--- a/examples/session.php
+++ b/examples/session.php
@@ -7,9 +7,9 @@ require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
 Requests::register_autoloader();
 
 // Set up our session
-$session = new Requests_Session('http://httpbin.org/');
+$session                    = new Requests_Session('http://httpbin.org/');
 $session->headers['Accept'] = 'application/json';
-$session->useragent = 'Awesomesauce';
+$session->useragent         = 'Awesomesauce';
 
 // Now let's make a request!
 $request = $session->get('/get');

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -374,9 +374,9 @@ class Requests {
 			}
 		}
 		else {
-			$need_ssl = (0 === stripos($url, 'https://'));
+			$need_ssl     = (0 === stripos($url, 'https://'));
 			$capabilities = array('ssl' => $need_ssl);
-			$transport = self::get_transport($capabilities);
+			$transport    = self::get_transport($capabilities);
 		}
 		$response = $transport->request($url, $headers, $data, $options);
 
@@ -447,7 +447,7 @@ class Requests {
 				$request['type'] = self::GET;
 			}
 			if (!isset($request['options'])) {
-				$request['options'] = $options;
+				$request['options']         = $options;
 				$request['options']['type'] = $request['type'];
 			}
 			else {
@@ -595,9 +595,9 @@ class Requests {
 		}
 
 		if ($options['idn'] !== false) {
-			$iri = new Requests_IRI($url);
+			$iri       = new Requests_IRI($url);
 			$iri->host = Requests_IDNAEncoder::encode($iri->ihost);
-			$url = $iri->uri;
+			$url       = $iri->uri;
 		}
 
 		// Massage the type to ensure we support it.
@@ -642,7 +642,7 @@ class Requests {
 				throw new Requests_Exception('Missing header/body separator', 'requests.no_crlf_separator');
 			}
 
-			$headers = substr($return->raw, 0, $pos);
+			$headers      = substr($return->raw, 0, $pos);
 			$return->body = substr($return->raw, $pos + strlen("\n\r\n\r"));
 		}
 		else {
@@ -658,14 +658,14 @@ class Requests {
 			throw new Requests_Exception('Response could not be parsed', 'noversion', $headers);
 		}
 		$return->protocol_version = (float) $matches[1];
-		$return->status_code = (int) $matches[2];
+		$return->status_code      = (int) $matches[2];
 		if ($return->status_code >= 200 && $return->status_code < 300) {
 			$return->success = true;
 		}
 
 		foreach ($headers as $header) {
 			list($key, $value) = explode(':', $header, 2);
-			$value = trim($value);
+			$value             = trim($value);
 			preg_replace('#(\s+)#i', ' ', $value);
 			$return->headers[$key] = $value;
 		}
@@ -705,7 +705,7 @@ class Requests {
 					$return
 				);
 				$options['hooks']->dispatch('requests.before_redirect', $hook_args);
-				$redirected = self::request($location, $req_headers, $req_data, $options['type'], $options);
+				$redirected            = self::request($location, $req_headers, $req_data, $options['type'], $options);
 				$redirected->history[] = $return;
 				return $redirected;
 			}
@@ -732,10 +732,10 @@ class Requests {
 	 */
 	public static function parse_multiple(&$response, $request) {
 		try {
-			$url = $request['url'];
-			$headers = $request['headers'];
-			$data = $request['data'];
-			$options = $request['options'];
+			$url      = $request['url'];
+			$headers  = $request['headers'];
+			$data     = $request['data'];
+			$options  = $request['options'];
 			$response = self::parse_response($response, $url, $headers, $data, $options);
 		}
 		catch (Requests_Exception $e) {
@@ -772,8 +772,8 @@ class Requests {
 			}
 
 			$chunk_length = strlen($matches[0]);
-			$decoded .= substr($encoded, $chunk_length, $length);
-			$encoded = substr($encoded, $chunk_length + $length + 2);
+			$decoded     .= substr($encoded, $chunk_length, $length);
+			$encoded      = substr($encoded, $chunk_length + $length + 2);
 
 			if (trim($encoded) === '0' || empty($encoded)) {
 				return $decoded;
@@ -866,12 +866,12 @@ class Requests {
 		// Compressed data might contain a full zlib header, if so strip it for
 		// gzinflate()
 		if (substr($gzData, 0, 3) == "\x1f\x8b\x08") {
-			$i = 10;
+			$i   = 10;
 			$flg = ord(substr($gzData, 3, 1));
 			if ($flg > 0) {
 				if ($flg & 4) {
 					list($xlen) = unpack('v', substr($gzData, $i, 2));
-					$i = $i + 2 + $xlen;
+					$i          = $i + 2 + $xlen;
 				}
 				if ($flg & 8) {
 					$i = strpos($gzData, "\0", $i) + 1;
@@ -900,7 +900,7 @@ class Requests {
 		$huffman_encoded = false;
 
 		// low nibble of first byte should be 0x08
-		list(, $first_nibble)    = unpack('h', $gzData);
+		list(, $first_nibble) = unpack('h', $gzData);
 
 		// First 2 bytes should be divisible by 0x1F
 		list(, $first_two_bytes) = unpack('n', $gzData);

--- a/library/Requests/Cookie.php
+++ b/library/Requests/Cookie.php
@@ -65,16 +65,16 @@ class Requests_Cookie {
 	 * @param array|Requests_Utility_CaseInsensitiveDictionary $attributes Associative array of attribute data
 	 */
 	public function __construct($name, $value, $attributes = array(), $flags = array(), $reference_time = null) {
-		$this->name = $name;
-		$this->value = $value;
+		$this->name       = $name;
+		$this->value      = $value;
 		$this->attributes = $attributes;
-		$default_flags = array(
+		$default_flags    = array(
 			'creation' => time(),
 			'last-access' => time(),
 			'persistent' => false,
 			'host-only' => true,
 		);
-		$this->flags = array_merge($default_flags, $flags);
+		$this->flags      = array_merge($default_flags, $flags);
 
 		$this->reference_time = time();
 		if ($reference_time !== null) {
@@ -228,7 +228,7 @@ class Requests_Cookie {
 	public function normalize() {
 		foreach ($this->attributes as $key => $value) {
 			$orig_value = $value;
-			$value = $this->normalize_attribute($key, $value);
+			$value      = $this->normalize_attribute($key, $value);
 			if ($value === null) {
 				unset($this->attributes[$key]);
 				continue;
@@ -385,7 +385,7 @@ class Requests_Cookie {
 	 * @return Requests_Cookie Parsed cookie object
 	 */
 	public static function parse($string, $name = '', $reference_time = null) {
-		$parts = explode(';', $string);
+		$parts   = explode(';', $string);
 		$kvparts = array_shift($parts);
 
 		if (!empty($name)) {
@@ -397,13 +397,13 @@ class Requests_Cookie {
 			// (`=foo`)
 			//
 			// https://bugzilla.mozilla.org/show_bug.cgi?id=169091
-			$name = '';
+			$name  = '';
 			$value = $kvparts;
 		}
 		else {
 			list($name, $value) = explode('=', $kvparts, 2);
 		}
-		$name = trim($name);
+		$name  = trim($name);
 		$value = trim($value);
 
 		// Attribute key are handled case-insensitively
@@ -412,15 +412,15 @@ class Requests_Cookie {
 		if (!empty($parts)) {
 			foreach ($parts as $part) {
 				if (strpos($part, '=') === false) {
-					$part_key = $part;
+					$part_key   = $part;
 					$part_value = true;
 				}
 				else {
 					list($part_key, $part_value) = explode('=', $part, 2);
-					$part_value = trim($part_value);
+					$part_value                  = trim($part_value);
 				}
 
-				$part_key = trim($part_key);
+				$part_key              = trim($part_key);
 				$attributes[$part_key] = $part_value;
 			}
 		}
@@ -449,7 +449,7 @@ class Requests_Cookie {
 			// Default domain/path attributes
 			if (empty($parsed->attributes['domain']) && !empty($origin)) {
 				$parsed->attributes['domain'] = $origin->host;
-				$parsed->flags['host-only'] = true;
+				$parsed->flags['host-only']   = true;
 			}
 			else {
 				$parsed->flags['host-only'] = false;

--- a/library/Requests/Cookie/Jar.php
+++ b/library/Requests/Cookie/Jar.php
@@ -168,8 +168,8 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 			$url = new Requests_IRI($url);
 		}
 
-		$cookies = Requests_Cookie::parse_from_headers($return->headers, $url);
-		$this->cookies = array_merge($this->cookies, $cookies);
+		$cookies         = Requests_Cookie::parse_from_headers($return->headers, $url);
+		$this->cookies   = array_merge($this->cookies, $cookies);
 		$return->cookies = $this;
 	}
 }

--- a/library/Requests/Exception/Transport/cURL.php
+++ b/library/Requests/Exception/Transport/cURL.php
@@ -2,7 +2,7 @@
 
 class Requests_Exception_Transport_cURL extends Requests_Exception_Transport {
 
-	const EASY = 'cURLEasy';
+	const EASY  = 'cURLEasy';
 	const MULTI = 'cURLMulti';
 	const SHARE = 'cURLShare';
 

--- a/library/Requests/IDNAEncoder.php
+++ b/library/Requests/IDNAEncoder.php
@@ -147,25 +147,25 @@ class Requests_IDNAEncoder {
 			// One byte sequence:
 			if ((~$value & 0x80) === 0x80) {
 				$character = $value;
-				$length = 1;
+				$length    = 1;
 				$remaining = 0;
 			}
 			// Two byte sequence:
 			elseif (($value & 0xE0) === 0xC0) {
 				$character = ($value & 0x1F) << 6;
-				$length = 2;
+				$length    = 2;
 				$remaining = 1;
 			}
 			// Three byte sequence:
 			elseif (($value & 0xF0) === 0xE0) {
 				$character = ($value & 0x0F) << 12;
-				$length = 3;
+				$length    = 3;
 				$remaining = 2;
 			}
 			// Four byte sequence:
 			elseif (($value & 0xF8) === 0xF0) {
 				$character = ($value & 0x07) << 18;
-				$length = 4;
+				$length    = 4;
 				$remaining = 3;
 			}
 			// Invalid byte:
@@ -236,7 +236,7 @@ class Requests_IDNAEncoder {
 		$h = $b = 0; // see loop
 		// copy them to the output in order
 		$codepoints = self::utf8_to_codepoints($input);
-		$extended = array();
+		$extended   = array();
 
 		foreach ($codepoints as $char) {
 			if ($char < 128) {
@@ -302,7 +302,7 @@ class Requests_IDNAEncoder {
 							break;
 						}
 						// output the code point for digit t + ((q - t) mod (base - t))
-						$digit = $t + (($q - $t) % (self::BOOTSTRAP_BASE - $t));
+						$digit   = $t + (($q - $t) % (self::BOOTSTRAP_BASE - $t));
 						$output .= self::digit_to_char($digit);
 						// let q = (q - t) div (base - t)
 						$q = floor(($q - $t) / (self::BOOTSTRAP_BASE - $t));

--- a/library/Requests/IPv6.php
+++ b/library/Requests/IPv6.php
@@ -40,8 +40,8 @@ class Requests_IPv6 {
 		}
 
 		list($ip1, $ip2) = explode('::', $ip);
-		$c1 = ($ip1 === '') ? -1 : substr_count($ip1, ':');
-		$c2 = ($ip2 === '') ? -1 : substr_count($ip2, ':');
+		$c1              = ($ip1 === '') ? -1 : substr_count($ip1, ':');
+		$c2              = ($ip2 === '') ? -1 : substr_count($ip2, ':');
 
 		if (strpos($ip2, '.') !== false) {
 			$c2++;
@@ -53,17 +53,17 @@ class Requests_IPv6 {
 		// ::xxx
 		elseif ($c1 === -1) {
 			$fill = str_repeat('0:', 7 - $c2);
-			$ip = str_replace('::', $fill, $ip);
+			$ip   = str_replace('::', $fill, $ip);
 		}
 		// xxx::
 		elseif ($c2 === -1) {
 			$fill = str_repeat(':0', 7 - $c1);
-			$ip = str_replace('::', $fill, $ip);
+			$ip   = str_replace('::', $fill, $ip);
 		}
 		// xxx::xxx
 		else {
 			$fill = ':' . str_repeat('0:', 6 - $c2 - $c1);
-			$ip = str_replace('::', $fill, $ip);
+			$ip   = str_replace('::', $fill, $ip);
 		}
 		return $ip;
 	}
@@ -84,7 +84,7 @@ class Requests_IPv6 {
 	 */
 	public static function compress($ip) {
 		// Prepare the IP to be compressed
-		$ip = self::uncompress($ip);
+		$ip       = self::uncompress($ip);
 		$ip_parts = self::split_v6_v4($ip);
 
 		// Replace all leading zeros
@@ -126,7 +126,7 @@ class Requests_IPv6 {
 	 */
 	protected static function split_v6_v4($ip) {
 		if (strpos($ip, '.') !== false) {
-			$pos = strrpos($ip, ':');
+			$pos       = strrpos($ip, ':');
 			$ipv6_part = substr($ip, 0, $pos);
 			$ipv4_part = substr($ip, $pos + 1);
 			return array($ipv6_part, $ipv4_part);
@@ -145,10 +145,10 @@ class Requests_IPv6 {
 	 * @return bool true if $ip is a valid IPv6 address
 	 */
 	public static function check_ipv6($ip) {
-		$ip = self::uncompress($ip);
+		$ip                = self::uncompress($ip);
 		list($ipv6, $ipv4) = self::split_v6_v4($ip);
-		$ipv6 = explode(':', $ipv6);
-		$ipv4 = explode('.', $ipv4);
+		$ipv6              = explode(':', $ipv6);
+		$ipv4              = explode('.', $ipv4);
 		if (count($ipv6) === 8 && count($ipv4) === 1 || count($ipv6) === 6 && count($ipv4) === 4) {
 			foreach ($ipv6 as $ipv6_part) {
 				// The section can't be empty

--- a/library/Requests/Proxy/HTTP.php
+++ b/library/Requests/Proxy/HTTP.php
@@ -64,7 +64,7 @@ class Requests_Proxy_HTTP implements Requests_Proxy {
 			}
 			elseif (count($args) == 3) {
 				list($this->proxy, $this->user, $this->pass) = $args;
-				$this->use_authentication = true;
+				$this->use_authentication                    = true;
 			}
 			else {
 				throw new Requests_Exception('Invalid number of arguments', 'proxyhttpbadargs');

--- a/library/Requests/SSL.php
+++ b/library/Requests/SSL.php
@@ -139,7 +139,7 @@ class Requests_SSL {
 		// Also validates that the host has 3 parts or more, as per Firefox's
 		// ruleset.
 		if (ip2long($host) === false) {
-			$parts = explode('.', $host);
+			$parts    = explode('.', $host);
 			$parts[0] = '*';
 			$wildcard = implode('.', $parts);
 			if ($wildcard === $reference) {

--- a/library/Requests/Session.php
+++ b/library/Requests/Session.php
@@ -64,9 +64,9 @@ class Requests_Session {
 	 * @param array $options Default options for requests
 	 */
 	public function __construct($url = null, $headers = array(), $data = array(), $options = array()) {
-		$this->url = $url;
+		$this->url     = $url;
 		$this->headers = $headers;
-		$this->data = $data;
+		$this->data    = $data;
 		$this->options = $options;
 
 		if (empty($this->options['cookies'])) {

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -90,9 +90,9 @@ class Requests_Transport_cURL implements Requests_Transport {
 	 * Constructor
 	 */
 	public function __construct() {
-		$curl = curl_version();
+		$curl          = curl_version();
 		$this->version = $curl['version_number'];
-		$this->handle = curl_init();
+		$this->handle  = curl_init();
 
 		curl_setopt($this->handle, CURLOPT_HEADER, false);
 		curl_setopt($this->handle, CURLOPT_RETURNTRANSFER, 1);
@@ -138,8 +138,8 @@ class Requests_Transport_cURL implements Requests_Transport {
 			$this->stream_handle = fopen($options['filename'], 'wb');
 		}
 
-		$this->response_data = '';
-		$this->response_bytes = 0;
+		$this->response_data       = '';
+		$this->response_bytes      = 0;
 		$this->response_byte_limit = false;
 		if ($options['max_bytes'] !== false) {
 			$this->response_byte_limit = $options['max_bytes'];
@@ -168,7 +168,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 			// Reset encoding and try again
 			curl_setopt($this->handle, CURLOPT_ENCODING, 'none');
 
-			$this->response_data = '';
+			$this->response_data  = '';
 			$this->response_bytes = 0;
 			curl_exec($this->handle);
 			$response = $this->response_data;
@@ -199,12 +199,12 @@ class Requests_Transport_cURL implements Requests_Transport {
 
 		$multihandle = curl_multi_init();
 		$subrequests = array();
-		$subhandles = array();
+		$subhandles  = array();
 
 		$class = get_class($this);
 		foreach ($requests as $id => $request) {
 			$subrequests[$id] = new $class();
-			$subhandles[$id] = $subrequests[$id]->get_subrequest_handle($request['url'], $request['headers'], $request['data'], $request['options']);
+			$subhandles[$id]  = $subrequests[$id]->get_subrequest_handle($request['url'], $request['headers'], $request['data'], $request['options']);
 			$request['options']['hooks']->dispatch('curl.before_multi_add', array(&$subhandles[$id]));
 			curl_multi_add_handle($multihandle, $subhandles[$id]);
 		}
@@ -237,8 +237,8 @@ class Requests_Transport_cURL implements Requests_Transport {
 				$options = $requests[$key]['options'];
 				if (CURLE_OK !== $done['result']) {
 					//get error string for handle.
-					$reason = curl_error($done['handle']);
-					$exception = new Requests_Exception_Transport_cURL(
+					$reason          = curl_error($done['handle']);
+					$exception       = new Requests_Exception_Transport_cURL(
 						$reason,
 						Requests_Exception_Transport_cURL::EASY,
 						$done['handle'],
@@ -287,8 +287,8 @@ class Requests_Transport_cURL implements Requests_Transport {
 			$this->stream_handle = fopen($options['filename'], 'wb');
 		}
 
-		$this->response_data = '';
-		$this->response_bytes = 0;
+		$this->response_data       = '';
+		$this->response_bytes      = 0;
 		$this->response_byte_limit = false;
 		if ($options['max_bytes'] !== false) {
 			$this->response_byte_limit = $options['max_bytes'];
@@ -320,7 +320,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 			$data_format = $options['data_format'];
 
 			if ($data_format === 'query') {
-				$url = self::format_get($url, $data);
+				$url  = self::format_get($url, $data);
 				$data = '';
 			}
 			elseif (!is_string($data)) {
@@ -440,7 +440,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 		// interim responses, such as a 100 Continue. We don't need that.
 		// (We may want to keep this somewhere just in case)
 		if ($this->done_headers) {
-			$this->headers = '';
+			$this->headers      = '';
 			$this->done_headers = false;
 		}
 		$this->headers .= $headers;
@@ -474,7 +474,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 			if (($this->response_bytes + $data_length) > $this->response_byte_limit) {
 				// Limit the length
 				$limited_length = ($this->response_byte_limit - $this->response_bytes);
-				$data = substr($data, 0, $limited_length);
+				$data           = substr($data, 0, $limited_length);
 			}
 		}
 
@@ -507,7 +507,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 			}
 
 			$query .= '&' . http_build_query($data, null, '&');
-			$query = trim($query, '&');
+			$query  = trim($query, '&');
 
 			if (empty($url_parts['query'])) {
 				$url .= '?' . $query;

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -62,9 +62,9 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		if (empty($url_parts)) {
 			throw new Requests_Exception('Invalid URL.', 'invalidurl', $url);
 		}
-		$host = $url_parts['host'];
-		$context = stream_context_create();
-		$verifyname = false;
+		$host                     = $url_parts['host'];
+		$context                  = stream_context_create();
+		$verifyname               = false;
 		$case_insensitive_headers = new Requests_Utility_CaseInsensitiveDictionary($headers);
 
 		// HTTPS support
@@ -79,7 +79,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 				// 'CN_match' => $host,
 				'capture_peer_cert' => true
 			);
-			$verifyname = true;
+			$verifyname      = true;
 
 			// SNI, if enabled (OpenSSL >=0.9.8j)
 			if (defined('OPENSSL_TLSEXT_SERVER_NAME') && OPENSSL_TLSEXT_SERVER_NAME) {
@@ -91,9 +91,9 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 
 			if (isset($options['verify'])) {
 				if ($options['verify'] === false) {
-					$context_options['verify_peer'] = false;
+					$context_options['verify_peer']      = false;
 					$context_options['verify_peer_name'] = false;
-					$verifyname = false;
+					$verifyname                          = false;
 				}
 				elseif (is_string($options['verify'])) {
 					$context_options['cafile'] = $options['verify'];
@@ -102,7 +102,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 
 			if (isset($options['verifyname']) && $options['verifyname'] === false) {
 				$context_options['verify_peer_name'] = false;
-				$verifyname = false;
+				$verifyname                          = false;
 			}
 
 			stream_context_set_option($context, array('ssl' => $context_options));
@@ -152,7 +152,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		$options['hooks']->dispatch('fsockopen.remote_host_path', array(&$path, $url));
 
 		$request_body = '';
-		$out = sprintf("%s %s HTTP/%.1F\r\n", $options['type'], $path, $options['protocol_version']);
+		$out          = sprintf("%s %s HTTP/%.1F\r\n", $options['type'], $path, $options['protocol_version']);
 
 		if ($options['type'] !== Requests::TRACE) {
 			if (is_array($data)) {
@@ -230,11 +230,11 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		}
 		stream_set_timeout($socket, $timeout_sec, $timeout_msec);
 
-		$response = $body = $headers = '';
+		$response   = $body = $headers = '';
 		$this->info = stream_get_meta_data($socket);
-		$size = 0;
-		$doingbody = false;
-		$download = false;
+		$size       = 0;
+		$doingbody  = false;
+		$download   = false;
 		if ($options['filename']) {
 			$download = fopen($options['filename'], 'wb');
 		}
@@ -250,7 +250,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 				$response .= $block;
 				if (strpos($response, "\r\n\r\n")) {
 					list($headers, $block) = explode("\r\n\r\n", $response, 2);
-					$doingbody = true;
+					$doingbody             = true;
 				}
 			}
 
@@ -266,7 +266,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 					if (($size + $data_length) > $this->max_bytes) {
 						// Limit the length
 						$limited_length = ($this->max_bytes - $size);
-						$block = substr($block, 0, $limited_length);
+						$block          = substr($block, 0, $limited_length);
 					}
 				}
 
@@ -302,10 +302,10 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 	 */
 	public function request_multiple($requests, $options) {
 		$responses = array();
-		$class = get_class($this);
+		$class     = get_class($this);
 		foreach ($requests as $id => $request) {
 			try {
-				$handler = new $class();
+				$handler        = new $class();
 				$responses[$id] = $handler->request($request['url'], $request['headers'], $request['data'], $request['options']);
 
 				$request['options']['hooks']->dispatch('transport.internal.parse_response', array(&$responses[$id], $request));
@@ -356,7 +356,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 			}
 
 			$url_parts['query'] .= '&' . http_build_query($data, '', '&');
-			$url_parts['query'] = trim($url_parts['query'], '&');
+			$url_parts['query']  = trim($url_parts['query'], '&');
 		}
 		if (isset($url_parts['path'])) {
 			if (isset($url_parts['query'])) {

--- a/library/Requests/Utility/CaseInsensitiveDictionary.php
+++ b/library/Requests/Utility/CaseInsensitiveDictionary.php
@@ -70,7 +70,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 			throw new Requests_Exception('Object is a dictionary, not a list', 'invalidset');
 		}
 
-		$key = strtolower($key);
+		$key              = strtolower($key);
 		$this->data[$key] = $value;
 	}
 

--- a/tests/Auth/Basic.php
+++ b/tests/Auth/Basic.php
@@ -64,7 +64,7 @@ class RequestsTest_Auth_Basic extends PHPUnit_Framework_TestCase {
 			'auth' => new Requests_Auth_Basic(array('user', 'passwd')),
 			'transport' => $transport,
 		);
-		$data = 'test';
+		$data    = 'test';
 		$request = Requests::post(httpbin('/post'), array(), $data, $options);
 		$this->assertEquals(200, $request->status_code);
 

--- a/tests/ChunkedEncoding.php
+++ b/tests/ChunkedEncoding.php
@@ -34,11 +34,11 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 	 * @dataProvider chunkedProvider
 	 */
 	public function testChunked($body, $expected) {
-		$transport = new MockTransport();
-		$transport->body = $body;
+		$transport          = new MockTransport();
+		$transport->body    = $body;
 		$transport->chunked = true;
 
-		$options = array(
+		$options  = array(
 			'transport' => $transport
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
@@ -62,11 +62,11 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 	 * @dataProvider notChunkedProvider
 	 */
 	public function testNotActuallyChunked($body) {
-		$transport = new MockTransport();
-		$transport->body = $body;
+		$transport          = new MockTransport();
+		$transport->body    = $body;
 		$transport->chunked = true;
 
-		$options = array(
+		$options  = array(
 			'transport' => $transport
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
@@ -80,11 +80,11 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 	 * that they're lying to us
 	 */
 	public function testMixedChunkiness() {
-		$transport = new MockTransport();
-		$transport->body = "02\r\nab\r\nNot actually chunked!";
+		$transport          = new MockTransport();
+		$transport->body    = "02\r\nab\r\nNot actually chunked!";
 		$transport->chunked = true;
 
-		$options = array(
+		$options  = array(
 			'transport' => $transport
 		);
 		$response = Requests::get('http://example.com/', array(), $options);

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -17,7 +17,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 			'httponly',
 			'path' => '/'
 		);
-		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
+		$cookie     = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
 
 		$this->assertEquals('requests-testcookie=testvalue', $cookie->format_for_header());
 		$this->assertEquals('requests-testcookie=testvalue; httponly; path=/', $cookie->format_for_set_cookie());
@@ -35,7 +35,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCookieJarSetter() {
-		$jar1 = new Requests_Cookie_Jar();
+		$jar1                        = new Requests_Cookie_Jar();
 		$jar1['requests-testcookie'] = 'testvalue';
 
 		$jar2 = new Requests_Cookie_Jar(
@@ -47,7 +47,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCookieJarUnsetter() {
-		$jar = new Requests_Cookie_Jar();
+		$jar                        = new Requests_Cookie_Jar();
 		$jar['requests-testcookie'] = 'testvalue';
 
 		$this->assertEquals('testvalue', $jar['requests-testcookie']);
@@ -61,7 +61,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testCookieJarAsList() {
-		$cookies = new Requests_Cookie_Jar();
+		$cookies   = new Requests_Cookie_Jar();
 		$cookies[] = 'requests-testcookie1=testvalue1';
 	}
 
@@ -70,7 +70,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 			'requests-testcookie1' => 'testvalue1',
 			'requests-testcookie2' => 'testvalue2',
 		);
-		$jar = new Requests_Cookie_Jar($cookies);
+		$jar     = new Requests_Cookie_Jar($cookies);
 
 		foreach ($jar as $key => $value) {
 			$this->assertEquals($cookies[$key], $value);
@@ -81,7 +81,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$options = array(
 			'follow_redirects' => false,
 		);
-		$url = httpbin('/cookies/set?requests-testcookie=testvalue');
+		$url     = httpbin('/cookies/set?requests-testcookie=testvalue');
 
 		$response = Requests::get($url, array(), $options);
 
@@ -94,7 +94,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$options = array(
 			'follow_redirects' => true,
 		);
-		$url = httpbin('/cookies/set?requests-testcookie=testvalue');
+		$url     = httpbin('/cookies/set?requests-testcookie=testvalue');
 
 		$response = Requests::get($url, array(), $options);
 
@@ -104,7 +104,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	}
 
 	protected function setCookieRequest($cookies) {
-		$options = array(
+		$options  = array(
 			'cookies' => $cookies,
 		);
 		$response = Requests::get(httpbin('/cookies/set'), array(), $options);
@@ -133,8 +133,8 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$options = array(
 			'follow_redirects' => true,
 		);
-		$url = httpbin('/cookies/set/testcookie/testvalue');
-		$url .= '?expiry=1';
+		$url     = httpbin('/cookies/set/testcookie/testvalue');
+		$url    .= '?expiry=1';
 
 		$response = Requests::get($url, array(), $options);
 		$response->throw_for_status();
@@ -149,7 +149,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 				'requests-testcookie1' => 'testvalue1',
 			)
 		);
-		$data = $this->setCookieRequest($cookies);
+		$data    = $this->setCookieRequest($cookies);
 
 		$this->assertArrayHasKey('requests-testcookie1', $data);
 		$this->assertEquals('testvalue1', $data['requests-testcookie1']);
@@ -160,7 +160,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 			'requests-testcookie1' => 'testvalue1',
 			'requests-testcookie2' => 'testvalue2',
 		);
-		$data = $this->setCookieRequest($cookies);
+		$data    = $this->setCookieRequest($cookies);
 
 		$this->assertArrayHasKey('requests-testcookie1', $data);
 		$this->assertEquals('testvalue1', $data['requests-testcookie1']);
@@ -176,7 +176,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 				'requests-testcookie2' => 'testvalue2',
 			)
 		);
-		$data = $this->setCookieRequest($cookies);
+		$data    = $this->setCookieRequest($cookies);
 
 		$this->assertArrayHasKey('requests-testcookie1', $data);
 		$this->assertEquals('testvalue1', $data['requests-testcookie1']);
@@ -191,7 +191,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 				new Requests_Cookie('requests-testcookie', 'testvalue'),
 			)
 		);
-		$data = $this->setCookieRequest($cookies);
+		$data    = $this->setCookieRequest($cookies);
 
 		$this->assertArrayHasKey('requests-testcookie', $data);
 		$this->assertEquals('testvalue', $data['requests-testcookie']);
@@ -226,9 +226,9 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	 * @dataProvider domainMatchProvider
 	 */
 	public function testDomainExactMatch($original, $check, $matches, $domain_matches) {
-		$attributes = new Requests_Utility_CaseInsensitiveDictionary();
+		$attributes           = new Requests_Utility_CaseInsensitiveDictionary();
 		$attributes['domain'] = $original;
-		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
+		$cookie               = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
 		$this->assertEquals($matches, $cookie->domain_matches($check));
 	}
 
@@ -236,12 +236,12 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	 * @dataProvider domainMatchProvider
 	 */
 	public function testDomainMatch($original, $check, $matches, $domain_matches) {
-		$attributes = new Requests_Utility_CaseInsensitiveDictionary();
+		$attributes           = new Requests_Utility_CaseInsensitiveDictionary();
 		$attributes['domain'] = $original;
-		$flags = array(
+		$flags                = array(
 			'host-only' => false
 		);
-		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
+		$cookie               = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
 		$this->assertEquals($domain_matches, $cookie->domain_matches($check));
 	}
 
@@ -269,9 +269,9 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	 * @dataProvider pathMatchProvider
 	 */
 	public function testPathMatch($original, $check, $matches) {
-		$attributes = new Requests_Utility_CaseInsensitiveDictionary();
+		$attributes         = new Requests_Utility_CaseInsensitiveDictionary();
 		$attributes['path'] = $original;
-		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
+		$cookie             = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
 		$this->assertEquals($matches, $cookie->path_matches($check));
 	}
 
@@ -308,11 +308,11 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	 * @dataProvider urlMatchProvider
 	 */
 	public function testUrlExactMatch($domain, $path, $check, $matches, $domain_matches) {
-		$attributes = new Requests_Utility_CaseInsensitiveDictionary();
+		$attributes           = new Requests_Utility_CaseInsensitiveDictionary();
 		$attributes['domain'] = $domain;
 		$attributes['path']   = $path;
-		$check = new Requests_IRI($check);
-		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
+		$check                = new Requests_IRI($check);
+		$cookie               = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
 		$this->assertEquals($matches, $cookie->uri_matches($check));
 	}
 
@@ -322,26 +322,26 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	 * @dataProvider urlMatchProvider
 	 */
 	public function testUrlMatch($domain, $path, $check, $matches, $domain_matches) {
-		$attributes = new Requests_Utility_CaseInsensitiveDictionary();
+		$attributes           = new Requests_Utility_CaseInsensitiveDictionary();
 		$attributes['domain'] = $domain;
 		$attributes['path']   = $path;
-		$flags = array(
+		$flags                = array(
 			'host-only' => false
 		);
-		$check = new Requests_IRI($check);
-		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
+		$check                = new Requests_IRI($check);
+		$cookie               = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
 		$this->assertEquals($domain_matches, $cookie->uri_matches($check));
 	}
 
 	public function testUrlMatchSecure() {
-		$attributes = new Requests_Utility_CaseInsensitiveDictionary();
+		$attributes           = new Requests_Utility_CaseInsensitiveDictionary();
 		$attributes['domain'] = 'example.com';
 		$attributes['path']   = '/';
 		$attributes['secure'] = true;
-		$flags = array(
+		$flags                = array(
 			'host-only' => false,
 		);
-		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
+		$cookie               = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
 
 		$this->assertTrue($cookie->uri_matches(new Requests_IRI('https://example.com/')));
 		$this->assertFalse($cookie->uri_matches(new Requests_IRI('http://example.com/')));
@@ -510,7 +510,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	 * @dataProvider parseResultProvider
 	 */
 	public function testParsingHeaderObject($header, $expected, $expected_attributes = array(), $expected_flags = array()) {
-		$headers = new Requests_Response_Headers();
+		$headers               = new Requests_Response_Headers();
 		$headers['Set-Cookie'] = $header;
 
 		// Set the reference time to 2014-01-01 00:00:00
@@ -637,8 +637,8 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	 * @dataProvider parseFromHeadersProvider
 	 */
 	public function testParsingHeaderWithOrigin($header, $origin, $expected, $expected_attributes = array(), $expected_flags = array()) {
-		$origin = new Requests_IRI($origin);
-		$headers = new Requests_Response_Headers();
+		$origin                = new Requests_IRI($origin);
+		$headers               = new Requests_Response_Headers();
 		$headers['Set-Cookie'] = $header;
 
 		// Set the reference time to 2014-01-01 00:00:00

--- a/tests/Encoding.php
+++ b/tests/Encoding.php
@@ -4,7 +4,7 @@ class RequestsTests_Encoding extends PHPUnit_Framework_TestCase {
 	protected static function mapData($type, $data) {
 		$real_data = array();
 		foreach ($data as $value) {
-			$key = $type . ': ' . $value[0];
+			$key             = $type . ': ' . $value[0];
 			$real_data[$key] = $value;
 		}
 		return $real_data;
@@ -56,15 +56,15 @@ class RequestsTests_Encoding extends PHPUnit_Framework_TestCase {
 	}
 
 	public static function encodedData() {
-		$datasets = array();
-		$datasets['gzip'] = self::gzipData();
-		$datasets['deflate'] = self::deflateData();
+		$datasets                                 = array();
+		$datasets['gzip']                         = self::gzipData();
+		$datasets['deflate']                      = self::deflateData();
 		$datasets['deflate without zlib headers'] = self::deflateWithoutHeadersData();
 
 		$data = array();
 		foreach ($datasets as $key => $set) {
 			$real_set = self::mapData($key, $set);
-			$data = array_merge($data, $real_set);
+			$data     = array_merge($data, $real_set);
 		}
 		return $data;
 	}

--- a/tests/IDNAEncoder.php
+++ b/tests/IDNAEncoder.php
@@ -26,7 +26,7 @@ class RequestsTest_IDNAEncoder extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testASCIITooLong() {
-		$data = str_repeat("abcd", 20);
+		$data   = str_repeat("abcd", 20);
 		$result = Requests_IDNAEncoder::encode($data);
 	}
 
@@ -34,7 +34,7 @@ class RequestsTest_IDNAEncoder extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testEncodedTooLong() {
-		$data = str_repeat("\xe4\xbb\x96", 60);
+		$data   = str_repeat("\xe4\xbb\x96", 60);
 		$result = Requests_IDNAEncoder::encode($data);
 	}
 

--- a/tests/Proxy/HTTP.php
+++ b/tests/Proxy/HTTP.php
@@ -30,7 +30,7 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 	public function testConnectWithString($transport) {
 		$this->checkProxyAvailable();
 
-		$options = array(
+		$options  = array(
 			'proxy' => REQUESTS_HTTP_PROXY,
 			'transport' => $transport,
 		);
@@ -47,7 +47,7 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 	public function testConnectWithArray($transport) {
 		$this->checkProxyAvailable();
 
-		$options = array(
+		$options  = array(
 			'proxy' => array(REQUESTS_HTTP_PROXY),
 			'transport' => $transport,
 		);
@@ -65,7 +65,7 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 	public function testConnectInvalidParameters($transport) {
 		$this->checkProxyAvailable();
 
-		$options = array(
+		$options  = array(
 			'proxy' => array(REQUESTS_HTTP_PROXY, 'testuser', 'password', 'something'),
 			'transport' => $transport,
 		);
@@ -78,7 +78,7 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 	public function testConnectWithInstance($transport) {
 		$this->checkProxyAvailable();
 
-		$options = array(
+		$options  = array(
 			'proxy' => new Requests_Proxy_HTTP(REQUESTS_HTTP_PROXY),
 			'transport' => $transport,
 		);
@@ -95,7 +95,7 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 	public function testConnectWithAuth($transport) {
 		$this->checkProxyAvailable('auth');
 
-		$options = array(
+		$options  = array(
 			'proxy' => array(
 				REQUESTS_HTTP_PROXY_AUTH,
 				REQUESTS_HTTP_PROXY_AUTH_USER,
@@ -117,7 +117,7 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 	public function testConnectWithInvalidAuth($transport) {
 		$this->checkProxyAvailable('auth');
 
-		$options = array(
+		$options  = array(
 			'proxy' => array(
 				REQUESTS_HTTP_PROXY_AUTH,
 				REQUESTS_HTTP_PROXY_AUTH_USER . '!',

--- a/tests/Requests.php
+++ b/tests/Requests.php
@@ -17,7 +17,7 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	 * Standard response header parsing
 	 */
 	public function testHeaderParsing() {
-		$transport = new RawTransport();
+		$transport       = new RawTransport();
 		$transport->data =
 			"HTTP/1.0 200 OK\r\n" .
 			"Host: localhost\r\n" .
@@ -31,17 +31,17 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 			"  three\r\n\r\n" .
 			"stop\r\n";
 
-		$options = array(
+		$options               = array(
 			'transport' => $transport
 		);
-		$response = Requests::get('http://example.com/', array(), $options);
-		$expected = new Requests_Response_Headers();
-		$expected['host'] = 'localhost,ambiguous';
-		$expected['nospace'] = 'here';
+		$response              = Requests::get('http://example.com/', array(), $options);
+		$expected              = new Requests_Response_Headers();
+		$expected['host']      = 'localhost,ambiguous';
+		$expected['nospace']   = 'here';
 		$expected['muchspace'] = 'there';
-		$expected['empty'] = '';
-		$expected['empty2'] = '';
-		$expected['folded'] = 'one two  three';
+		$expected['empty']     = '';
+		$expected['empty2']    = '';
+		$expected['folded']    = 'one two  three';
 		foreach ($expected as $key => $value) {
 			$this->assertEquals($value, $response->headers[$key]);
 		}
@@ -52,7 +52,7 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testProtocolVersionParsing() {
-		$transport = new RawTransport();
+		$transport       = new RawTransport();
 		$transport->data =
 			"HTTP/1.0 200 OK\r\n" .
 			"Host: localhost\r\n\r\n";
@@ -66,13 +66,13 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testRawAccess() {
-		$transport = new RawTransport();
+		$transport       = new RawTransport();
 		$transport->data =
 			"HTTP/1.0 200 OK\r\n" .
 			"Host: localhost\r\n\r\n" .
 			"Test";
 
-		$options = array(
+		$options  = array(
 			'transport' => $transport
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
@@ -83,10 +83,10 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	 * Headers with only \n delimiting should be treated as if they're \r\n
 	 */
 	public function testHeaderOnlyLF() {
-		$transport = new RawTransport();
+		$transport       = new RawTransport();
 		$transport->data = "HTTP/1.0 200 OK\r\nTest: value\nAnother-Test: value\r\n\r\n";
 
-		$options = array(
+		$options  = array(
 			'transport' => $transport
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
@@ -103,10 +103,10 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testInvalidProtocolVersion() {
-		$transport = new RawTransport();
+		$transport       = new RawTransport();
 		$transport->data = "HTTP/0.9 200 OK\r\n\r\n<p>Test";
 
-		$options = array(
+		$options  = array(
 			'transport' => $transport
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
@@ -118,10 +118,10 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testSingleCRLFSeparator() {
-		$transport = new RawTransport();
+		$transport       = new RawTransport();
 		$transport->data = "HTTP/0.9 200 OK\r\n<p>Test";
 
-		$options = array(
+		$options  = array(
 			'transport' => $transport
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
@@ -131,20 +131,20 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testInvalidStatus() {
-		$transport = new RawTransport();
+		$transport       = new RawTransport();
 		$transport->data = "HTTP/1.1 OK\r\nTest: value\nAnother-Test: value\r\n\r\nTest";
 
-		$options = array(
+		$options  = array(
 			'transport' => $transport
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
 	}
 
 	public function test30xWithoutLocation() {
-		$transport = new MockTransport();
+		$transport       = new MockTransport();
 		$transport->code = 302;
 
-		$options = array(
+		$options  = array(
 			'transport' => $transport
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
@@ -156,7 +156,7 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testTimeoutException() {
-		$options = array('timeout' => 0.5);
+		$options  = array('timeout' => 0.5);
 		$response = Requests::get(httpbin('/delay/3'), array(), $options);
 	}
 }

--- a/tests/Response/Headers.php
+++ b/tests/Response/Headers.php
@@ -2,13 +2,13 @@
 
 class RequestsTest_Response_Headers extends PHPUnit_Framework_TestCase {
 	public function testArrayAccess() {
-		$headers = new Requests_Response_Headers();
+		$headers                 = new Requests_Response_Headers();
 		$headers['Content-Type'] = 'text/plain';
 
 		$this->assertEquals('text/plain', $headers['Content-Type']);
 	}
 	public function testCaseInsensitiveArrayAccess() {
-		$headers = new Requests_Response_Headers();
+		$headers                 = new Requests_Response_Headers();
 		$headers['Content-Type'] = 'text/plain';
 
 		$this->assertEquals('text/plain', $headers['CONTENT-TYPE']);
@@ -19,8 +19,8 @@ class RequestsTest_Response_Headers extends PHPUnit_Framework_TestCase {
 	 * @depends testArrayAccess
 	 */
 	public function testIteration() {
-		$headers = new Requests_Response_Headers();
-		$headers['Content-Type'] = 'text/plain';
+		$headers                   = new Requests_Response_Headers();
+		$headers['Content-Type']   = 'text/plain';
 		$headers['Content-Length'] = 10;
 
 		foreach ($headers as $name => $value) {
@@ -41,12 +41,12 @@ class RequestsTest_Response_Headers extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testInvalidKey() {
-		$headers = new Requests_Response_Headers();
+		$headers   = new Requests_Response_Headers();
 		$headers[] = 'text/plain';
 	}
 
 	public function testMultipleHeaders() {
-		$headers = new Requests_Response_Headers();
+		$headers           = new Requests_Response_Headers();
 		$headers['Accept'] = 'text/html;q=1.0';
 		$headers['Accept'] = '*/*;q=0.1';
 

--- a/tests/Session.php
+++ b/tests/Session.php
@@ -20,8 +20,8 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 			'X-Requests-Session' => 'BasicGET',
 			'X-Requests-Request' => 'notset',
 		);
-		$session = new Requests_Session(httpbin('/'), $session_headers);
-		$response = $session->get('/get', array('X-Requests-Request' => 'GET'));
+		$session         = new Requests_Session(httpbin('/'), $session_headers);
+		$response        = $session->get('/get', array('X-Requests-Request' => 'GET'));
 		$response->throw_for_status(false);
 		$this->assertEquals(200, $response->status_code);
 
@@ -37,8 +37,8 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 			'X-Requests-Session' => 'BasicHEAD',
 			'X-Requests-Request' => 'notset',
 		);
-		$session = new Requests_Session(httpbin('/'), $session_headers);
-		$response = $session->head('/get', array('X-Requests-Request' => 'HEAD'));
+		$session         = new Requests_Session(httpbin('/'), $session_headers);
+		$response        = $session->head('/get', array('X-Requests-Request' => 'HEAD'));
 		$response->throw_for_status(false);
 		$this->assertEquals(200, $response->status_code);
 	}
@@ -48,8 +48,8 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 			'X-Requests-Session' => 'BasicDELETE',
 			'X-Requests-Request' => 'notset',
 		);
-		$session = new Requests_Session(httpbin('/'), $session_headers);
-		$response = $session->delete('/delete', array('X-Requests-Request' => 'DELETE'));
+		$session         = new Requests_Session(httpbin('/'), $session_headers);
+		$response        = $session->delete('/delete', array('X-Requests-Request' => 'DELETE'));
 		$response->throw_for_status(false);
 		$this->assertEquals(200, $response->status_code);
 
@@ -65,8 +65,8 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 			'X-Requests-Session' => 'BasicPOST',
 			'X-Requests-Request' => 'notset',
 		);
-		$session = new Requests_Session(httpbin('/'), $session_headers);
-		$response = $session->post('/post', array('X-Requests-Request' => 'POST'), array('postdata' => 'exists'));
+		$session         = new Requests_Session(httpbin('/'), $session_headers);
+		$response        = $session->post('/post', array('X-Requests-Request' => 'POST'), array('postdata' => 'exists'));
 		$response->throw_for_status(false);
 		$this->assertEquals(200, $response->status_code);
 
@@ -82,8 +82,8 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 			'X-Requests-Session' => 'BasicPUT',
 			'X-Requests-Request' => 'notset',
 		);
-		$session = new Requests_Session(httpbin('/'), $session_headers);
-		$response = $session->put('/put', array('X-Requests-Request' => 'PUT'), array('postdata' => 'exists'));
+		$session         = new Requests_Session(httpbin('/'), $session_headers);
+		$response        = $session->put('/put', array('X-Requests-Request' => 'PUT'), array('postdata' => 'exists'));
 		$response->throw_for_status(false);
 		$this->assertEquals(200, $response->status_code);
 
@@ -99,8 +99,8 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 			'X-Requests-Session' => 'BasicPATCH',
 			'X-Requests-Request' => 'notset',
 		);
-		$session = new Requests_Session(httpbin('/'), $session_headers);
-		$response = $session->patch('/patch', array('X-Requests-Request' => 'PATCH'), array('postdata' => 'exists'));
+		$session         = new Requests_Session(httpbin('/'), $session_headers);
+		$response        = $session->patch('/patch', array('X-Requests-Request' => 'PATCH'), array('postdata' => 'exists'));
 		$response->throw_for_status(false);
 		$this->assertEquals(200, $response->status_code);
 
@@ -112,8 +112,8 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testMultiple() {
-		$session = new Requests_Session(httpbin('/'), array('X-Requests-Session' => 'Multiple'));
-		$requests = array(
+		$session   = new Requests_Session(httpbin('/'), array('X-Requests-Session' => 'Multiple'));
+		$requests  = array(
 			'test1' => array(
 				'url' => httpbin('/get')
 			),
@@ -147,7 +147,7 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 			'X-TestHeader' => 'testing',
 			'X-TestHeader2' => 'requests-test'
 		);
-		$data = array(
+		$data    = array(
 			'testdata' => 'value1',
 			'test2' => 'value2',
 			'test3' => array(
@@ -170,7 +170,7 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($options['testoption'], $session->testoption);
 
 		// Test setting new property
-		$session->newoption = 'foobar';
+		$session->newoption   = 'foobar';
 		$options['newoption'] = 'foobar';
 		$this->assertEquals($options['newoption'], $session->options['newoption']);
 
@@ -179,7 +179,7 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		$this->assertFalse(isset($session->newoption));
 
 		// Update property
-		$session->testoption = 'foobar';
+		$session->testoption   = 'foobar';
 		$options['testoption'] = 'foobar';
 		$this->assertEquals($options['testoption'], $session->testoption);
 
@@ -190,7 +190,7 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 	public function testSharedCookies() {
 		$session = new Requests_Session(httpbin('/'));
 
-		$options = array(
+		$options  = array(
 			'follow_redirects' => false
 		);
 		$response = $session->get('/cookies/set?requests-testcookie=testvalue', array(), $options);

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -2,7 +2,7 @@
 
 abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	public function setUp() {
-		$callback = array($this->transport, 'test');
+		$callback  = array($this->transport, 'test');
 		$supported = call_user_func($callback);
 
 		if (!$supported) {
@@ -49,8 +49,8 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testResponseByteLimit() {
-		$limit = 104;
-		$options = array(
+		$limit    = 104;
+		$options  = array(
 			'max_bytes' => $limit,
 		);
 		$response = Requests::get(httpbin('/bytes/325'), array(), $this->getOptions($options));
@@ -58,8 +58,8 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testResponseByteLimitWithFile() {
-		$limit = 300;
-		$options = array(
+		$limit    = 300;
+		$options  = array(
 			'max_bytes' => $limit,
 			'filename' => tempnam(sys_get_temp_dir(), 'RLT') // RequestsLibraryTest
 		);
@@ -88,7 +88,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGETWithData() {
-		$data = array(
+		$data    = array(
 			'test' => 'true',
 			'test2' => 'test',
 		);
@@ -101,7 +101,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGETWithNestedData() {
-		$data = array(
+		$data    = array(
 			'test' => 'true',
 			'test2' => array(
 				'test3' => 'test',
@@ -117,7 +117,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGETWithDataAndQuery() {
-		$data = array(
+		$data    = array(
 			'test2' => 'test',
 		);
 		$request = Requests::request(httpbin('/get?test=true'), array(), $data, Requests::GET, $this->getOptions());
@@ -160,7 +160,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testRawPOST() {
-		$data = 'test';
+		$data    = 'test';
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
 		$this->assertEquals(200, $request->status_code);
 
@@ -169,7 +169,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testFormPost() {
-		$data = 'test=true&test2=test';
+		$data    = 'test=true&test2=test';
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
 		$this->assertEquals(200, $request->status_code);
 
@@ -178,7 +178,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testPOSTWithArray() {
-		$data = array(
+		$data    = array(
 			'test' => 'true',
 			'test2' => 'test',
 		);
@@ -190,7 +190,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testPOSTWithNestedData() {
-		$data = array(
+		$data    = array(
 			'test' => 'true',
 			'test2' => array(
 				'test3' => 'test',
@@ -205,7 +205,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testRawPUT() {
-		$data = 'test';
+		$data    = 'test';
 		$request = Requests::put(httpbin('/put'), array(), $data, $this->getOptions());
 		$this->assertEquals(200, $request->status_code);
 
@@ -214,7 +214,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testFormPUT() {
-		$data = 'test=true&test2=test';
+		$data    = 'test=true&test2=test';
 		$request = Requests::put(httpbin('/put'), array(), $data, $this->getOptions());
 		$this->assertEquals(200, $request->status_code);
 
@@ -223,7 +223,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testPUTWithArray() {
-		$data = array(
+		$data    = array(
 			'test' => 'true',
 			'test2' => 'test',
 		);
@@ -235,7 +235,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testRawPATCH() {
-		$data = 'test';
+		$data    = 'test';
 		$request = Requests::patch(httpbin('/patch'), array(), $data, $this->getOptions());
 		$this->assertEquals(200, $request->status_code);
 
@@ -244,7 +244,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testFormPATCH() {
-		$data = 'test=true&test2=test';
+		$data    = 'test=true&test2=test';
 		$request = Requests::patch(httpbin('/patch'), array(), $data, $this->getOptions());
 		$this->assertEquals(200, $request->status_code, $request->body);
 
@@ -253,7 +253,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testPATCHWithArray() {
-		$data = array(
+		$data    = array(
 			'test' => 'true',
 			'test2' => 'test',
 		);
@@ -279,7 +279,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testDELETEWithData() {
-		$data = array(
+		$data    = array(
 			'test' => 'true',
 			'test2' => 'test',
 		);
@@ -297,7 +297,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testLOCKWithData() {
-		$data = array(
+		$data    = array(
 			'test' => 'true',
 			'test2' => 'test',
 		);
@@ -386,7 +386,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	 * @dataProvider statusCodeSuccessProvider
 	 */
 	public function testStatusCode($code, $success) {
-		$transport = new MockTransport();
+		$transport       = new MockTransport();
 		$transport->code = $code;
 
 		$url = sprintf(httpbin('/status/%d'), $code);
@@ -404,10 +404,10 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	 * @dataProvider statusCodeSuccessProvider
 	 */
 	public function testStatusCodeThrow($code, $success) {
-		$transport = new MockTransport();
+		$transport       = new MockTransport();
 		$transport->code = $code;
 
-		$url = sprintf(httpbin('/status/%d'), $code);
+		$url     = sprintf(httpbin('/status/%d'), $code);
 		$options = array(
 			'follow_redirects' => false,
 			'transport' => $transport,
@@ -429,10 +429,10 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	 * @dataProvider statusCodeSuccessProvider
 	 */
 	public function testStatusCodeThrowAllowRedirects($code, $success) {
-		$transport = new MockTransport();
+		$transport       = new MockTransport();
 		$transport->code = $code;
 
-		$url = sprintf(httpbin('/status/%d'), $code);
+		$url     = sprintf(httpbin('/status/%d'), $code);
 		$options = array(
 			'follow_redirects' => false,
 			'transport' => $transport,
@@ -448,7 +448,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testStatusCodeUnknown() {
-		$transport = new MockTransport();
+		$transport       = new MockTransport();
 		$transport->code = 599;
 
 		$options = array(
@@ -464,7 +464,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception_HTTP_Unknown
 	 */
 	public function testStatusCodeThrowUnknown() {
-		$transport = new MockTransport();
+		$transport       = new MockTransport();
 		$transport->code = 599;
 
 		$options = array(
@@ -492,7 +492,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertEmpty($request->body);
 
 		$contents = file_get_contents($options['filename']);
-		$result = json_decode($contents, true);
+		$result   = json_decode($contents, true);
 		$this->assertEquals(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 
@@ -504,7 +504,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'blocking' => false
 		);
 		$request = Requests::get(httpbin('/get'), array(), $this->getOptions($options));
-		$empty = new Requests_Response();
+		$empty   = new Requests_Response();
 		$this->assertEquals($empty, $request);
 	}
 
@@ -622,7 +622,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testMultiple() {
-		$requests = array(
+		$requests  = array(
 			'test1' => array(
 				'url' => httpbin('/get')
 			),
@@ -652,7 +652,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testMultipleWithDifferingMethods() {
-		$requests = array(
+		$requests  = array(
 			'get' => array(
 				'url' => httpbin('/get'),
 			),
@@ -677,7 +677,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	 * @depends testTimeout
 	 */
 	public function testMultipleWithFailure() {
-		$requests = array(
+		$requests  = array(
 			'success' => array(
 				'url' => httpbin('/get'),
 			),
@@ -694,7 +694,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testMultipleUsingCallback() {
-		$requests = array(
+		$requests        = array(
 			'get' => array(
 				'url' => httpbin('/get'),
 			),
@@ -705,17 +705,17 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			),
 		);
 		$this->completed = array();
-		$options = array(
+		$options         = array(
 			'complete' => array($this, 'completeCallback'),
 		);
-		$responses = Requests::request_multiple($requests, $this->getOptions($options));
+		$responses       = Requests::request_multiple($requests, $this->getOptions($options));
 
 		$this->assertEquals($this->completed, $responses);
 		$this->completed = array();
 	}
 
 	public function testMultipleUsingCallbackAndFailure() {
-		$requests = array(
+		$requests        = array(
 			'success' => array(
 				'url' => httpbin('/get'),
 			),
@@ -727,10 +727,10 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			),
 		);
 		$this->completed = array();
-		$options = array(
+		$options         = array(
 			'complete' => array($this, 'completeCallback'),
 		);
-		$responses = Requests::request_multiple($requests, $this->getOptions($options));
+		$responses       = Requests::request_multiple($requests, $this->getOptions($options));
 
 		$this->assertEquals($this->completed, $responses);
 		$this->completed = array();
@@ -741,7 +741,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testMultipleToFile() {
-		$requests = array(
+		$requests  = array(
 			'get' => array(
 				'url' => httpbin('/get'),
 				'options' => array(
@@ -761,14 +761,14 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 
 		// GET request
 		$contents = file_get_contents($requests['get']['options']['filename']);
-		$result = json_decode($contents, true);
+		$result   = json_decode($contents, true);
 		$this->assertEquals(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 		unlink($requests['get']['options']['filename']);
 
 		// POST request
 		$contents = file_get_contents($requests['post']['options']['filename']);
-		$result = json_decode($contents, true);
+		$result   = json_decode($contents, true);
 		$this->assertEquals(httpbin('/post'), $result['url']);
 		$this->assertEquals('test', $result['data']);
 		unlink($requests['post']['options']['filename']);
@@ -852,7 +852,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testQueryDataFormat() {
-		$data = array('test' => 'true', 'test2' => 'test');
+		$data    = array('test' => 'true', 'test2' => 'test');
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions(array('data_format' => 'query')));
 		$this->assertEquals(200, $request->status_code);
 
@@ -862,7 +862,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testBodyDataFormat() {
-		$data = array('test' => 'true', 'test2' => 'test');
+		$data    = array('test' => 'true', 'test2' => 'test');
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions(array('data_format' => 'body')));
 		$this->assertEquals(200, $request->status_code);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,7 +37,7 @@ function autoload_tests($class) {
 	}
 
 	$class = substr($class, 13);
-	$file = str_replace('_', '/', $class);
+	$file  = str_replace('_', '/', $class);
 	if (file_exists(dirname(__FILE__) . '/' . $file . '.php')) {
 		require_once dirname(__FILE__) . '/' . $file . '.php';
 	}
@@ -51,9 +51,9 @@ function httpbin($suffix = '', $ssl = false) {
 }
 
 class MockTransport implements Requests_Transport {
-	public $code = 200;
-	public $chunked = false;
-	public $body = 'Test Body';
+	public $code        = 200;
+	public $chunked     = false;
+	public $body        = 'Test Body';
 	public $raw_headers = '';
 
 	private static $messages = array(
@@ -106,8 +106,8 @@ class MockTransport implements Requests_Transport {
 	);
 
 	public function request($url, $headers = array(), $data = array(), $options = array()) {
-		$status = isset(self::$messages[$this->code]) ? self::$messages[$this->code] : $this->code . ' unknown';
-		$response = "HTTP/1.0 $status\r\n";
+		$status    = isset(self::$messages[$this->code]) ? self::$messages[$this->code] : $this->code . ' unknown';
+		$response  = "HTTP/1.0 $status\r\n";
 		$response .= "Content-Type: text/plain\r\n";
 		if ($this->chunked) {
 			$response .= "Transfer-Encoding: chunked\r\n";
@@ -121,12 +121,12 @@ class MockTransport implements Requests_Transport {
 	public function request_multiple($requests, $options) {
 		$responses = array();
 		foreach ($requests as $id => $request) {
-			$handler = new MockTransport();
-			$handler->code = $request['options']['mock.code'];
-			$handler->chunked = $request['options']['mock.chunked'];
-			$handler->body = $request['options']['mock.body'];
+			$handler              = new MockTransport();
+			$handler->code        = $request['options']['mock.code'];
+			$handler->chunked     = $request['options']['mock.chunked'];
+			$handler->body        = $request['options']['mock.body'];
 			$handler->raw_headers = $request['options']['mock.raw_headers'];
-			$responses[$id] = $handler->request($request['url'], $request['headers'], $request['data'], $request['options']);
+			$responses[$id]       = $handler->request($request['url'], $request['headers'], $request['data'], $request['options']);
 
 			if (!empty($options['mock.parse'])) {
 				$request['options']['hooks']->dispatch('transport.internal.parse_response', array(&$responses[$id], $request));
@@ -149,9 +149,9 @@ class RawTransport implements Requests_Transport {
 	}
 	public function request_multiple($requests, $options) {
 		foreach ($requests as $id => &$request) {
-			$handler = new RawTransport();
+			$handler       = new RawTransport();
 			$handler->data = $request['options']['raw.data'];
-			$request = $handler->request($request['url'], $request['headers'], $request['data'], $request['options']);
+			$request       = $handler->request($request['url'], $request['headers'], $request['data'], $request['options']);
 		}
 
 		return $requests;


### PR DESCRIPTION
When several lines containing assignments directly follow each other, it increases readability for the assignment operator - `=` and its variants - to be aligned.