### PR TITLE
CI/QA: add code style check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,6 @@ tests/ export-ignore
 .coveralls.yml export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore
+.phpcs.xml.dist export-ignore
 .travis.yml export-ignore
 package.xml.tpl export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ tests/coverage/*
 # Ignore composer related files
 /composer.lock
 /vendor
+
+# Ignore local overrides of the PHPCS config file.
+.phpcs.xml
+phpcs.xml

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -83,6 +83,13 @@
 		<!-- Let spacing before a cast be determined by the operator/parentheses whitespace rule
 			 of the preceding character. -->
 		<exclude name="WordPress.WhiteSpace.CastStructureSpacing"/>
+
+		<!-- ==========================================================================
+			 Forbid "assignments in conditions" instead of enforcing Yoda conditions.
+			 ========================================================================== -->
+		<exclude name="WordPress.PHP.YodaConditions"/>
+		<!-- A while loop is the only valid control structure where an assignment can be justified. -->
+		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
 	</rule>
 
 
@@ -134,5 +141,10 @@
 			<property name="spacing" value="0"/>
 		</properties>
 	</rule>
+
+	<!-- ==========================================================================
+		 Disallow Yoda conditions.
+		 ========================================================================== -->
+	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
 
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -41,7 +41,10 @@
 	-->
 
 	<config name="testVersion" value="5.2-"/>
-	<rule ref="PHPCompatibility"/>
+	<rule ref="PHPCompatibility">
+		<!-- The example code may contain code samples targetted at PHP > 5.2. -->
+		<exclude-pattern>/examples/*\.php$</exclude-pattern>
+	</rule>
 
 
 	<!--

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -58,6 +58,81 @@
 		<!-- No need for this sniff as PHP linting is included in the CI builds against
 			 multiple PHP versions (which is the better solution). -->
 		<exclude name="Generic.PHP.Syntax"/>
+
+		<!-- ==========================================================================
+			 No "nacin-spacing". I.e. don't enforce whitespace on the inside of braces and such.
+			 ========================================================================== -->
+
+		<!-- Replace by the Squiz version of the sniff which is space-poor in contrast
+			 to the space-rich WPCS sniff. -->
+		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
+
+		<!-- Replaced by the Squiz version of the sniff which doesn't enforce whitespace
+			 around the boolean not `!` operator and enforcement via the Generic sniff. -->
+		<exclude name="WordPress.WhiteSpace.OperatorSpacing"/>
+
+		<!-- Replaced by the Squiz version of the sniff which doesn't enforce whitespace around array index keys. -->
+		<exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
+
+		<!-- Disabled as the preference for this repo is no spaces on the inside of parentheses.
+			 Once WPCS 3.0.0 comes out, the opposite can be enforced via the
+			 NormalizedArrays.Arrays.ArrayBraceSpacing sniff from PHPCSExtra. -->
+		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceAfterArrayOpener"/>
+		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceBeforeArrayCloser"/>
+
+		<!-- Let spacing before a cast be determined by the operator/parentheses whitespace rule
+			 of the preceding character. -->
+		<exclude name="WordPress.WhiteSpace.CastStructureSpacing"/>
+	</rule>
+
+
+	<!-- ==========================================================================
+		 Enforcement of space-poor code style.
+		 ========================================================================== -->
+
+	<!-- Overrule the properties set in the WP Core ruleset for several sniffs. -->
+	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+		<properties>
+			<property name="requiredSpacesAfterOpen" value="0"/>
+			<property name="requiredSpacesBeforeClose" value="0"/>
+		</properties>
+		<!-- Undo the WPCS severity change (exclusion) for spacing before close -->
+		<severity>5</severity>
+	</rule>
+
+	<rule ref="PEAR.Functions.FunctionCallSignature">
+		<properties>
+			<property name="requiredSpacesAfterOpen" value="0"/>
+			<property name="requiredSpacesBeforeClose" value="0"/>
+		</properties>
+	</rule>
+
+	<rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing">
+		<properties>
+			<property name="spacing" value="0"/>
+		</properties>
+	</rule>
+
+	<!-- Include replacement sniffs which enforce the opposite of WPCS for several excluded sniffs. -->
+	<rule ref="Squiz.WhiteSpace.ControlStructureSpacing">
+		<!-- Note: These two violations should potentially be addressed at a later point in time. -->
+		<exclude name="Squiz.WhiteSpace.ControlStructureSpacing.NoLineAfterClose"/>
+		<exclude name="Squiz.WhiteSpace.ControlStructureSpacing.LineAfterClose"/>
+	</rule>
+
+	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
+		<properties>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
+
+	<rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+
+	<!-- Enforce no space after the boolean not `!` operator. -->
+	<rule ref="Generic.Formatting.SpaceAfterNot">
+		<properties>
+			<property name="spacing" value="0"/>
+		</properties>
 	</rule>
 
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -90,6 +90,25 @@
 		<exclude name="WordPress.PHP.YodaConditions"/>
 		<!-- A while loop is the only valid control structure where an assignment can be justified. -->
 		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
+
+		<!-- ==========================================================================
+			 Miscellaneous other exclusions.
+			 ========================================================================== -->
+
+		<!-- This repo complies with PSR 0 for filename conventions. -->
+		<exclude name="WordPress.Files.FileName"/>
+
+		<!-- This code base consistently has the second keyword of multi-part control structures
+			 on a new line.
+			 Once WPCS 3.0.0 comes out, the style used in this repo can be enforced via the
+			 Universal.ControlStructures.IfElseDeclaration sniff from PHPCSExtra. -->
+		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
+
+		<!-- Ignore WP specific sniffs as Requests is also used outside of a WP context. -->
+		<exclude name="WordPress.WP"/>
+		<exclude name="WordPress.DateTime"/>
+		<exclude name="WordPress.Security"/>
+		<exclude name="WordPress.PHP.DiscouragedPHPFunctions"/>
 	</rule>
 
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -166,4 +166,46 @@
 		 ========================================================================== -->
 	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
 
+
+	<!--
+	#############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	#############################################################################
+	-->
+
+	<!-- Allow error silencing only for a select group of functions. -->
+	<rule ref="WordPress.PHP.NoSilencedErrors">
+		<properties>
+			<property name="custom_whitelist" type="array">
+				<element value="gzdecode"/>
+				<element value="gzinflate"/>
+				<element value="gzuncompress"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Make sure everything in the global namespace is prefixed. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="Requests"/>
+			</property>
+		</properties>
+		
+		<!-- Only code within the actual distributed package needs to be prefixed. -->
+		<include-pattern>/library/*\.php$</include-pattern>
+	</rule>
+
+	<!-- Simplify alignment rules for multiline arrays. -->
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<!-- No need to adjust alignment of large arrays when the item with the largest key is removed. -->
+			<property name="exact" value="false"/>
+			<!-- Don't align multi-line items if ALL items in the array are multi-line. -->
+			<property name="alignMultilineItems" value="!=100"/>
+			<!-- The array assignment operator should always be on the same line as the array key. -->
+			<property name="ignoreNewlines" value="false"/>
+		</properties>
+	</rule>
+
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	name="Requests"
+	xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+	<description>Requests rules for PHP_CodeSniffer</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
+	-->
+
+	<!-- Scan all files. -->
+	<file>.</file>
+
+	<!-- Third party files and build files don't need to comply with these coding standards. -->
+	<exclude-pattern>*/library/Requests/IRI\.php$</exclude-pattern>
+	<exclude-pattern>*/tests/IRI\.php$</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/tests/coverage/</exclude-pattern>
+
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Show progress, show the error codes for each message (source). -->
+	<arg value="ps"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+
+	<!--
+	#############################################################################
+	CHECK FOR PHP CROSS-VERSION COMPATIBILITY
+	#############################################################################
+	-->
+
+	<config name="testVersion" value="5.2-"/>
+	<rule ref="PHPCompatibility"/>
+
+
+	<!--
+	#############################################################################
+	CODING STYLE RULES
+	#############################################################################
+	-->
+
+	<!-- Use the WordPress Coding Standards as a basis, but with tweaks. -->
+	<rule ref="WordPress-Extra">
+		<!-- No need for this sniff as PHP linting is included in the CI builds against
+			 multiple PHP versions (which is the better solution). -->
+		<exclude name="Generic.PHP.Syntax"/>
+	</rule>
+
+</ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -208,4 +208,63 @@
 		</properties>
 	</rule>
 
