### PR TITLE
QA: use the most specific PHPUnit assertion possible

### DIFF
--- a/tests/Auth/Basic.php
+++ b/tests/Auth/Basic.php
@@ -22,11 +22,11 @@ class RequestsTest_Auth_Basic extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$request = Requests::get(httpbin('/basic-auth/user/passwd'), array(), $options);
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body);
-		$this->assertEquals(true, $result->authenticated);
-		$this->assertEquals('user', $result->user);
+		$this->assertTrue($result->authenticated);
+		$this->assertSame('user', $result->user);
 	}
 
 	/**
@@ -43,11 +43,11 @@ class RequestsTest_Auth_Basic extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$request = Requests::get(httpbin('/basic-auth/user/passwd'), array(), $options);
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body);
-		$this->assertEquals(true, $result->authenticated);
-		$this->assertEquals('user', $result->user);
+		$this->assertTrue($result->authenticated);
+		$this->assertSame('user', $result->user);
 	}
 
 	/**
@@ -65,15 +65,15 @@ class RequestsTest_Auth_Basic extends PHPUnit_Framework_TestCase {
 		);
 		$data    = 'test';
 		$request = Requests::post(httpbin('/post'), array(), $data, $options);
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body);
 
 		$auth = $result->headers->Authorization;
 		$auth = explode(' ', $auth);
 
-		$this->assertEquals(base64_encode('user:passwd'), $auth[1]);
-		$this->assertEquals('test', $result->data);
+		$this->assertSame(base64_encode('user:passwd'), $auth[1]);
+		$this->assertSame('test', $result->data);
 	}
 
 	/**

--- a/tests/ChunkedEncoding.php
+++ b/tests/ChunkedEncoding.php
@@ -43,7 +43,7 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
 
-		$this->assertEquals($expected, $response->body);
+		$this->assertSame($expected, $response->body);
 	}
 
 	public static function notChunkedProvider() {
@@ -71,7 +71,7 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
 
-		$this->assertEquals($transport->body, $response->body);
+		$this->assertSame($transport->body, $response->body);
 	}
 
 
@@ -88,6 +88,6 @@ class RequestsTest_ChunkedDecoding extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
-		$this->assertEquals($transport->body, $response->body);
+		$this->assertSame($transport->body, $response->body);
 	}
 }

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -4,12 +4,12 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 	public function testBasicCookie() {
 		$cookie = new Requests_Cookie('requests-testcookie', 'testvalue');
 
-		$this->assertEquals('requests-testcookie', $cookie->name);
-		$this->assertEquals('testvalue', $cookie->value);
-		$this->assertEquals('testvalue', (string) $cookie);
+		$this->assertSame('requests-testcookie', $cookie->name);
+		$this->assertSame('testvalue', $cookie->value);
+		$this->assertSame('testvalue', (string) $cookie);
 
-		$this->assertEquals('requests-testcookie=testvalue', $cookie->format_for_header());
-		$this->assertEquals('requests-testcookie=testvalue', $cookie->format_for_set_cookie());
+		$this->assertSame('requests-testcookie=testvalue', $cookie->format_for_header());
+		$this->assertSame('requests-testcookie=testvalue', $cookie->format_for_set_cookie());
 	}
 
 	public function testCookieWithAttributes() {
@@ -19,14 +19,14 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		);
 		$cookie     = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
 
-		$this->assertEquals('requests-testcookie=testvalue', $cookie->format_for_header());
-		$this->assertEquals('requests-testcookie=testvalue; httponly; path=/', $cookie->format_for_set_cookie());
+		$this->assertSame('requests-testcookie=testvalue', $cookie->format_for_header());
+		$this->assertSame('requests-testcookie=testvalue; httponly; path=/', $cookie->format_for_set_cookie());
 	}
 
 	public function testEmptyCookieName() {
 		$cookie = Requests_Cookie::parse('test');
-		$this->assertEquals('', $cookie->name);
-		$this->assertEquals('test', $cookie->value);
+		$this->assertSame('', $cookie->name);
+		$this->assertSame('test', $cookie->value);
 	}
 
 	public function testEmptyAttributes() {
@@ -50,7 +50,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$jar                        = new Requests_Cookie_Jar();
 		$jar['requests-testcookie'] = 'testvalue';
 
-		$this->assertEquals('testvalue', $jar['requests-testcookie']);
+		$this->assertSame('testvalue', $jar['requests-testcookie']);
 
 		unset($jar['requests-testcookie']);
 		$this->assertEmpty($jar['requests-testcookie']);
@@ -74,7 +74,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$jar     = new Requests_Cookie_Jar($cookies);
 
 		foreach ($jar as $key => $value) {
-			$this->assertEquals($cookies[$key], $value);
+			$this->assertSame($cookies[$key], $value);
 		}
 	}
 
@@ -88,7 +88,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 
 		$cookie = $response->cookies['requests-testcookie'];
 		$this->assertNotEmpty($cookie);
-		$this->assertEquals('testvalue', $cookie->value);
+		$this->assertSame('testvalue', $cookie->value);
 	}
 
 	public function testPersistenceOnRedirect() {
@@ -101,7 +101,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 
 		$cookie = $response->cookies['requests-testcookie'];
 		$this->assertNotEmpty($cookie);
-		$this->assertEquals('testvalue', $cookie->value);
+		$this->assertSame('testvalue', $cookie->value);
 	}
 
 	protected function setCookieRequest($cookies) {
@@ -124,7 +124,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$data = $this->setCookieRequest($cookies);
 
 		$this->assertArrayHasKey('requests-testcookie1', $data);
-		$this->assertEquals('testvalue1', $data['requests-testcookie1']);
+		$this->assertSame('testvalue1', $data['requests-testcookie1']);
 	}
 
 	/**
@@ -153,7 +153,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$data    = $this->setCookieRequest($cookies);
 
 		$this->assertArrayHasKey('requests-testcookie1', $data);
-		$this->assertEquals('testvalue1', $data['requests-testcookie1']);
+		$this->assertSame('testvalue1', $data['requests-testcookie1']);
 	}
 
 	public function testSendingMultipleCookies() {
@@ -164,10 +164,10 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$data    = $this->setCookieRequest($cookies);
 
 		$this->assertArrayHasKey('requests-testcookie1', $data);
-		$this->assertEquals('testvalue1', $data['requests-testcookie1']);
+		$this->assertSame('testvalue1', $data['requests-testcookie1']);
 
 		$this->assertArrayHasKey('requests-testcookie2', $data);
-		$this->assertEquals('testvalue2', $data['requests-testcookie2']);
+		$this->assertSame('testvalue2', $data['requests-testcookie2']);
 	}
 
 	public function testSendingMultipleCookiesWithJar() {
@@ -180,10 +180,10 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$data    = $this->setCookieRequest($cookies);
 
 		$this->assertArrayHasKey('requests-testcookie1', $data);
-		$this->assertEquals('testvalue1', $data['requests-testcookie1']);
+		$this->assertSame('testvalue1', $data['requests-testcookie1']);
 
 		$this->assertArrayHasKey('requests-testcookie2', $data);
-		$this->assertEquals('testvalue2', $data['requests-testcookie2']);
+		$this->assertSame('testvalue2', $data['requests-testcookie2']);
 	}
 
 	public function testSendingPrebakedCookie() {
@@ -195,7 +195,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$data    = $this->setCookieRequest($cookies);
 
 		$this->assertArrayHasKey('requests-testcookie', $data);
-		$this->assertEquals('testvalue', $data['requests-testcookie']);
+		$this->assertSame('testvalue', $data['requests-testcookie']);
 	}
 
 	public function domainMatchProvider() {
@@ -230,7 +230,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$attributes           = new Requests_Utility_CaseInsensitiveDictionary();
 		$attributes['domain'] = $original;
 		$cookie               = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
-		$this->assertEquals($matches, $cookie->domain_matches($check));
+		$this->assertSame($matches, $cookie->domain_matches($check));
 	}
 
 	/**
@@ -243,7 +243,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 			'host-only' => false,
 		);
 		$cookie               = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
-		$this->assertEquals($domain_matches, $cookie->domain_matches($check));
+		$this->assertSame($domain_matches, $cookie->domain_matches($check));
 	}
 
 	public function pathMatchProvider() {
@@ -273,7 +273,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$attributes         = new Requests_Utility_CaseInsensitiveDictionary();
 		$attributes['path'] = $original;
 		$cookie             = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
-		$this->assertEquals($matches, $cookie->path_matches($check));
+		$this->assertSame($matches, $cookie->path_matches($check));
 	}
 
 	public function urlMatchProvider() {
@@ -314,7 +314,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		$attributes['path']   = $path;
 		$check                = new Requests_IRI($check);
 		$cookie               = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes);
-		$this->assertEquals($matches, $cookie->uri_matches($check));
+		$this->assertSame($matches, $cookie->uri_matches($check));
 	}
 
 	/**
@@ -331,7 +331,7 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 		);
 		$check                = new Requests_IRI($check);
 		$cookie               = new Requests_Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
-		$this->assertEquals($domain_matches, $cookie->uri_matches($check));
+		$this->assertSame($domain_matches, $cookie->uri_matches($check));
 	}
 
 	public function testUrlMatchSecure() {
@@ -459,22 +459,22 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 
 	protected function check_parsed_cookie($cookie, $expected, $expected_attributes, $expected_flags = array()) {
 		if (isset($expected['name'])) {
-			$this->assertEquals($expected['name'], $cookie->name);
+			$this->assertSame($expected['name'], $cookie->name);
 		}
 		if (isset($expected['value'])) {
-			$this->assertEquals($expected['value'], $cookie->value);
+			$this->assertSame($expected['value'], $cookie->value);
 		}
 		if (isset($expected['expired'])) {
-			$this->assertEquals($expected['expired'], $cookie->is_expired());
+			$this->assertSame($expected['expired'], $cookie->is_expired());
 		}
 		if (isset($expected_attributes)) {
 			foreach ($expected_attributes as $attr_key => $attr_val) {
-				$this->assertEquals($attr_val, $cookie->attributes[$attr_key], "$attr_key should match supplied");
+				$this->assertSame($attr_val, $cookie->attributes[$attr_key], "$attr_key should match supplied");
 			}
 		}
 		if (isset($expected_flags)) {
 			foreach ($expected_flags as $flag_key => $flag_val) {
-				$this->assertEquals($flag_val, $cookie->flags[$flag_key], "$flag_key should match supplied");
+				$this->assertSame($flag_val, $cookie->flags[$flag_key], "$flag_key should match supplied");
 			}
 		}
 	}

--- a/tests/Encoding.php
+++ b/tests/Encoding.php
@@ -74,7 +74,7 @@ class RequestsTests_Encoding extends PHPUnit_Framework_TestCase {
 	 */
 	public function testDecompress($original, $encoded) {
 		$decoded = Requests::decompress($encoded);
-		$this->assertEquals($original, $decoded);
+		$this->assertSame($original, $decoded);
 	}
 
 	/**
@@ -82,7 +82,7 @@ class RequestsTests_Encoding extends PHPUnit_Framework_TestCase {
 	 */
 	public function testCompatibleInflate($original, $encoded) {
 		$decoded = Requests::compatible_gzinflate($encoded);
-		$this->assertEquals($original, $decoded);
+		$this->assertSame($original, $decoded);
 	}
 
 	protected function bin2hex($field) {

--- a/tests/IDNAEncoder.php
+++ b/tests/IDNAEncoder.php
@@ -19,7 +19,7 @@ class RequestsTest_IDNAEncoder extends PHPUnit_Framework_TestCase {
 	 */
 	public function testEncoding($data, $expected) {
 		$result = Requests_IDNAEncoder::encode($data);
-		$this->assertEquals($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 	/**
@@ -50,22 +50,22 @@ class RequestsTest_IDNAEncoder extends PHPUnit_Framework_TestCase {
 
 	public function testASCIICharacter() {
 		$result = Requests_IDNAEncoder::encode('a');
-		$this->assertEquals('a', $result);
+		$this->assertSame('a', $result);
 	}
 
 	public function testTwoByteCharacter() {
 		$result = Requests_IDNAEncoder::encode("\xc2\xb6"); // Pilcrow character
-		$this->assertEquals('xn--tba', $result);
+		$this->assertSame('xn--tba', $result);
 	}
 
 	public function testThreeByteCharacter() {
 		$result = Requests_IDNAEncoder::encode("\xe2\x82\xac"); // Euro symbol
-		$this->assertEquals('xn--lzg', $result);
+		$this->assertSame('xn--lzg', $result);
 	}
 
 	public function testFourByteCharacter() {
 		$result = Requests_IDNAEncoder::encode("\xf0\xa4\xad\xa2"); // Chinese symbol?
-		$this->assertEquals('xn--ww6j', $result);
+		$this->assertSame('xn--ww6j', $result);
 	}
 
 	/**

--- a/tests/IRI.php
+++ b/tests/IRI.php
@@ -98,8 +98,8 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 	public function testStringRFC3986($relative, $expected)
 	{
 		$base = new Requests_IRI('http://a/b/c/d;p?q');
-		$this->assertEquals($expected, Requests_IRI::absolutize($base, $relative)->iri);
-		$this->assertEquals($expected, (string) Requests_IRI::absolutize($base, $relative));
+		$this->assertSame($expected, Requests_IRI::absolutize($base, $relative)->iri);
+		$this->assertSame($expected, (string) Requests_IRI::absolutize($base, $relative));
 	}
 
 	/**
@@ -108,8 +108,8 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 	public function testBothStringRFC3986($relative, $expected)
 	{
 		$base = 'http://a/b/c/d;p?q';
-		$this->assertEquals($expected, Requests_IRI::absolutize($base, $relative)->iri);
-		$this->assertEquals($expected, (string) Requests_IRI::absolutize($base, $relative));
+		$this->assertSame($expected, Requests_IRI::absolutize($base, $relative)->iri);
+		$this->assertSame($expected, (string) Requests_IRI::absolutize($base, $relative));
 	}
 
 	/**
@@ -150,8 +150,8 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 	public function testStringSP($base, $relative, $expected)
 	{
 		$base = new Requests_IRI($base);
-		$this->assertEquals($expected, Requests_IRI::absolutize($base, $relative)->iri);
-		$this->assertEquals($expected, (string) Requests_IRI::absolutize($base, $relative));
+		$this->assertSame($expected, Requests_IRI::absolutize($base, $relative)->iri);
+		$this->assertSame($expected, (string) Requests_IRI::absolutize($base, $relative));
 	}
 
 	/**
@@ -178,7 +178,7 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 	public function testAbsolutizeString($base, $relative, $expected)
 	{
 		$base = new Requests_IRI($base);
-		$this->assertEquals($expected, Requests_IRI::absolutize($base, $relative)->iri);
+		$this->assertSame($expected, Requests_IRI::absolutize($base, $relative)->iri);
 	}
 
 	/**
@@ -280,8 +280,8 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 	public function testStringNormalization($input, $output)
 	{
 		$input = new Requests_IRI($input);
-		$this->assertEquals($output, $input->iri);
-		$this->assertEquals($output, (string) $input);
+		$this->assertSame($output, $input->iri);
+		$this->assertSame($output, (string) $input);
 	}
 
 	/**
@@ -342,12 +342,12 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 		$iri->path = '/test/';
 		$iri->fragment = 'test';
 
-		$this->assertEquals('http', $iri->scheme);
-		$this->assertEquals('user:password', $iri->userinfo);
-		$this->assertEquals('example.com', $iri->host);
-		$this->assertEquals(80, $iri->port);
-		$this->assertEquals('/test/', $iri->path);
-		$this->assertEquals('test', $iri->fragment);
+		$this->assertSame('http', $iri->scheme);
+		$this->assertSame('user:password', $iri->userinfo);
+		$this->assertSame('example.com', $iri->host);
+		$this->assertSame(80, $iri->port);
+		$this->assertSame('/test/', $iri->path);
+		$this->assertSame('test', $iri->fragment);
 	}
 
 	public function testReadAliased()
@@ -359,12 +359,12 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 		$iri->path = '/test/';
 		$iri->fragment = 'test';
 
-		$this->assertEquals('http', $iri->ischeme);
-		$this->assertEquals('user:password', $iri->iuserinfo);
-		$this->assertEquals('example.com', $iri->ihost);
-		$this->assertEquals(80, $iri->iport);
-		$this->assertEquals('/test/', $iri->ipath);
-		$this->assertEquals('test', $iri->ifragment);
+		$this->assertSame('http', $iri->ischeme);
+		$this->assertSame('user:password', $iri->iuserinfo);
+		$this->assertSame('example.com', $iri->ihost);
+		$this->assertSame(80, $iri->iport);
+		$this->assertSame('/test/', $iri->ipath);
+		$this->assertSame('test', $iri->ifragment);
 	}
 
 	public function testWriteAliased()
@@ -376,12 +376,12 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 		$iri->ipath = '/test/';
 		$iri->ifragment = 'test';
 
-		$this->assertEquals('http', $iri->scheme);
-		$this->assertEquals('user:password', $iri->userinfo);
-		$this->assertEquals('example.com', $iri->host);
-		$this->assertEquals(80, $iri->port);
-		$this->assertEquals('/test/', $iri->path);
-		$this->assertEquals('test', $iri->fragment);
+		$this->assertSame('http', $iri->scheme);
+		$this->assertSame('user:password', $iri->userinfo);
+		$this->assertSame('example.com', $iri->host);
+		$this->assertSame(80, $iri->port);
+		$this->assertSame('/test/', $iri->path);
+		$this->assertSame('test', $iri->fragment);
 	}
 
 	/**
@@ -399,8 +399,8 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 		$iri = new Requests_IRI('http://example.com/a/?b=c#d');
 		$iri->host = null;
 
-		$this->assertEquals(null, $iri->host);
-		$this->assertEquals('http:/a/?b=c#d', (string) $iri);
+		$this->assertNull($iri->host);
+		$this->assertSame('http:/a/?b=c#d', (string) $iri);
 	}
 
 	public function testBadPort()
@@ -408,6 +408,6 @@ class RequestsTest_IRI extends PHPUnit_Framework_TestCase
 		$iri = new Requests_IRI();
 		$iri->port = 'example';
 
-		$this->assertEquals(null, $iri->port);
+		$this->assertNull($iri->port);
 	}
 }

--- a/tests/Proxy/HTTP.php
+++ b/tests/Proxy/HTTP.php
@@ -35,10 +35,10 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$response = Requests::get(httpbin('/get'), array(), $options);
-		$this->assertEquals('http', $response->headers['x-requests-proxied']);
+		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 		$data = json_decode($response->body, true);
-		$this->assertEquals('http', $data['headers']['x-requests-proxy']);
+		$this->assertSame('http', $data['headers']['x-requests-proxy']);
 	}
 
 	/**
@@ -52,10 +52,10 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$response = Requests::get(httpbin('/get'), array(), $options);
-		$this->assertEquals('http', $response->headers['x-requests-proxied']);
+		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 		$data = json_decode($response->body, true);
-		$this->assertEquals('http', $data['headers']['x-requests-proxy']);
+		$this->assertSame('http', $data['headers']['x-requests-proxy']);
 	}
 
 	/**
@@ -85,10 +85,10 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$response = Requests::get(httpbin('/get'), array(), $options);
-		$this->assertEquals('http', $response->headers['x-requests-proxied']);
+		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 		$data = json_decode($response->body, true);
-		$this->assertEquals('http', $data['headers']['x-requests-proxy']);
+		$this->assertSame('http', $data['headers']['x-requests-proxy']);
 	}
 
 	/**
@@ -106,11 +106,11 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$response = Requests::get(httpbin('/get'), array(), $options);
-		$this->assertEquals(200, $response->status_code);
-		$this->assertEquals('http', $response->headers['x-requests-proxied']);
+		$this->assertSame(200, $response->status_code);
+		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 		$data = json_decode($response->body, true);
-		$this->assertEquals('http', $data['headers']['x-requests-proxy']);
+		$this->assertSame('http', $data['headers']['x-requests-proxy']);
 	}
 
 	/**
@@ -128,6 +128,6 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$response = Requests::get(httpbin('/get'), array(), $options);
-		$this->assertEquals(407, $response->status_code);
+		$this->assertSame(407, $response->status_code);
 	}
 }

--- a/tests/Requests.php
+++ b/tests/Requests.php
@@ -11,7 +11,7 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 
 	public function testDefaultTransport() {
 		$request = Requests::get(httpbin('/get'));
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 	}
 
 	/**
@@ -44,11 +44,11 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 		$expected['empty2']    = '';
 		$expected['folded']    = 'one two  three';
 		foreach ($expected as $key => $value) {
-			$this->assertEquals($value, $response->headers[$key]);
+			$this->assertSame($value, $response->headers[$key]);
 		}
 
 		foreach ($response->headers as $key => $value) {
-			$this->assertEquals($value, $expected[$key]);
+			$this->assertSame($value, $expected[$key]);
 		}
 	}
 
@@ -63,7 +63,7 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 		);
 
 		$response = Requests::get('http://example.com/', array(), $options);
-		$this->assertEquals(1.0, $response->protocol_version);
+		$this->assertSame(1.0, $response->protocol_version);
 	}
 
 	public function testRawAccess() {
@@ -77,7 +77,7 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
-		$this->assertEquals($transport->data, $response->raw);
+		$this->assertSame($transport->data, $response->raw);
 	}
 
 	/**
@@ -91,8 +91,8 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
-		$this->assertEquals('value', $response->headers['test']);
-		$this->assertEquals('value', $response->headers['another-test']);
+		$this->assertSame('value', $response->headers['test']);
+		$this->assertSame('value', $response->headers['another-test']);
 	}
 
 	/**
@@ -152,8 +152,8 @@ class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
 			'transport' => $transport,
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
-		$this->assertEquals(302, $response->status_code);
-		$this->assertEquals(0, $response->redirects);
+		$this->assertSame(302, $response->status_code);
+		$this->assertSame(0, $response->redirects);
 	}
 
 	/**

--- a/tests/Response/Headers.php
+++ b/tests/Response/Headers.php
@@ -5,14 +5,14 @@ class RequestsTest_Response_Headers extends PHPUnit_Framework_TestCase {
 		$headers                 = new Requests_Response_Headers();
 		$headers['Content-Type'] = 'text/plain';
 
-		$this->assertEquals('text/plain', $headers['Content-Type']);
+		$this->assertSame('text/plain', $headers['Content-Type']);
 	}
 	public function testCaseInsensitiveArrayAccess() {
 		$headers                 = new Requests_Response_Headers();
 		$headers['Content-Type'] = 'text/plain';
 
-		$this->assertEquals('text/plain', $headers['CONTENT-TYPE']);
-		$this->assertEquals('text/plain', $headers['content-type']);
+		$this->assertSame('text/plain', $headers['CONTENT-TYPE']);
+		$this->assertSame('text/plain', $headers['content-type']);
 	}
 
 	/**
@@ -26,10 +26,10 @@ class RequestsTest_Response_Headers extends PHPUnit_Framework_TestCase {
 		foreach ($headers as $name => $value) {
 			switch (strtolower($name)) {
 				case 'content-type':
-					$this->assertEquals('text/plain', $value);
+					$this->assertSame('text/plain', $value);
 					break;
 				case 'content-length':
-					$this->assertEquals(10, $value);
+					$this->assertSame('10', $value);
 					break;
 				default:
 					throw new Exception('Invalid name: ' . $name);
@@ -51,6 +51,6 @@ class RequestsTest_Response_Headers extends PHPUnit_Framework_TestCase {
 		$headers['Accept'] = 'text/html;q=1.0';
 		$headers['Accept'] = '*/*;q=0.1';
 
-		$this->assertEquals('text/html;q=1.0,*/*;q=0.1', $headers['Accept']);
+		$this->assertSame('text/html;q=1.0,*/*;q=0.1', $headers['Accept']);
 	}
 }

--- a/tests/Session.php
+++ b/tests/Session.php
@@ -23,13 +23,13 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		$session         = new Requests_Session(httpbin('/'), $session_headers);
 		$response        = $session->get('/get', array('X-Requests-Request' => 'GET'));
 		$response->throw_for_status(false);
-		$this->assertEquals(200, $response->status_code);
+		$this->assertSame(200, $response->status_code);
 
 		$data = json_decode($response->body, true);
 		$this->assertArrayHasKey('X-Requests-Session', $data['headers']);
-		$this->assertEquals('BasicGET', $data['headers']['X-Requests-Session']);
+		$this->assertSame('BasicGET', $data['headers']['X-Requests-Session']);
 		$this->assertArrayHasKey('X-Requests-Request', $data['headers']);
-		$this->assertEquals('GET', $data['headers']['X-Requests-Request']);
+		$this->assertSame('GET', $data['headers']['X-Requests-Request']);
 	}
 
 	public function testBasicHEAD() {
@@ -40,7 +40,7 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		$session         = new Requests_Session(httpbin('/'), $session_headers);
 		$response        = $session->head('/get', array('X-Requests-Request' => 'HEAD'));
 		$response->throw_for_status(false);
-		$this->assertEquals(200, $response->status_code);
+		$this->assertSame(200, $response->status_code);
 	}
 
 	public function testBasicDELETE() {
@@ -51,13 +51,13 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		$session         = new Requests_Session(httpbin('/'), $session_headers);
 		$response        = $session->delete('/delete', array('X-Requests-Request' => 'DELETE'));
 		$response->throw_for_status(false);
-		$this->assertEquals(200, $response->status_code);
+		$this->assertSame(200, $response->status_code);
 
 		$data = json_decode($response->body, true);
 		$this->assertArrayHasKey('X-Requests-Session', $data['headers']);
-		$this->assertEquals('BasicDELETE', $data['headers']['X-Requests-Session']);
+		$this->assertSame('BasicDELETE', $data['headers']['X-Requests-Session']);
 		$this->assertArrayHasKey('X-Requests-Request', $data['headers']);
-		$this->assertEquals('DELETE', $data['headers']['X-Requests-Request']);
+		$this->assertSame('DELETE', $data['headers']['X-Requests-Request']);
 	}
 
 	public function testBasicPOST() {
@@ -68,13 +68,13 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		$session         = new Requests_Session(httpbin('/'), $session_headers);
 		$response        = $session->post('/post', array('X-Requests-Request' => 'POST'), array('postdata' => 'exists'));
 		$response->throw_for_status(false);
-		$this->assertEquals(200, $response->status_code);
+		$this->assertSame(200, $response->status_code);
 
 		$data = json_decode($response->body, true);
 		$this->assertArrayHasKey('X-Requests-Session', $data['headers']);
-		$this->assertEquals('BasicPOST', $data['headers']['X-Requests-Session']);
+		$this->assertSame('BasicPOST', $data['headers']['X-Requests-Session']);
 		$this->assertArrayHasKey('X-Requests-Request', $data['headers']);
-		$this->assertEquals('POST', $data['headers']['X-Requests-Request']);
+		$this->assertSame('POST', $data['headers']['X-Requests-Request']);
 	}
 
 	public function testBasicPUT() {
@@ -85,13 +85,13 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		$session         = new Requests_Session(httpbin('/'), $session_headers);
 		$response        = $session->put('/put', array('X-Requests-Request' => 'PUT'), array('postdata' => 'exists'));
 		$response->throw_for_status(false);
-		$this->assertEquals(200, $response->status_code);
+		$this->assertSame(200, $response->status_code);
 
 		$data = json_decode($response->body, true);
 		$this->assertArrayHasKey('X-Requests-Session', $data['headers']);
-		$this->assertEquals('BasicPUT', $data['headers']['X-Requests-Session']);
+		$this->assertSame('BasicPUT', $data['headers']['X-Requests-Session']);
 		$this->assertArrayHasKey('X-Requests-Request', $data['headers']);
-		$this->assertEquals('PUT', $data['headers']['X-Requests-Request']);
+		$this->assertSame('PUT', $data['headers']['X-Requests-Request']);
 	}
 
 	public function testBasicPATCH() {
@@ -102,13 +102,13 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		$session         = new Requests_Session(httpbin('/'), $session_headers);
 		$response        = $session->patch('/patch', array('X-Requests-Request' => 'PATCH'), array('postdata' => 'exists'));
 		$response->throw_for_status(false);
-		$this->assertEquals(200, $response->status_code);
+		$this->assertSame(200, $response->status_code);
 
 		$data = json_decode($response->body, true);
 		$this->assertArrayHasKey('X-Requests-Session', $data['headers']);
-		$this->assertEquals('BasicPATCH', $data['headers']['X-Requests-Session']);
+		$this->assertSame('BasicPATCH', $data['headers']['X-Requests-Session']);
 		$this->assertArrayHasKey('X-Requests-Request', $data['headers']);
-		$this->assertEquals('PATCH', $data['headers']['X-Requests-Request']);
+		$this->assertSame('PATCH', $data['headers']['X-Requests-Request']);
 	}
 
 	public function testMultiple() {
@@ -126,19 +126,19 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		// test1
 		$this->assertNotEmpty($responses['test1']);
 		$this->assertInstanceOf('Requests_Response', $responses['test1']);
-		$this->assertEquals(200, $responses['test1']->status_code);
+		$this->assertSame(200, $responses['test1']->status_code);
 
 		$result = json_decode($responses['test1']->body, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
+		$this->assertSame(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 
 		// test2
 		$this->assertNotEmpty($responses['test2']);
 		$this->assertInstanceOf('Requests_Response', $responses['test2']);
-		$this->assertEquals(200, $responses['test2']->status_code);
+		$this->assertSame(200, $responses['test2']->status_code);
 
 		$result = json_decode($responses['test2']->body, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
+		$this->assertSame(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
@@ -161,18 +161,18 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		);
 
 		$session = new Requests_Session('http://example.com/', $headers, $data, $options);
-		$this->assertEquals('http://example.com/', $session->url);
-		$this->assertEquals($headers, $session->headers);
-		$this->assertEquals($data, $session->data);
-		$this->assertEquals($options['testoption'], $session->options['testoption']);
+		$this->assertSame('http://example.com/', $session->url);
+		$this->assertSame($headers, $session->headers);
+		$this->assertSame($data, $session->data);
+		$this->assertSame($options['testoption'], $session->options['testoption']);
 
 		// Test via property access
-		$this->assertEquals($options['testoption'], $session->testoption);
+		$this->assertSame($options['testoption'], $session->testoption);
 
 		// Test setting new property
 		$session->newoption   = 'foobar';
 		$options['newoption'] = 'foobar';
-		$this->assertEquals($options['newoption'], $session->options['newoption']);
+		$this->assertSame($options['newoption'], $session->options['newoption']);
 
 		// Test unsetting property
 		unset($session->newoption);
@@ -181,7 +181,7 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		// Update property
 		$session->testoption   = 'foobar';
 		$options['testoption'] = 'foobar';
-		$this->assertEquals($options['testoption'], $session->testoption);
+		$this->assertSame($options['testoption'], $session->testoption);
 
 		// Test getting invalid property
 		$this->assertNull($session->invalidoption);
@@ -194,7 +194,7 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 			'follow_redirects' => false,
 		);
 		$response = $session->get('/cookies/set?requests-testcookie=testvalue', array(), $options);
-		$this->assertEquals(302, $response->status_code);
+		$this->assertSame(302, $response->status_code);
 
 		// Check the cookies
 		$response = $session->get('/cookies');
@@ -208,6 +208,6 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 		$cookies = array(
 			'requests-testcookie' => 'testvalue',
 		);
-		$this->assertEquals($cookies, $data['cookies']);
+		$this->assertSame($cookies, $data['cookies']);
 	}
 }

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -54,7 +54,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'max_bytes' => $limit,
 		);
 		$response = Requests::get(httpbin('/bytes/325'), array(), $this->getOptions($options));
-		$this->assertEquals($limit, strlen($response->body));
+		$this->assertSame($limit, strlen($response->body));
 	}
 
 	public function testResponseByteLimitWithFile() {
@@ -65,26 +65,26 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		);
 		$response = Requests::get(httpbin('/bytes/482'), array(), $this->getOptions($options));
 		$this->assertEmpty($response->body);
