### PR TITLE
Run tests against  PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ stages:
   - sniff
   - test
 
+env:
+  - COMPOSER_PHPUNIT=true
+
 jobs:
   fast_finish: true
   include:
@@ -33,23 +36,16 @@ jobs:
      dist: trusty
      env: COMPOSER_PHPUNIT=false
    - php: 5.6
-     env: TEST_COVERAGE=1 COMPOSER_PHPUNIT=true
+     env: TEST_COVERAGE=1
    - php: 7.0
-     env: COMPOSER_PHPUNIT=true
    - php: 7.1
-     env: COMPOSER_PHPUNIT=true
    - php: 7.2
-     env: COMPOSER_PHPUNIT=true
    - php: 7.3
-     env: COMPOSER_PHPUNIT=true
    - php: 7.4
-     env: COMPOSER_PHPUNIT=true
    - php: nightly
-     env: COMPOSER_PHPUNIT=true
 
   allow_failures:
     - php: nightly
-      env: COMPOSER_PHPUNIT=true
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,8 +62,8 @@ install:
  - if [ "$TEST_COVERAGE" != '1' ]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
 
  # Setup the test server
- - phpenv local $( phpenv versions | grep 5.6 | tail -1 )
- - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then travis_retry composer remove phpunit/phpunit --dev; fi
+ - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then phpenv local $( phpenv versions | grep 5.6 | tail -1 ); fi
+ - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then travis_retry composer remove --dev --no-update phpunit/phpunit; fi
  - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then export PHPUNIT_BIN="phpunit";
    else export PHPUNIT_BIN="$(pwd)/vendor/bin/phpunit";
    fi
@@ -73,9 +73,14 @@ install:
     # As they are only needed in the sniff stage, remove them.
     travis_retry composer remove --dev --no-update squizlabs/php_codesniffer phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer
    fi
- - travis_retry composer install --dev --no-interaction
+ - |
+   if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    travis_retry composer install --no-interaction --ignore-platform-reqs
+   else
+    travis_retry composer install --no-interaction
+   fi
  - TESTPHPBIN=$(phpenv which php)
- - phpenv local --unset
+ - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then phpenv local --unset; fi
 
  # Setup the proxy
  - pip install --user mitmproxy==0.18.2

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,12 @@
 		],
 		"fixcs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+		],
+		"test": [
+			"@php ./vendor/phpunit/phpunit/phpunit -c ./tests/phpunit.xml.dist --no-coverage"
+		],
+		"coverage": [
+			"@php ./vendor/phpunit/phpunit/phpunit -c ./tests/phpunit.xml.dist"
 		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	},
 	"require-dev": {
 		"requests/test-server": "dev-master",
-		"phpunit/phpunit": "<6.0",
+		"phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5",
 		"squizlabs/php_codesniffer": "^3.5",
 		"phpcompatibility/php-compatibility": "^9.0",
 		"wp-coding-standards/wpcs": "^2.0",

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -443,6 +443,10 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 				$this->setExpectedException('Requests_Exception', null);
 			}
 		}
+
+		// Prevent a "test does not perform any assertions" message for all other cases.
+		$this->assertTrue(true);
+
 		$request = Requests::get($url, array(), $options);
 		$request->throw_for_status(false);
 	}
@@ -465,6 +469,10 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 				$this->setExpectedException('Requests_Exception_HTTP_' . $code, null, $code);
 			}
 		}
+
+		// Prevent a "test does not perform any assertions" message for all other cases.
+		$this->assertTrue(true);
+
 		$request = Requests::get($url, array(), $options);
 		$request->throw_for_status(true);
 	}

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -827,6 +827,13 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		$this->assertSame('8080', $matches[1]);
 	}
 
+	/**
+	 * This test will be skipped on PHP 8 as it would fail due to the use of an incompatible
+	 * PHPUnit version. Once the test suite is compatible with PHPUnit 9, this "requires" can
+	 * be removed.
+	 *
+	 * @requires PHP < 8
+	 */
 	public function testProgressCallback() {
 		$mock = $this->getMockBuilder('stdClass')->setMethods(array('progress'))->getMock();
 		$mock->expects($this->atLeastOnce())->method('progress');
@@ -840,6 +847,13 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		Requests::get(httpbin('/get'), array(), $options);
 	}
 
+	/**
+	 * This test will be skipped on PHP 8 as it would fail due to the use of an incompatible
+	 * PHPUnit version. Once the test suite is compatible with PHPUnit 9, this "requires" can
+	 * be removed.
+	 *
+	 * @requires PHP < 8
+	 */
 	public function testAfterRequestCallback() {
 		$mock = $this->getMockBuilder('stdClass')
 			->setMethods(array('after_request'))

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="bootstrap.php" verbose="true">
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+	backupGlobals="true"
+	bootstrap="bootstrap.php"
+	colors="true"
+	verbose="true"
+	>
 	<testsuites>
 		<testsuite name="Authentication">
 			<directory suffix=".php">Auth</directory>
@@ -24,16 +31,11 @@
 	</testsuites>
 
 	<logging>
-		<log type="coverage-html" target="coverage" title="PHPUnit"
-			charset="UTF-8" yui="true" highlight="true"
-			lowUpperBound="35" highLowerBound="90"/>
+		<log type="coverage-html" target="coverage" lowUpperBound="35" highLowerBound="90"/>
 	</logging>
 
 	<filter>
-		<blacklist>
-			<directory suffix=".php">.</directory>
-		</blacklist>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true">
 			<directory suffix=".php">../library</directory>
 		</whitelist>
 	</filter>


### PR DESCRIPTION
Slightly simpler alternative for #428 to allow the tests to run on PHP 8 for now (save for two tests).

Based on this set up, we can conclude that for the code covered by the current tests, the library is compatible with PHP 8.

Closes #428 

/cc @TimothyBJacobs

## Commit details

### Travis: simplify setting of `COMPOSER_PHPUNIT` env variable

### Composer: add convenience scripts for running the tests

### Tests: fix PHPUnit configuration

The PHPUnit configuration did not validate against any available PHPUnit XSD file.

This stabilizes the file and annotates against which XSD it has been validated.

Notes:
* The default value of the `backupGlobals` option has changed in PHPUnit 6 from `true` to `false`.
    Setting this explicitly to `true` for cross-version compatibility.
* The file will now validate against the PHPUnit XSD for PHPUnit 4.4 up to 9.2.

### Composer: allow installation of a wider range of PHPUnit versions

### Travis: allow installing PHPUnit 7.5 on nightly

### RequestsTest_Transport_Base::testStatusCodeThrow*(): prevent marking as risky

These two tests set exception expectations in a limited set of circumstances. In all other circumstances they basically test that *no* exception is being thrown.

As in the "no exception" cases, no other assertions are performed, the tests would be marked as "risky".

By doing a simple `assertTrue()`, we prevent the test being marked as risky, while maintaining the existing test functionality.

### Tests: selectively skip two tests on PHP 8

... as they would fail due to the PHPUnit version being used not being compatible with PHP 8.

Once the test suite has been made compatible with PHPUnit 9.x, these tests should be able to run fine on PHP 8.