+
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	Exclude specific files for specific sniffs.
+	#############################################################################
+	-->
+
+	<!-- ==========================================================================
+		 Package code
+		 ========================================================================== -->
+
+	<!-- Don't rename existing classes to prevent a BC break. -->
+	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
+		<exclude-pattern>*/Transport/cURL\.php$</exclude-pattern>
+		<exclude-pattern>*/Transport/fsockopen\.php$</exclude-pattern>
+	</rule>
+
+	<!-- ==========================================================================
+		 Example code
+		 ========================================================================== -->
+
+	<!-- Using PHP 5.4+ syntax in example code is fine. -->
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+		<exclude-pattern>/examples/cookie_jar\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Using var_dump() in example code is fine. -->
+	<rule ref="WordPress.PHP.DevelopmentFunctions.error_log_var_dump">
+		<exclude-pattern>/examples/[^/]+\.php$</exclude-pattern>
+	</rule>
+
+	<!-- ==========================================================================
+		 Test code
+		 ========================================================================== -->
+
+	<!-- The PHPUnit6-compat file is only loaded on PHP 7.0 or higher. -->
+	<rule ref="PHPCompatibility.FunctionUse.NewFunctions.class_aliasFound">
+		<exclude-pattern>/tests/phpunit6-compat\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound">
+		<exclude-pattern>/tests/phpunit6-compat\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Tests aren't run on PHP 5.2.0 anymore, so just ignore this. -->
+	<rule ref="PHPCompatibility.FunctionUse.NewFunctions.sys_get_temp_dirFound">
+		<exclude-pattern>/tests/Transport/Base\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Overloaded methods to make the expected exceptions more specific. -->
+	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod">
+		<exclude-pattern>/tests/Transport/*\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Allow single-line multi-item associative arrays in the unit tests. -->
+	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,26 @@
 dist: xenial
 language: php
+
+stages:
+  - sniff
+  - test
+
 jobs:
   fast_finish: true
   include:
-   - php: 5.2
+   - stage: sniff
+     php: 7.4
+     install:
+       - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+       - travis_retry composer install --no-interaction
+     before_script: skip
+     script:
+       # Check the code against the coding standards.
+       - composer checkcs
+     after_script: skip
+
+   - stage: test
+     php: 5.2
      dist: precise
      env: COMPOSER_PHPUNIT=false
    - php: 5.3
@@ -29,6 +46,7 @@ jobs:
      env: COMPOSER_PHPUNIT=true
    - php: nightly
      env: COMPOSER_PHPUNIT=true
+
   allow_failures:
     - php: nightly
       env: COMPOSER_PHPUNIT=true
@@ -52,6 +70,12 @@ install:
  - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then travis_retry composer remove phpunit/phpunit --dev; fi
  - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then export PHPUNIT_BIN="phpunit";
    else export PHPUNIT_BIN="$(pwd)/vendor/bin/phpunit";
+   fi
+ - |
+   if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" ]]; then
+    # The PHPCS dependencies require PHP 5.4, so would block istall on PHP < 5.4.
+    # As they are only needed in the sniff stage, remove them.
+    travis_retry composer remove --dev --no-update phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer
    fi
  - travis_retry composer install --dev --no-interaction
  - TESTPHPBIN=$(phpenv which php)

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" ]]; then
     # The PHPCS dependencies require PHP 5.4, so would block istall on PHP < 5.4.
     # As they are only needed in the sniff stage, remove them.
-    travis_retry composer remove --dev --no-update phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer
+    travis_retry composer remove --dev --no-update squizlabs/php_codesniffer phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer
    fi
  - travis_retry composer install --dev --no-interaction
  - TESTPHPBIN=$(phpenv which php)

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 	"require-dev": {
 		"requests/test-server": "dev-master",
 		"phpunit/phpunit": "<6.0",
+		"squizlabs/php_codesniffer": "^3.5",
 		"phpcompatibility/php-compatibility": "^9.0",
 		"wp-coding-standards/wpcs": "^2.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7"

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,21 @@
 	},
 	"require-dev": {
 		"requests/test-server": "dev-master",
-		"phpunit/phpunit": "<6.0"
+		"phpunit/phpunit": "<6.0",
+		"phpcompatibility/php-compatibility": "^9.0",
+		"wp-coding-standards/wpcs": "^2.0",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7"
 	},
 	"type": "library",
 	"autoload": {
 		"psr-0": {"Requests": "library/"}
+	},
+	"scripts" : {
+		"checkcs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+		],
+		"fixcs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+		]
 	}
 }

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -830,6 +830,7 @@ class Requests {
 		}
 
 		if (function_exists('gzdecode')) {
+			// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.gzdecodeFound -- Wrapped in function_exists() for PHP 5.2.
 			$decoded = @gzdecode($data);
 			if ($decoded !== false) {
 				return $decoded;

--- a/library/Requests/IDNAEncoder.php
+++ b/library/Requests/IDNAEncoder.php
@@ -141,6 +141,7 @@ class Requests_IDNAEncoder {
 		// Get number of bytes
 		$strlen = strlen($input);
 
+		// phpcs:ignore Generic.CodeAnalysis.JumbledIncrementer -- This is a deliberate choice.
 		for ($position = 0; $position < $strlen; $position++) {
 			$value = ord($input[$position]);
 

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -100,9 +100,11 @@ class Requests_Transport_cURL implements Requests_Transport {
 			curl_setopt($this->handle, CURLOPT_ENCODING, '');
 		}
 		if (defined('CURLOPT_PROTOCOLS')) {
+			// phpcs:ignore PHPCompatibility.Constants.NewConstants.curlopt_protocolsFound
 			curl_setopt($this->handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 		}
 		if (defined('CURLOPT_REDIR_PROTOCOLS')) {
+			// phpcs:ignore PHPCompatibility.Constants.NewConstants.curlopt_redir_protocolsFound
 			curl_setopt($this->handle, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 		}
 	}
@@ -364,6 +366,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 			curl_setopt($this->handle, CURLOPT_TIMEOUT, ceil($timeout));
 		}
 		else {
+			// phpcs:ignore PHPCompatibility.Constants.NewConstants.curlopt_timeout_msFound
 			curl_setopt($this->handle, CURLOPT_TIMEOUT_MS, round($timeout * 1000));
 		}
 
@@ -371,6 +374,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 			curl_setopt($this->handle, CURLOPT_CONNECTTIMEOUT, ceil($options['connect_timeout']));
 		}
 		else {
+			// phpcs:ignore PHPCompatibility.Constants.NewConstants.curlopt_connecttimeout_msFound
 			curl_setopt($this->handle, CURLOPT_CONNECTTIMEOUT_MS, round($options['connect_timeout'] * 1000));
 		}
 		curl_setopt($this->handle, CURLOPT_URL, $url);

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -81,6 +81,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 			$verifyname      = true;
 
 			// SNI, if enabled (OpenSSL >=0.9.8j)
+			// phpcs:ignore PHPCompatibility.Constants.NewConstants.openssl_tlsext_server_nameFound
 			if (defined('OPENSSL_TLSEXT_SERVER_NAME') && OPENSSL_TLSEXT_SERVER_NAME) {
 				$context_options['SNI_enabled'] = true;
 				if (isset($options['verifyname']) && $options['verifyname'] === false) {

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -118,6 +118,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		}
 		$remote_socket .= ':' . $url_parts['port'];
 
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler(array($this, 'connect_error_handler'), E_WARNING | E_NOTICE);
 
 		$options['hooks']->dispatch('fsockopen.remote_socket', array(&$remote_socket));

--- a/tests/Cookies.php
+++ b/tests/Cookies.php
@@ -379,11 +379,11 @@ class RequestsTest_Cookies extends PHPUnit_Framework_TestCase {
 			// Basic parsing
 			array(
 				'foo=bar',
-				array( 'name' => 'foo', 'value' => 'bar' ),
+				array('name' => 'foo', 'value' => 'bar'),
 			),
 			array(
 				'bar',
-				array( 'name' => '', 'value' => 'bar' ),
+				array('name' => '', 'value' => 'bar'),
 			),
 
 			// Expiration

--- a/tests/Utility/FilteredIterator.php
+++ b/tests/Utility/FilteredIterator.php
@@ -9,6 +9,7 @@ class RequestsTest_Utility_FilteredIterator extends PHPUnit_Framework_TestCase {
 		if (get_class($value) === 'Requests_Utility_FilteredIterator') {
 			$new_value = unserialize($serialized);
 			if (version_compare(PHP_VERSION, '5.3', '>=')) {
+				// phpcs:ignore PHPCompatibility.Syntax.NewClassMemberAccess.OnNewFound -- Wrapped in version check.
 				$property = (new ReflectionClass('Requests_Utility_FilteredIterator'))->getProperty('callback');
 				$property->setAccessible(true);
 				$callback_value = $property->getValue($new_value);


### PR DESCRIPTION
## QA: add code style check for the code in this repo

This PR:
* Adds `dev` requirements for the WP Coding Standards, PHPCompatibility and the DealerDirect Composer PHPCS plugin.
* Adds a custom PHPCS ruleset which uses the `WordPress-Extra` ruleset to check the code style and code quality of code in this repo and the `PHPCompatibility` standard to test for PHP cross-version compatibility.
* Adds convenience scripts to the `composer.json` file to check the code of the repo.
* Allows for individual developers to overload the `.phpcs.xml.dist` file by ignoring the typical overload files.
* Adds the CS check to the Travis script in a separate stage.
    The CS check only needs to be run on one build, preferably against a high PHP version.
    To that end, I've set up stages and added the CS check to a separate `stage`.
    Ref: https://docs.travis-ci.com/user/build-stages/
    Also note that the PHPCS dependencies have a minimum supported PHP version of PHP 5.4, while this repo still supports PHP 5.2.
    To prevent a failing `composer install` on PHP < 5.4, the PHPCS related dependencies are removed for the `test` stage.

Note:
The WordPress Coding Standards were chosen as the basis for the code style checks as most contributors to this repo originate from the WordPress community and will be familiar with this code style.

Main differences from the WordPress Coding Standards based on a discussion last year with Ryan + an analysis of the code styles used in the code base as-it-was:
* No "nacin-spacing", i.e. no whitespace on the inside of parentheses.
* No Yoda conditions. The WPCS Yoda conditions check does not prevent assignments in conditions anyway and it decreases readbility. Instead, a "no assignments in conditions" rule which is included in `WordPress-Extra` is enforced.

Also note that the `WordPress-Docs` checks are not enabled. This may be added at a later point in time. Enabling the scan at this time would, however, yield over 900 violations which would still need to be fixed first.

## PHPCS ruleset: implementation examples can use different PHP minimum

Don't enforce the PHP 5.2 minimum supported PHP version on the code samples in the `examples` folder.
It's perfectly fine for some of those code samples to show implementation examples targetted at a higher minimum PHP version.

## PHPCS ruleset: enforce "space-poor" code style

See the inline documentation in the ruleset for full details.

## PHPCS ruleset: forbid Yoda conditions

Instead forbid _assignments in conditions_ which is what Yoda is supposed to be about anyway.

The only exception made is for `while()` loops in which assignments in condition can actually be a valid choice.

As the `Generic.ControlStructures.DisallowYodaConditions` sniff used for enforcing this is only available since PHPCS 3.5.0, the PHPCS package is also added to the `composer.json` file.

Normally, this wouldn't be needed and shouldn't be done as such requirements might conflict with the requirements from the other PHPCS related dependencies, but their minimum supported PHPCS version is lower than PHPCS 3.5.0, so we need to enforce that PHPCS 3.5.0 or newer is installed.

Currently, WPCS requires a minimum of PHPCS 3.3.1 and PHPCompatibility a minimum of PHPCS 2.3 or 3.0.2.

Once the minimum supported PHPCS version for (one of) these external standards used goes up to `3.5.0`, the requirement in the Requests' `composer.json` file should be removed to prevent future conflicts.

## PHPCS ruleset: exclude various other rules

### `WordPress.Files.FileName`

This repo uses PSR-0 for the class name determination, which conflicts with the WPCS rules, so ignoring the WPCS sniff.

There is currently no sniff available to enforce PSR-0.

### `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace`

This contrast with the code style used in the code base as-is. The opposite can in the future be enforced once PHPCSExtra 1.0 has been tagged (which will be included in WPCS 3.0.0).

### Ignore various WP specific sniffs.

As Requests is a stand-alone library, sniffs referring to WordPress native functions or doing things "the WordPress way" are irrelevant.

## PHPCS ruleset: add minimal sniff specific configuration

Certain sniffs will only work when given some more information (`PrefixAllGlobals`), others will be less noisy with some minimal configuration.

This adds such configuration for three sniffs coming from WPCS.

### `WordPress.PHP.NoSilencedErrors`

Some PHP function will throw warnings in certain situations which cannot be avoided, no matter how much error checking is done ahead of the function call.
This whitelists three such functions used in the `Requests` library to be allowed to use error silencing.

### `WordPress.NamingConventions.PrefixAllGlobals`

The `PrefixAllGlobals` sniff will only work when it knows which prefix is desired.

In addition, code which is not part of the distributed package as used by consumers of this package - i.e. tests, build script etc - does not have to comply with the "prefix all globals" rules.

### `WordPress.Arrays.MultipleStatementAlignment`

The standard configuration for arrow alignment in multi-line arrays can be quite fiddly.
This overloads the WordPress defaults to use a slightly more sane configuration.

## PHPCS ruleset: add very selective file based exceptions

Add some very selective file name based exceptions to the rules for various reasons as documented in the ruleset with each individual exception.

## PHPCS: whitelist select compatibility issues

... as they are surrounded by the correct safeguards for cross-version compatibility.

## PHPCS: whitelist select QA issues

# CS: minor additional fixes

Few more tiny fixes for issues found while cleaning up the ruleset.

