### PR TITLE
Disable deserialization in FilteredIterator

### DIFF
--- a/library/Requests/Utility/FilteredIterator.php
+++ b/library/Requests/Utility/FilteredIterator.php
@@ -42,4 +42,20 @@ class Requests_Utility_FilteredIterator extends ArrayIterator {
 		$value = call_user_func($this->callback, $value);
 		return $value;
 	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function unserialize( $serialized ) {
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function __unserialize( $serialized ) { // phpcs:ignore PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.MethodDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__unserializeFound
+	}
+
+	public function __wakeup() { // phpcs:ignore PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.MethodDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__wakeupFound
+		unset( $this->callback );
+	}
 }


### PR DESCRIPTION
WordPress 5.5.2 included a security fix to disable deserialization in `Requests_Utility_FilteredIterator`:
https://core.trac.wordpress.org/changeset/49373

This PR aims to merge that change upstream.