### PR TITLE
Requests::parse_response(): ensure URL is always a string

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -634,7 +634,7 @@ class Requests {
 		}
 
 		$return->raw  = $headers;
-		$return->url  = $url;
+		$return->url  = (string) $url;
 		$return->body = '';
 
 		if (!$options['filename']) {

--- a/tests/Session.php
+++ b/tests/Session.php
@@ -6,13 +6,21 @@ class RequestsTest_Session extends PHPUnit_Framework_TestCase {
 
 		// Set the cookies up
 		$response = $session->get('/get');
-		$this->assertTrue($response->success);
-		$this->assertEquals(httpbin('/get'), $response->url);
+		$this->assertTrue($response->success, 'Session property "success" is not equal to true');
+		$this->assertSame(
+			httpbin('/get'),
+			$response->url,
+			'Session property "url" is not equal to the expected get URL'
+		);
 
 		$data = json_decode($response->body, true);
-		$this->assertNotNull($data);
-		$this->assertArrayHasKey('url', $data);
-		$this->assertEquals(httpbin('/get'), $data['url']);
+		$this->assertNotNull($data, 'Decoded response body is null');
+		$this->assertArrayHasKey('url', $data, 'Response data array does not have key "url"');
+		$this->assertSame(
+			httpbin('/get'),
+			$data['url'],
+			'The value of the "url" key in the response data array is not equal to the expected get URL'
+		);
 	}
 
 	public function testBasicGET() {


### PR DESCRIPTION
This fixes an issue on PHP 5.2/5.3 where the `Requests_Response::__toString()` method would not always automagically be invoked.

I've verified that this is the only place in the application where the `Requests_Response::$url` property is being set.

I considered making the property `private` and adding magic setter/getter methods, but that would open the class up to injection of other non-public properties, which is not the intention of this change.

Includes:
* Making the tests which cover this property use a strict typed assertion.
* Adding "failure messages" to the various assertions in this test to more easily be able to distinguish which assertion has failed.