### PR TITLE
CS: no multiple assignments in one statement

### DIFF
--- a/library/Requests/IDNAEncoder.php
+++ b/library/Requests/IDNAEncoder.php
@@ -234,7 +234,8 @@ class Requests_IDNAEncoder {
 		// let bias = initial_bias
 		$bias = self::BOOTSTRAP_INITIAL_BIAS;
 		// let h = b = the number of basic code points in the input
-		$h = $b = 0; // see loop
+		$h = 0;
+		$b = 0; // see loop
 		// copy them to the output in order
 		$codepoints = self::utf8_to_codepoints($input);
 		$extended   = array();

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -499,9 +499,10 @@ class Requests_Transport_cURL implements Requests_Transport {
 	 */
 	protected static function format_get($url, $data) {
 		if (!empty($data)) {
+			$query     = '';
 			$url_parts = parse_url($url);
 			if (empty($url_parts['query'])) {
-				$query = $url_parts['query'] = '';
+				$url_parts['query'] = '';
 			}
 			else {
 				$query = $url_parts['query'];

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -230,7 +230,9 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		}
 		stream_set_timeout($socket, $timeout_sec, $timeout_msec);
 
-		$response   = $body = $headers = '';
+		$response   = '';
+		$body       = '';
+		$headers    = '';
 		$this->info = stream_get_meta_data($socket);
 		$size       = 0;
 		$doingbody  = false;


### PR DESCRIPTION
Multiple assignments in one statement makes for harder to debug, harder to read code and is considered a code smell.