### PR TITLE
QA: remove useless variable assignments

### DIFF
--- a/tests/Auth/Basic.php
+++ b/tests/Auth/Basic.php
@@ -2,11 +2,10 @@
 
 class RequestsTest_Auth_Basic extends PHPUnit_Framework_TestCase {
 	public static function transportProvider() {
-		$transports = array(
+		return array(
 			array('Requests_Transport_fsockopen'),
 			array('Requests_Transport_cURL'),
 		);
-		return $transports;
 	}
 
 	/**

--- a/tests/Auth/Basic.php
+++ b/tests/Auth/Basic.php
@@ -80,7 +80,7 @@ class RequestsTest_Auth_Basic extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testMissingPassword() {
-		$auth = new Requests_Auth_Basic(array('user'));
+		new Requests_Auth_Basic(array('user'));
 	}
 
 }

--- a/tests/IDNAEncoder.php
+++ b/tests/IDNAEncoder.php
@@ -26,23 +26,23 @@ class RequestsTest_IDNAEncoder extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testASCIITooLong() {
-		$data   = str_repeat('abcd', 20);
-		$result = Requests_IDNAEncoder::encode($data);
+		$data = str_repeat('abcd', 20);
+		Requests_IDNAEncoder::encode($data);
 	}
 
 	/**
 	 * @expectedException Requests_Exception
 	 */
 	public function testEncodedTooLong() {
-		$data   = str_repeat("\xe4\xbb\x96", 60);
-		$result = Requests_IDNAEncoder::encode($data);
+		$data = str_repeat("\xe4\xbb\x96", 60);
+		Requests_IDNAEncoder::encode($data);
 	}
 
 	/**
 	 * @expectedException Requests_Exception
 	 */
 	public function testAlreadyPrefixed() {
-		$result = Requests_IDNAEncoder::encode("xn--\xe4\xbb\x96");
+		Requests_IDNAEncoder::encode("xn--\xe4\xbb\x96");
 	}
 
 	public function testASCIICharacter() {
@@ -69,34 +69,34 @@ class RequestsTest_IDNAEncoder extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testFiveByteCharacter() {
-		$result = Requests_IDNAEncoder::encode("\xfb\xb6\xb6\xb6\xb6");
+		Requests_IDNAEncoder::encode("\xfb\xb6\xb6\xb6\xb6");
 	}
 
 	/**
 	 * @expectedException Requests_Exception
 	 */
 	public function testSixByteCharacter() {
-		$result = Requests_IDNAEncoder::encode("\xfd\xb6\xb6\xb6\xb6\xb6");
+		Requests_IDNAEncoder::encode("\xfd\xb6\xb6\xb6\xb6\xb6");
 	}
 
 	/**
 	 * @expectedException Requests_Exception
 	 */
 	public function testInvalidASCIICharacterWithMultibyte() {
-		$result = Requests_IDNAEncoder::encode("\0\xc2\xb6");
+		Requests_IDNAEncoder::encode("\0\xc2\xb6");
 	}
 
 	/**
 	 * @expectedException Requests_Exception
 	 */
 	public function testUnfinishedMultibyte() {
-		$result = Requests_IDNAEncoder::encode("\xc2");
+		Requests_IDNAEncoder::encode("\xc2");
 	}
 
 	/**
 	 * @expectedException Requests_Exception
 	 */
 	public function testPartialMultibyte() {
-		$result = Requests_IDNAEncoder::encode("\xc2\xc2\xb6");
+		Requests_IDNAEncoder::encode("\xc2\xc2\xb6");
 	}
 }

--- a/tests/Proxy/HTTP.php
+++ b/tests/Proxy/HTTP.php
@@ -65,11 +65,11 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 	public function testConnectInvalidParameters($transport) {
 		$this->checkProxyAvailable();
 
-		$options  = array(
+		$options = array(
 			'proxy'     => array(REQUESTS_HTTP_PROXY, 'testuser', 'password', 'something'),
 			'transport' => $transport,
 		);
-		$response = Requests::get(httpbin('/get'), array(), $options);
+		Requests::get(httpbin('/get'), array(), $options);
 	}
 
 	/**

--- a/tests/Requests.php
+++ b/tests/Requests.php
@@ -5,7 +5,7 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testInvalidProtocol() {
-		$request = Requests::request('ftp://128.0.0.1/');
+		Requests::request('ftp://128.0.0.1/');
 	}
 
 	public function testDefaultTransport() {
@@ -106,10 +106,10 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 		$transport       = new RequestsTest_Mock_RawTransport();
 		$transport->data = "HTTP/0.9 200 OK\r\n\r\n<p>Test";
 
-		$options  = array(
+		$options = array(
 			'transport' => $transport,
 		);
-		$response = Requests::get('http://example.com/', array(), $options);
+		Requests::get('http://example.com/', array(), $options);
 	}
 
 	/**
@@ -121,10 +121,10 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 		$transport       = new RequestsTest_Mock_RawTransport();
 		$transport->data = "HTTP/0.9 200 OK\r\n<p>Test";
 
-		$options  = array(
+		$options = array(
 			'transport' => $transport,
 		);
-		$response = Requests::get('http://example.com/', array(), $options);
+		Requests::get('http://example.com/', array(), $options);
 	}
 
 	/**
@@ -134,10 +134,10 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 		$transport       = new RequestsTest_Mock_RawTransport();
 		$transport->data = "HTTP/1.1 OK\r\nTest: value\nAnother-Test: value\r\n\r\nTest";
 
-		$options  = array(
+		$options = array(
 			'transport' => $transport,
 		);
-		$response = Requests::get('http://example.com/', array(), $options);
+		Requests::get('http://example.com/', array(), $options);
 	}
 
 	public function test30xWithoutLocation() {
@@ -156,7 +156,7 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testTimeoutException() {
-		$options  = array('timeout' => 0.5);
-		$response = Requests::get(httpbin('/delay/3'), array(), $options);
+		$options = array('timeout' => 0.5);
+		Requests::get(httpbin('/delay/3'), array(), $options);
 	}
 }

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -352,7 +352,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$options = array(
 			'redirects' => 10, // default, but force just in case
 		);
-		$request = Requests::get(httpbin('/redirect/11'), array(), $this->getOptions($options));
+		Requests::get(httpbin('/redirect/11'), array(), $this->getOptions($options));
 	}
 
 	public static function statusCodeSuccessProvider() {
@@ -534,7 +534,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	 * @expectedException Requests_Exception
 	 */
 	public function testBadIP() {
-		$request = Requests::get('http://256.256.256.0/', array(), $this->getOptions());
+		Requests::get('http://256.256.256.0/', array(), $this->getOptions());
 	}
 
 	public function testHTTPS() {
@@ -561,7 +561,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			return;
 		}
 
-		$request = Requests::get('https://testssl-expire.disig.sk/index.en.html', array(), $this->getOptions());
+		Requests::get('https://testssl-expire.disig.sk/index.en.html', array(), $this->getOptions());
 	}
 
 	/**
@@ -573,7 +573,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			return;
 		}
 
-		$request = Requests::get('https://testssl-revoked.disig.sk/index.en.html', array(), $this->getOptions());
+		Requests::get('https://testssl-revoked.disig.sk/index.en.html', array(), $this->getOptions());
 	}
 
 	/**
@@ -587,7 +587,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			return;
 		}
 
-		$request = Requests::head('https://wrong.host.badssl.com/', array(), $this->getOptions());
+		Requests::head('https://wrong.host.badssl.com/', array(), $this->getOptions());
 	}
 
 	public function testBadDomainNoVerify() {
@@ -640,7 +640,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$options = array(
 			'timeout' => 1,
 		);
-		$request = Requests::get(httpbin('/delay/10'), array(), $this->getOptions($options));
+		Requests::get(httpbin('/delay/10'), array(), $this->getOptions($options));
 	}
 
 	public function testMultiple() {
@@ -763,7 +763,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testMultipleToFile() {
-		$requests  = array(
+		$requests = array(
 			'get' => array(
 				'url'     => httpbin('/get'),
 				'options' => array(
@@ -779,7 +779,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 				),
 			),
 		);
-		$responses = Requests::request_multiple($requests, $this->getOptions());
+		Requests::request_multiple($requests, $this->getOptions());
 
 		// GET request
 		$contents = file_get_contents($requests['get']['options']['filename']);
@@ -829,7 +829,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		);
 		$options = $this->getOptions($options);
 
-		$response = Requests::get(httpbin('/get'), array(), $options);
+		Requests::get(httpbin('/get'), array(), $options);
 	}
 
 	public function testAfterRequestCallback() {
@@ -851,7 +851,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		);
 		$options = $this->getOptions($options);
 
-		$response = Requests::get(httpbin('/get'), array(), $options);
+		Requests::get(httpbin('/get'), array(), $options);
 	}
 
 	public function testReusableTransport() {

--- a/tests/Transport/fsockopen.php
+++ b/tests/Transport/fsockopen.php
@@ -10,7 +10,7 @@ class RequestsTest_Transport_fsockopen extends RequestsTest_Transport_Base {
 		$hooks = new Requests_Hooks();
 		$hooks->register('fsockopen.after_headers', array($this, 'checkContentLengthHeader'));
 
-		$request = Requests::post(httpbin('/post'), array(), array(), $this->getOptions(array('hooks' => $hooks)));
+		Requests::post(httpbin('/post'), array(), array(), $this->getOptions(array('hooks' => $hooks)));
 	}
 
 	/**


### PR DESCRIPTION
### QA: remove useless variable assignments [1]

No need to declare a variable here if it's not used other than to be `return`ed.

### QA: remove useless variable assignments [2]

Each of these is testing that the function call triggers an exception - which stops the test dead - or is checking an assertion via a hooked-in method.
So no need to assign the return of the function call to a variable, when the variable is not being tested via an assertion.