### PR TITLE
Tests: verify exception messages

### DIFF
--- a/tests/Auth/Basic.php
+++ b/tests/Auth/Basic.php
@@ -77,7 +77,8 @@ class RequestsTest_Auth_Basic extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Invalid number of arguments
 	 */
 	public function testMissingPassword() {
 		new Requests_Auth_Basic(array('user'));

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -58,7 +58,8 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Object is a dictionary, not a list
 	 */
 	public function testCookieJarAsList() {
 		$cookies   = new Requests_Cookie_Jar();

--- a/tests/IDNAEncoder.php
+++ b/tests/IDNAEncoder.php
@@ -23,7 +23,8 @@ class RequestsTest_IDNAEncoder extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Provided string is too long
 	 */
 	public function testASCIITooLong() {
 		$data = str_repeat('abcd', 20);
@@ -31,7 +32,8 @@ class RequestsTest_IDNAEncoder extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Encoded string is too long
 	 */
 	public function testEncodedTooLong() {
 		$data = str_repeat("\xe4\xbb\x96", 60);
@@ -39,7 +41,8 @@ class RequestsTest_IDNAEncoder extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Provided string begins with ACE prefix
 	 */
 	public function testAlreadyPrefixed() {
 		Requests_IDNAEncoder::encode("xn--\xe4\xbb\x96");
@@ -66,35 +69,40 @@ class RequestsTest_IDNAEncoder extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Invalid Unicode codepoint
 	 */
 	public function testFiveByteCharacter() {
 		Requests_IDNAEncoder::encode("\xfb\xb6\xb6\xb6\xb6");
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Invalid Unicode codepoint
 	 */
 	public function testSixByteCharacter() {
 		Requests_IDNAEncoder::encode("\xfd\xb6\xb6\xb6\xb6\xb6");
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Invalid Unicode codepoint
 	 */
 	public function testInvalidASCIICharacterWithMultibyte() {
 		Requests_IDNAEncoder::encode("\0\xc2\xb6");
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Invalid Unicode codepoint
 	 */
 	public function testUnfinishedMultibyte() {
 		Requests_IDNAEncoder::encode("\xc2");
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Invalid Unicode codepoint
 	 */
 	public function testPartialMultibyte() {
 		Requests_IDNAEncoder::encode("\xc2\xc2\xb6");

--- a/tests/Proxy/HTTP.php
+++ b/tests/Proxy/HTTP.php
@@ -60,7 +60,9 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider transportProvider
-	 * @expectedException Requests_Exception
+	 *
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Invalid number of arguments
 	 */
 	public function testConnectInvalidParameters($transport) {
 		$this->checkProxyAvailable();

--- a/tests/Requests.php
+++ b/tests/Requests.php
@@ -2,7 +2,8 @@
 
 class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Only HTTP(S) requests are handled
 	 */
 	public function testInvalidProtocol() {
 		Requests::request('ftp://128.0.0.1/');
@@ -100,7 +101,8 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	 * We do not support HTTP/0.9. If this is really an issue for you, file a
 	 * new issue, and update your server/proxy to support a proper protocol.
 	 *
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Response could not be parsed
 	 */
 	public function testInvalidProtocolVersion() {
 		$transport       = new RequestsTest_Mock_RawTransport();
@@ -115,7 +117,8 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	/**
 	 * HTTP/0.9 also appears to use a single CRLF instead of two
 	 *
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Missing header/body separator
 	 */
 	public function testSingleCRLFSeparator() {
 		$transport       = new RequestsTest_Mock_RawTransport();
@@ -128,7 +131,8 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Response could not be parsed
 	 */
 	public function testInvalidStatus() {
 		$transport       = new RequestsTest_Mock_RawTransport();
@@ -153,7 +157,8 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage timed out
 	 */
 	public function testTimeoutException() {
 		$options = array('timeout' => 0.5);

--- a/tests/Response/Headers.php
+++ b/tests/Response/Headers.php
@@ -38,7 +38,8 @@ class RequestsTest_Response_Headers extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Object is a dictionary, not a list
 	 */
 	public function testInvalidKey() {
 		$headers   = new Requests_Response_Headers();

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -345,8 +345,8 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
-	 * @todo This should also check that the type is "toomanyredirects"
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage Too many redirects
 	 */
 	public function testTooManyRedirects() {
 		$options = array(
@@ -483,7 +483,8 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception_HTTP_Unknown
+	 * @expectedException        Requests_Exception_HTTP_Unknown
+	 * @expectedExceptionMessage 599 Unknown
 	 */
 	public function testStatusCodeThrowUnknown() {
 		$transport       = new RequestsTest_Mock_Transport();
@@ -634,7 +635,8 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException Requests_Exception
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage timed out
 	 */
 	public function testTimeout() {
 		$options = array(

--- a/tests/Transport/cURL.php
+++ b/tests/Transport/cURL.php
@@ -2,4 +2,38 @@
 
 class RequestsTest_Transport_cURL extends RequestsTest_Transport_Base {
 	protected $transport = 'Requests_Transport_cURL';
+
+	/**
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage t resolve host
+	 */
+	public function testBadIP() {
+		parent::testBadIP();
+	}
+
+	/**
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage certificate subject name
+	 */
+	public function testExpiredHTTPS() {
+		parent::testExpiredHTTPS();
+	}
+
+	/**
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage certificate subject name
+	 */
+	public function testRevokedHTTPS() {
+		parent::testRevokedHTTPS();
+	}
+
+	/**
+	 * Test that SSL fails with a bad certificate
+	 *
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage certificate subject name
+	 */
+	public function testBadDomain() {
+		parent::testBadDomain();
+	}
 }

--- a/tests/Transport/fsockopen.php
+++ b/tests/Transport/fsockopen.php
@@ -4,6 +4,39 @@ class RequestsTest_Transport_fsockopen extends RequestsTest_Transport_Base {
 	protected $transport = 'Requests_Transport_fsockopen';
 
 	/**
+	 * @expectedException Requests_Exception
+	 */
+	public function testBadIP() {
+		parent::testBadIP();
+	}
+
+	/**
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage SSL certificate did not match the requested domain name
+	 */
+	public function testExpiredHTTPS() {
+		parent::testExpiredHTTPS();
+	}
+
+	/**
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage SSL certificate did not match the requested domain name
+	 */
+	public function testRevokedHTTPS() {
+		parent::testRevokedHTTPS();
+	}
+
+	/**
+	 * Test that SSL fails with a bad certificate
+	 *
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage SSL certificate did not match the requested domain name
+	 */
+	public function testBadDomain() {
+		parent::testBadDomain();
+	}
+
+	/**
 	 * Issue #248.
 	 */
 	public function testContentLengthHeader() {


### PR DESCRIPTION
Don't just verify that an exception is thrown, but verify that it is the exception expected for a particular test.

This addresses all exceptions, safe one.

Note: in some cases, the verification is done on a _partial_ message string to allow for changed exception message strings across PHP versions.

In a future commit in which the annotations for exception expectations are replaced by method calls, logic can be added to improve the message checking in a cross-version compatible manner.