### PR TITLE
Requests::parse_response(): ensure `body` is always a string

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -633,8 +633,9 @@ class Requests {
 			return $return;
 		}
 
-		$return->raw = $headers;
-		$return->url = $url;
+		$return->raw  = $headers;
+		$return->url  = $url;
+		$return->body = '';
 
 		if (!$options['filename']) {
 			$pos = strpos($headers, "\r\n\r\n");
@@ -643,11 +644,12 @@ class Requests {
 				throw new Requests_Exception('Missing header/body separator', 'requests.no_crlf_separator');
 			}
 
-			$headers      = substr($return->raw, 0, $pos);
-			$return->body = substr($return->raw, $pos + strlen("\n\r\n\r"));
-		}
-		else {
-			$return->body = '';
+			$headers = substr($return->raw, 0, $pos);
+			// Headers will always be separated from the body by two new lines - `\n\r\n\r`.
+			$body = substr($return->raw, $pos + 4);
+			if (!empty($body)) {
+				$return->body = $body;
+			}
 		}
 		// Pretend CRLF = LF for compatibility (RFC 2616, section 19.3)
 		$headers = str_replace("\r\n", "\n", $headers);

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -150,8 +150,8 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 
 	public function testHEAD() {
 		$request = Requests::head(httpbin('/get'), array(), $this->getOptions());
-		$this->assertEquals(200, $request->status_code);
-		$this->assertEquals('', $request->body);
+		$this->assertSame(200, $request->status_code);
+		$this->assertSame('', $request->body);
 	}
 
 	public function testTRACE() {


### PR DESCRIPTION
This fixes an issue on PHP < 7.0, where the value of `Requests_Response::$body` could be `false` when there was no response body.

The behaviour of the `substr()` method has seen some (undocumented) changes across PHP versions.

In PHP < 7.0, the method would return `false` if `$start` was equal to the length of the subject string.
As of PHP 7.0, the method will return an empty string in that case and only return `false` if `$start` is _beyond_ the length of the subject string.
In PHP 8.0, this will change yet again and the function will no longer return `false` ever, but will return an empty string in all "failure" cases.

Knowing this, checking the return value of `substr()` with `empty()` is the most appropriate course of action.

I've verified that this is the only place in the application where the `Requests_Response::$body` property is being set.

Includes:
* Making the tests which cover this property use a strict typed assertion.