### PR TITLE
QA: don't use count() in a looping condition

### DIFF
--- a/library/Requests/IDNAEncoder.php
+++ b/library/Requests/IDNAEncoder.php
@@ -265,7 +265,8 @@ class Requests_IDNAEncoder {
 		}
 		// {if the input contains a non-basic code point < n then fail}
 		// while h < length(input) do begin
-		while ($h < count($codepoints)) {
+		$codepointcount = count($codepoints);
+		while ($h < $codepointcount) {
 			// let m = the minimum code point >= n in the input
 			$m = array_shift($extended);
 			//printf('next code point to insert is %s' . PHP_EOL, dechex($m));
@@ -274,7 +275,7 @@ class Requests_IDNAEncoder {
 			// let n = m
 			$n = $m;
 			// for each code point c in the input (in order) do begin
-			for ($num = 0; $num < count($codepoints); $num++) {
+			for ($num = 0; $num < $codepointcount; $num++) {
 				$c = $codepoints[$num];
 				// if c < n then increment delta, fail on overflow
 				if ($c < $n) {

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -209,8 +209,9 @@ class Requests_Transport_cURL implements Requests_Transport {
 			curl_multi_add_handle($multihandle, $subhandles[$id]);
 		}
 
-		$completed = 0;
-		$responses = array();
+		$completed       = 0;
+		$responses       = array();
+		$subrequestcount = count($subrequests);
 
 		$request['options']['hooks']->dispatch('curl.before_multi_exec', array(&$multihandle));
 
@@ -262,7 +263,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 				$completed++;
 			}
 		}
-		while ($active || $completed < count($subrequests));
+		while ($active || $completed < $subrequestcount);
 
 		$request['options']['hooks']->dispatch('curl.after_multi_exec', array(&$multihandle));
 


### PR DESCRIPTION
Efficiency fix.

Don't use `count()` in a looping condition as it will be called on every single loop, while the return value of the call to `count()` should not (and doesn't in these cases) change within the loop.