### PR TITLE
QA: use strict comparisons

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -604,7 +604,7 @@ class Requests {
 		$type = strtoupper($type);
 
 		if (!isset($options['data_format'])) {
-			if (in_array($type, array(self::HEAD, self::GET, self::DELETE))) {
+			if (in_array($type, array(self::HEAD, self::GET, self::DELETE), true)) {
 				$options['data_format'] = 'query';
 			}
 			else {
@@ -865,7 +865,7 @@ class Requests {
 	public static function compatible_gzinflate($gzData) {
 		// Compressed data might contain a full zlib header, if so strip it for
 		// gzinflate()
-		if (substr($gzData, 0, 3) == "\x1f\x8b\x08") {
+		if (substr($gzData, 0, 3) === "\x1f\x8b\x08") {
 			$i   = 10;
 			$flg = ord(substr($gzData, 3, 1));
 			if ($flg > 0) {
@@ -905,7 +905,7 @@ class Requests {
 		// First 2 bytes should be divisible by 0x1F
 		list(, $first_two_bytes) = unpack('n', $gzData);
 
-		if (0x08 == $first_nibble && 0 == ($first_two_bytes % 0x1F)) {
+		if (0x08 === $first_nibble && 0 === ($first_two_bytes % 0x1F)) {
 			$huffman_encoded = true;
 		}
 
@@ -915,7 +915,7 @@ class Requests {
 			}
 		}
 
-		if ("\x50\x4b\x03\x04" == substr($gzData, 0, 4)) {
+		if ("\x50\x4b\x03\x04" === substr($gzData, 0, 4)) {
 			// ZIP file format header
 			// Offset 6: 2 bytes, General-purpose field
 			// Offset 26: 2 bytes, filename length
@@ -927,7 +927,7 @@ class Requests {
 			// If the file has been compressed on the fly, 0x08 bit is set of
 			// the general purpose field. We can use this to differentiate
 			// between a compressed document, and a ZIP file
-			$zip_compressed_on_the_fly = (0x08 == (0x08 & $general_purpose_flag));
+			$zip_compressed_on_the_fly = (0x08 === (0x08 & $general_purpose_flag));
 
 			if (!$zip_compressed_on_the_fly) {
 				// Don't attempt to decode a compressed zip file

--- a/library/Requests/Proxy/HTTP.php
+++ b/library/Requests/Proxy/HTTP.php
@@ -59,10 +59,10 @@ class Requests_Proxy_HTTP implements Requests_Proxy {
 			$this->proxy = $args;
 		}
 		elseif (is_array($args)) {
-			if (count($args) == 1) {
+			if (count($args) === 1) {
 				list($this->proxy) = $args;
 			}
-			elseif (count($args) == 3) {
+			elseif (count($args) === 3) {
 				list($this->proxy, $this->user, $this->pass) = $args;
 				$this->use_authentication                    = true;
 			}

--- a/library/Requests/Response.php
+++ b/library/Requests/Response.php
@@ -97,7 +97,7 @@ class Requests_Response {
 	 */
 	public function is_redirect() {
 		$code = $this->status_code;
-		return in_array($code, array(300, 301, 302, 303, 307)) || $code > 307 && $code < 400;
+		return in_array($code, array(300, 301, 302, 303, 307), true) || $code > 307 && $code < 400;
 	}
 
 	/**

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -222,7 +222,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		}
 
 		$timeout_sec = (int) floor($options['timeout']);
-		if ($timeout_sec == $options['timeout']) {
+		if ($timeout_sec === $options['timeout']) {
 			$timeout_msec = 0;
 		}
 		else {


### PR DESCRIPTION
Strict type comparisons should be used as a rule, with loose type comparisons being the exception.

This is especially important when comparing variables which are expected to be strings, as when one of the two operands - for whatever reason - is not a string, the other operand will be juggled to the type of the first operand which can lead to unexpected results and hard to debug bugs.

For array functions which do loose type comparisons, setting the third `$strict` parameter to `false` can be seen as a clear indication that this is a conscious, well thought out decision by the developer.
In all other cases, `$strict` `true` should be used.

Refs:
* http://phpcheatsheets.com/compare/equal/
* http://php.net/manual/en/function.in-array.php