-		$this->assertEquals($limit, filesize($options['filename']));
+		$this->assertSame($limit, filesize($options['filename']));
 		unlink($options['filename']);
 	}
 
 	public function testSimpleGET() {
 		$request = Requests::get(httpbin('/get'), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
+		$this->assertSame(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
 	public function testGETWithArgs() {
 		$request = Requests::get(httpbin('/get?test=true&test2=test'), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/get?test=true&test2=test'), $result['url']);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
+		$this->assertSame(httpbin('/get?test=true&test2=test'), $result['url']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['args']);
 	}
 
 	public function testGETWithData() {
@@ -93,11 +93,11 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'test2' => 'test',
 		);
 		$request = Requests::request(httpbin('/get'), array(), $data, Requests::GET, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/get?test=true&test2=test'), $result['url']);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
+		$this->assertSame(httpbin('/get?test=true&test2=test'), $result['url']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['args']);
 	}
 
 	public function testGETWithNestedData() {
@@ -109,11 +109,11 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			),
 		);
 		$request = Requests::request(httpbin('/get'), array(), $data, Requests::GET, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/get?test=true&test2%5Btest3%5D=test&test2%5Btest4%5D=test-too'), $result['url']);
-		$this->assertEquals(array('test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'), $result['args']);
+		$this->assertSame(httpbin('/get?test=true&test2%5Btest3%5D=test&test2%5Btest4%5D=test-too'), $result['url']);
+		$this->assertSame(array('test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'), $result['args']);
 	}
 
 	public function testGETWithDataAndQuery() {
@@ -121,30 +121,30 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'test2' => 'test',
 		);
 		$request = Requests::request(httpbin('/get?test=true'), array(), $data, Requests::GET, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/get?test=true&test2=test'), $result['url']);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
+		$this->assertSame(httpbin('/get?test=true&test2=test'), $result['url']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['args']);
 	}
 
 	public function testGETWithHeaders() {
 		$headers = array(
-			'Requested-At' => time(),
+			'Requested-At' => (string) time(),
 		);
 		$request = Requests::get(httpbin('/get'), $headers, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals($headers['Requested-At'], $result['headers']['Requested-At']);
+		$this->assertSame($headers['Requested-At'], $result['headers']['Requested-At']);
 	}
 
 	public function testChunked() {
 		$request = Requests::get(httpbin('/stream/1'), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/stream/1'), $result['url']);
+		$this->assertSame(httpbin('/stream/1'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
@@ -156,16 +156,16 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 
 	public function testTRACE() {
 		$request = Requests::trace(httpbin('/trace'), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 	}
 
 	public function testRawPOST() {
 		$data    = 'test';
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals('test', $result['data']);
+		$this->assertSame('test', $result['data']);
 	}
 
 	/**
@@ -193,10 +193,10 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	public function testFormPost() {
 		$data    = 'test=true&test2=test';
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
 	}
 
 	public function testPOSTWithArray() {
@@ -205,10 +205,10 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'test2' => 'test',
 		);
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
 	}
 
 	public function testPOSTWithNestedData() {
@@ -220,28 +220,28 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			),
 		);
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(array('test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'), $result['form']);
+		$this->assertSame(array('test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'), $result['form']);
 	}
 
 	public function testRawPUT() {
 		$data    = 'test';
 		$request = Requests::put(httpbin('/put'), array(), $data, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals('test', $result['data']);
+		$this->assertSame('test', $result['data']);
 	}
 
 	public function testFormPUT() {
 		$data    = 'test=true&test2=test';
 		$request = Requests::put(httpbin('/put'), array(), $data, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
 	}
 
 	public function testPUTWithArray() {
@@ -250,28 +250,28 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'test2' => 'test',
 		);
 		$request = Requests::put(httpbin('/put'), array(), $data, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
 	}
 
 	public function testRawPATCH() {
 		$data    = 'test';
 		$request = Requests::patch(httpbin('/patch'), array(), $data, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals('test', $result['data']);
+		$this->assertSame('test', $result['data']);
 	}
 
 	public function testFormPATCH() {
 		$data    = 'test=true&test2=test';
 		$request = Requests::patch(httpbin('/patch'), array(), $data, $this->getOptions());
-		$this->assertEquals(200, $request->status_code, $request->body);
+		$this->assertSame(200, $request->status_code, $request->body);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
 	}
 
 	public function testPATCHWithArray() {
@@ -280,23 +280,23 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'test2' => 'test',
 		);
 		$request = Requests::patch(httpbin('/patch'), array(), $data, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
 	}
 
 	public function testOPTIONS() {
 		$request = Requests::options(httpbin('/options'), array(), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 	}
 
 	public function testDELETE() {
 		$request = Requests::delete(httpbin('/delete'), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/delete'), $result['url']);
+		$this->assertSame(httpbin('/delete'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
@@ -306,16 +306,16 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'test2' => 'test',
 		);
 		$request = Requests::request(httpbin('/delete'), array(), $data, Requests::DELETE, $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/delete?test=true&test2=test'), $result['url']);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['args']);
+		$this->assertSame(httpbin('/delete?test=true&test2=test'), $result['url']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['args']);
 	}
 
 	public function testLOCK() {
 		$request = Requests::request(httpbin('/lock'), array(), array(), 'LOCK', $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 	}
 
 	public function testLOCKWithData() {
@@ -324,24 +324,24 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'test2' => 'test',
 		);
 		$request = Requests::request(httpbin('/lock'), array(), $data, 'LOCK', $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
 	}
 
 	public function testRedirects() {
 		$request = Requests::get(httpbin('/redirect/6'), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
-		$this->assertEquals(6, $request->redirects);
+		$this->assertSame(6, $request->redirects);
 	}
 
 	public function testRelativeRedirects() {
 		$request = Requests::get(httpbin('/relative-redirect/6'), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
-		$this->assertEquals(6, $request->redirects);
+		$this->assertSame(6, $request->redirects);
 	}
 
 	/**
@@ -418,8 +418,8 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'transport'        => $transport,
 		);
 		$request = Requests::get($url, array(), $options);
-		$this->assertEquals($code, $request->status_code);
-		$this->assertEquals($success, $request->success);
+		$this->assertSame($code, $request->status_code);
+		$this->assertSame($success, $request->success);
 	}
 
 	/**
@@ -478,8 +478,8 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		);
 
 		$request = Requests::get(httpbin('/status/599'), array(), $options);
-		$this->assertEquals(599, $request->status_code);
-		$this->assertEquals(false, $request->success);
+		$this->assertSame(599, $request->status_code);
+		$this->assertFalse($request->success);
 	}
 
 	/**
@@ -500,10 +500,10 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 
 	public function testGzipped() {
 		$request = Requests::get(httpbin('/gzip'), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body);
-		$this->assertEquals(true, $result->gzipped);
+		$this->assertTrue($result->gzipped);
 	}
 
 	public function testStreamToFile() {
@@ -511,12 +511,12 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			'filename' => tempnam(sys_get_temp_dir(), 'RLT'), // RequestsLibraryTest
 		);
 		$request = Requests::get(httpbin('/get'), array(), $this->getOptions($options));
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 		$this->assertEmpty($request->body);
 
 		$contents = file_get_contents($options['filename']);
 		$result   = json_decode($contents, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
+		$this->assertSame(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 
 		unlink($options['filename']);
@@ -545,7 +545,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		}
 
 		$request = Requests::get(httpbin('/get', true), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
 		// Disable, since httpbin always returns http
@@ -615,7 +615,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		}
 
 		$request = Requests::head('https://badssl.com/', array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 	}
 
 	/**
@@ -631,7 +631,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		}
 
 		$request = Requests::head('https://humanmade.com/', array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 	}
 
 	/**
@@ -659,19 +659,19 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		// test1
 		$this->assertNotEmpty($responses['test1']);
 		$this->assertInstanceOf('Requests_Response', $responses['test1']);
-		$this->assertEquals(200, $responses['test1']->status_code);
+		$this->assertSame(200, $responses['test1']->status_code);
 
 		$result = json_decode($responses['test1']->body, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
+		$this->assertSame(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 
 		// test2
 		$this->assertNotEmpty($responses['test2']);
 		$this->assertInstanceOf('Requests_Response', $responses['test2']);
-		$this->assertEquals(200, $responses['test2']->status_code);
+		$this->assertSame(200, $responses['test2']->status_code);
 
 		$result = json_decode($responses['test2']->body, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
+		$this->assertSame(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
@@ -689,12 +689,12 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$responses = Requests::request_multiple($requests, $this->getOptions());
 
 		// get
-		$this->assertEquals(200, $responses['get']->status_code);
+		$this->assertSame(200, $responses['get']->status_code);
 
 		// post
-		$this->assertEquals(200, $responses['post']->status_code);
+		$this->assertSame(200, $responses['post']->status_code);
 		$result = json_decode($responses['post']->body, true);
-		$this->assertEquals('test', $result['data']);
+		$this->assertSame('test', $result['data']);
 	}
 
 	/**
@@ -713,7 +713,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			),
 		);
 		$responses = Requests::request_multiple($requests, $this->getOptions());
-		$this->assertEquals(200, $responses['success']->status_code);
+		$this->assertSame(200, $responses['success']->status_code);
 		$this->assertInstanceOf('Requests_Exception', $responses['timeout']);
 	}
 
@@ -734,7 +734,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		);
 		$responses       = Requests::request_multiple($requests, $this->getOptions($options));
 
-		$this->assertEquals($this->completed, $responses);
+		$this->assertSame($this->completed, $responses);
 		$this->completed = array();
 	}
 
@@ -756,7 +756,7 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		);
 		$responses       = Requests::request_multiple($requests, $this->getOptions($options));
 
-		$this->assertEquals($this->completed, $responses);
+		$this->assertSame($this->completed, $responses);
 		$this->completed = array();
 	}
 
@@ -786,15 +786,15 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		// GET request
 		$contents = file_get_contents($requests['get']['options']['filename']);
 		$result   = json_decode($contents, true);
-		$this->assertEquals(httpbin('/get'), $result['url']);
+		$this->assertSame(httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 		unlink($requests['get']['options']['filename']);
 
 		// POST request
 		$contents = file_get_contents($requests['post']['options']['filename']);
 		$result   = json_decode($contents, true);
-		$this->assertEquals(httpbin('/post'), $result['url']);
-		$this->assertEquals('test', $result['data']);
+		$this->assertSame(httpbin('/post'), $result['url']);
+		$this->assertSame('test', $result['data']);
 		unlink($requests['post']['options']['filename']);
 	}
 
@@ -815,10 +815,10 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 			}
 		}
 
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 		$num = preg_match('#You have reached this page on port <b>(\d+)</b>#i', $request->body, $matches);
-		$this->assertEquals(1, $num, 'Response should contain the port number');
-		$this->assertEquals(8080, $matches[1]);
+		$this->assertSame(1, $num, 'Response should contain the port number');
+		$this->assertSame('8080', $matches[1]);
 	}
 
 	public function testProgressCallback() {
@@ -862,14 +862,14 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$request1 = Requests::get(httpbin('/get'), array(), $options);
 		$request2 = Requests::get(httpbin('/get'), array(), $options);
 
-		$this->assertEquals(200, $request1->status_code);
-		$this->assertEquals(200, $request2->status_code);
+		$this->assertSame(200, $request1->status_code);
+		$this->assertSame(200, $request2->status_code);
 
 		$result1 = json_decode($request1->body, true);
 		$result2 = json_decode($request2->body, true);
 
-		$this->assertEquals(httpbin('/get'), $result1['url']);
-		$this->assertEquals(httpbin('/get'), $result2['url']);
+		$this->assertSame(httpbin('/get'), $result1['url']);
+		$this->assertSame(httpbin('/get'), $result2['url']);
 
 		$this->assertEmpty($result1['args']);
 		$this->assertEmpty($result2['args']);
@@ -878,20 +878,20 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 	public function testQueryDataFormat() {
 		$data    = array('test' => 'true', 'test2' => 'test');
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions(array('data_format' => 'query')));
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/post') . '?test=true&test2=test', $result['url']);
-		$this->assertEquals('', $result['data']);
+		$this->assertSame(httpbin('/post') . '?test=true&test2=test', $result['url']);
+		$this->assertSame('', $result['data']);
 	}
 
 	public function testBodyDataFormat() {
 		$data    = array('test' => 'true', 'test2' => 'test');
 		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions(array('data_format' => 'body')));
-		$this->assertEquals(200, $request->status_code);
+		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertEquals(httpbin('/post'), $result['url']);
-		$this->assertEquals(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(httpbin('/post'), $result['url']);
+		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
 	}
 }


### PR DESCRIPTION
This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available has been extended hugely over the years.

To have the most reliable tests, the most specific assertion should be used.

Refs:
* https://phpunit.de/manual/4.8/en/appendixes.assertions.html
* https://phpunit.readthedocs.io/en/7.5/assertions.html#

Most notably, this changes nearly all calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison and `assertSame()` does a strict type comparison.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame


---- 

Note: this change now causes two tests to fail on PHP 5.4-5.6 and three tests to fail on PHP 5.2-5.3.

Based on these test results, the methods under test are not PHP cross-version compatible as they return different results depending on the PHP version.

We'll need to decide what the desired behaviour should be and will need to adjust the code base to fix this. Input for this very welcome.

---
<details>
  <summary><b>Test failure details</b></summary>

The first two fail on all PHP 5.x builds. The third only on PHP 5.2 and 5.3.

```
There were 3 failures:
1) RequestsTest_Transport_cURL::testHEAD
Failed asserting that false is identical to ''.
/home/travis/build/rmccue/Requests/tests/Transport/Base.php:154
/home/travis/.phpenv/versions/5.2.17/bin/phpunit:46
2) RequestsTest_Transport_fsockopen::testHEAD
Failed asserting that false is identical to ''.
/home/travis/build/rmccue/Requests/tests/Transport/Base.php:154
/home/travis/.phpenv/versions/5.2.17/bin/phpunit:46
3) RequestsTest_Session::testURLResolution
Failed asserting that Requests_IRI Object (
    'scheme' => 'http'
    'iuserinfo' => null
    'ihost' => 'localhost'
    'port' => 8080
    'ipath' => '/get'
    'iquery' => null
    'ifragment' => null
    'normalization' => Array (
        'acap' => Array (
            'port' => 674
        )
        'dict' => Array (
            'port' => 2628
        )
        'file' => Array (
            'ihost' => 'localhost'
        )
        'http' => Array (
            'port' => 80
        )
        'https' => Array (
            'port' => 443
        )
    )
) is identical to 'http://localhost:8080/get'.
/home/travis/build/rmccue/Requests/tests/Session.php:10
/home/travis/.phpenv/versions/5.2.17/bin/phpunit:46
```
</details>

---