### PR TITLE
CS: clean up after merges

### DIFF
--- a/library/Requests/Utility/FilteredIterator.php
+++ b/library/Requests/Utility/FilteredIterator.php
@@ -46,16 +46,16 @@ class Requests_Utility_FilteredIterator extends ArrayIterator {
 	/**
 	 * @inheritdoc
 	 */
-	public function unserialize( $serialized ) {
-	}
+	public function unserialize($serialized) {}
 
 	/**
 	 * @inheritdoc
+	 *
+	 * @phpcs:disable PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__unserializeFound
 	 */
-	public function __unserialize( $serialized ) { // phpcs:ignore PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.MethodDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__unserializeFound
-	}
+	public function __unserialize($serialized) {}
 
-	public function __wakeup() { // phpcs:ignore PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.MethodDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__wakeupFound
-		unset( $this->callback );
+	public function __wakeup() {
+		unset($this->callback);
 	}
 }

--- a/tests/Utility/FilteredIterator.php
+++ b/tests/Utility/FilteredIterator.php
@@ -1,32 +1,32 @@
 <?php
 
-class RequestsTest_Requests extends PHPUnit_Framework_TestCase {
+class RequestsTest_Utility_FilteredIterator extends PHPUnit_Framework_TestCase {
 	/**
-	 * @dataProvider data_serialize_deserialize_objects
+	 * @dataProvider dataSerializeDeserializeObjects
 	 */
-	function test_deserialize_request_utility_filtered_iterator_objects( $value ) {
-		$serialized = serialize( $value );
-		if ( get_class( $value ) === 'Requests_Utility_FilteredIterator' ) {
-			$new_value = unserialize( $serialized );
-			if ( version_compare( PHP_VERSION, '5.3', '>=' ) ) {
-				$property = ( new ReflectionClass( 'Requests_Utility_FilteredIterator' ) )->getProperty( 'callback' );
-				$property->setAccessible( true );
-				$callback_value = $property->getValue( $new_value );
-				$this->assertSame( null, $callback_value );
+	public function testDeserializeRequestUtilityFilteredIteratorObjects($value) {
+		$serialized = serialize($value);
+		if (get_class($value) === 'Requests_Utility_FilteredIterator') {
+			$new_value = unserialize($serialized);
+			if (version_compare(PHP_VERSION, '5.3', '>=')) {
+				$property = (new ReflectionClass('Requests_Utility_FilteredIterator'))->getProperty('callback');
+				$property->setAccessible(true);
+				$callback_value = $property->getValue($new_value);
+				$this->assertSame(null, $callback_value);
 			} else {
 				$current_item = $new_value->current();
-				$this->assertSame( null, $current_item );
+				$this->assertSame(null, $current_item);
 			}
 		} else {
-			$this->assertEquals( $value->count(), unserialize( $serialized )->count() );
+			$this->assertEquals($value->count(), unserialize($serialized)->count());
 		}
 	}
 
-	function data_serialize_deserialize_objects() {
+	public function dataSerializeDeserializeObjects() {
 		return array(
-			array( new Requests_Utility_FilteredIterator( array( 1 ), 'md5' ) ),
-			array( new Requests_Utility_FilteredIterator( array( 1, 2 ), 'sha1' ) ),
-			array( new ArrayIterator( array( 1, 2, 3 ) ) ),
+			array(new Requests_Utility_FilteredIterator(array(1), 'md5')),
+			array(new Requests_Utility_FilteredIterator(array(1, 2), 'sha1')),
+			array(new ArrayIterator(array(1, 2, 3))),
 		);
 	}
 }


### PR DESCRIPTION
Clean up the newly introduced code.

* Use an unique class name for the test class.
* Use camelCase method names for the tests.
* Add method visibility modifiers
* Remove unnecessary whitelist comments.
* Fix up whitespace.