### PR TITLE
Documentation: link review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,8 +555,8 @@ default
 - [Add Composer support][#6] - You can now install Requests via the
   `rmccue/requests` package on Composer
 
-[docs/proxy]: http://requests.ryanmccue.info/docs/proxy.html
-[docs/usage-advanced]: http://requests.ryanmccue.info/docs/usage-advanced.html
+[docs/proxy]: https://requests.ryanmccue.info/docs/proxy.html
+[docs/usage-advanced]: https://requests.ryanmccue.info/docs/usage-advanced.html
 
 [#1]: https://github.com/WordPress/Requests/issues/1
 [#2]: https://github.com/WordPress/Requests/issues/2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Requests for PHP
 [![CS](https://github.com/WordPress/Requests/actions/workflows/cs.yml/badge.svg)](https://github.com/WordPress/Requests/actions/workflows/cs.yml)
 [![Lint](https://github.com/WordPress/Requests/actions/workflows/lint.yml/badge.svg)](https://github.com/WordPress/Requests/actions/workflows/lint.yml)
 [![Test](https://github.com/WordPress/Requests/actions/workflows/test.yml/badge.svg)](https://github.com/WordPress/Requests/actions/workflows/test.yml)
-[![codecov.io](http://codecov.io/github/WordPress/Requests/coverage.svg?branch=stable)](http://codecov.io/github/WordPress/Requests?branch=stable)
+[![codecov.io](https://codecov.io/gh/WordPress/Requests/branch/stable/graph/badge.svg?token=AfpxK7WMxj&branch=stable)](https://codecov.io/gh/WordPress/Requests?branch=stable)
 
 Requests is a HTTP library written in PHP, for human beings. It is roughly
 based on the API from the excellent [Requests Python
@@ -135,7 +135,7 @@ Testing
 Requests strives to have 100% code-coverage of the library with an extensive
 set of tests. We're not quite there yet, but [we're getting close][codecov].
 
-[codecov]: http://codecov.io/github/WordPress/Requests
+[codecov]: https://codecov.io/github/WordPress/Requests/
 
 To run the test suite, first check that you have the [PHP
 JSON extension ](https://www.php.net/book.json) enabled. Then

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ the new BSD license) and has no dependencies, except for PHP 5.6+.
 
 Despite PHP's use as a language for the web, its tools for sending HTTP requests
 are severely lacking. cURL has an
-[interesting API](http://php.net/manual/en/function.curl-setopt.php), to say the
+[interesting API](https://www.php.net/curl-setopt), to say the
 least, and you can't always rely on it being available. Sockets provide only low
 level access, and require you to build most of the HTTP response parsing
 yourself.
@@ -138,7 +138,7 @@ set of tests. We're not quite there yet, but [we're getting close][codecov].
 [codecov]: http://codecov.io/github/WordPress/Requests
 
 To run the test suite, first check that you have the [PHP
-JSON extension ](http://php.net/manual/en/book.json.php) enabled. Then
+JSON extension ](https://www.php.net/book.json) enabled. Then
 simply:
 ```bash
 $ phpunit

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -49,7 +49,7 @@ Available Hooks
 
     Parameters: `string &$response, array &$info`
 
-    `$info` contains the associated array as defined in the return value for [curl_getinfo()](http://php.net/manual/en/function.curl-getinfo.php#refsect1-function.curl-getinfo-returnvalues).
+    `$info` contains the associated array as defined in the return value for [curl_getinfo()](https://www.php.net/curl-getinfo#refsect1-function.curl-getinfo-returnvalues).
 
 * **`fsockopen.before_request`**
 
@@ -77,7 +77,7 @@ Available Hooks
 
     Parameters: `string &$response, array &$info`
 
-    `$info` contains the associated array as defined in the return value for [stream_get_meta_data()](http://php.net/manual/en/function.stream-get-meta-data.php#refsect1-function.stream-get-meta-data-returnvalues).
+    `$info` contains the associated array as defined in the return value for [stream_get_meta_data()](https://www.php.net/stream-get-meta-data#refsect1-function.stream-get-meta-data-returnvalues).
 
 
 

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -66,7 +66,7 @@ first PHP HTTP library to fully support SSL verification.
 See also the [related PHP][php-bug-47030] and [OpenSSL-related][php-bug-55820]
 bugs in PHP for more information on Subject Alternate Name field.
 
-[Mozilla certificate authority list]: http://www.mozilla.org/projects/security/certs/
+[Mozilla certificate authority list]: https://www.mozilla.org/projects/security/certs/
 [php-bug-47030]: https://php.net/47030
 [php-bug-55820]: https://php.net/55820
 

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -67,8 +67,8 @@ See also the [related PHP][php-bug-47030] and [OpenSSL-related][php-bug-55820]
 bugs in PHP for more information on Subject Alternate Name field.
 
 [Mozilla certificate authority list]: http://www.mozilla.org/projects/security/certs/
-[php-bug-47030]: https://bugs.php.net/bug.php?id=47030
-[php-bug-55820]:https://bugs.php.net/bug.php?id=55820
+[php-bug-47030]: https://php.net/47030
+[php-bug-55820]: https://php.net/55820
 
 ***
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,7 +54,7 @@ You'll probably also want to pass in some data. You can pass in either a
 string, an array or an object (Requests uses [`http_build_query`][build_query]
 internally) as the third parameter (after the URL and headers):
 
-[build_query]: http://php.net/http_build_query
+[build_query]: https://www.php.net/http_build_query
 
 ```php
 $data = array('key1' => 'value1', 'key2' => 'value2');

--- a/docs/why-requests.md
+++ b/docs/why-requests.md
@@ -62,7 +62,7 @@ Why should I use Requests?
 [hooking system]: hooks.md
 [requests_ssl]: https://github.com/WordPress/Requests/blob/stable/library/Requests/SSL.php
 [ghactions]: https://github.com/WordPress/Requests/actions
-[wpssl]: http://core.trac.wordpress.org/ticket/25007
+[wpssl]: https://core.trac.wordpress.org/ticket/25007
 
 
 Why shouldn't I use...

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -872,8 +872,8 @@ class Requests {
 	 *
 	 * @since 2.8.1
 	 * @link https://core.trac.wordpress.org/ticket/18273
-	 * @link https://secure.php.net/manual/en/function.gzinflate.php#70875
-	 * @link https://secure.php.net/manual/en/function.gzinflate.php#77336
+	 * @link https://www.php.net/gzinflate#70875
+	 * @link https://www.php.net/gzinflate#77336
 	 *
 	 * @param string $gz_data String to decompress.
 	 * @return string|bool False on failure.

--- a/library/Requests/IPv6.php
+++ b/library/Requests/IPv6.php
@@ -30,7 +30,7 @@ class Requests_IPv6 {
 	 * @author elfrink at introweb dot nl
 	 * @author Josh Peck <jmp at joshpeck dot org>
 	 * @copyright 2003-2005 The PHP Group
-	 * @license http://www.opensource.org/licenses/bsd-license.php
+	 * @license https://opensource.org/licenses/bsd-license.php
 	 * @param string $ip An IPv6 address
 	 * @return string The uncompressed IPv6 address
 	 */

--- a/library/Requests/IRI.php
+++ b/library/Requests/IRI.php
@@ -43,7 +43,7 @@
  * @author Geoffrey Sneddon
  * @author Steve Minutillo
  * @copyright 2007-2009 Geoffrey Sneddon and Steve Minutillo
- * @license http://www.opensource.org/licenses/bsd-license.php
+ * @license https://opensource.org/licenses/bsd-license.php
  * @link http://hg.gsnedders.com/iri/
  *
  * @property string $iri IRI we're working with

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -33,7 +33,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 	/**
 	 * Information on the current request
 	 *
-	 * @var array cURL information array, see {@see https://secure.php.net/curl_getinfo}
+	 * @var array cURL information array, see {@see https://www.php.net/curl_getinfo}
 	 */
 	public $info;
 
@@ -513,7 +513,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 	 * Format a URL given GET data
 	 *
 	 * @param string $url
-	 * @param array|object $data Data to build query using, see {@see https://secure.php.net/http_build_query}
+	 * @param array|object $data Data to build query using, see {@see https://www.php.net/http_build_query}
 	 * @return string URL with data
 	 */
 	protected static function format_get($url, $data) {

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -30,7 +30,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 	/**
 	 * Stream metadata
 	 *
-	 * @var array Associative array of properties, see {@see https://secure.php.net/stream_get_meta_data}
+	 * @var array Associative array of properties, see {@see https://www.php.net/stream_get_meta_data}
 	 */
 	public $info;
 
@@ -351,7 +351,7 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 	 * Format a URL given GET data
 	 *
 	 * @param array $url_parts
-	 * @param array|object $data Data to build query using, see {@see https://secure.php.net/http_build_query}
+	 * @param array|object $data Data to build query using, see {@see https://www.php.net/http_build_query}
 	 * @return string URL with data
 	 */
 	protected static function format_get($url_parts, $data) {

--- a/tests/IRI.php
+++ b/tests/IRI.php
@@ -35,7 +35,7 @@
  * @package IRI
  * @author Geoffrey Sneddon
  * @copyright 2008-2010 Geoffrey Sneddon
- * @license http://www.opensource.org/licenses/bsd-license.php
+ * @license https://opensource.org/licenses/bsd-license.php
  * @link http://hg.gsnedders.com/iri/
  *
  */

--- a/tests/SSL.php
+++ b/tests/SSL.php
@@ -97,7 +97,7 @@ class RequestsTest_SSL extends PHPUnit_Framework_TestCase {
 	 * As per RFC2818, if the SAN field exists, we should parse that and ignore
 	 * the value of the CN field.
 	 *
-	 * @link http://tools.ietf.org/html/rfc2818#section-3.1
+	 * @link https://tools.ietf.org/html/rfc2818#section-3.1
 	 */
 	public function testIgnoreCNWithSAN() {
 		$certificate = $this->fakeCertificate('example.net', 'example.com');


### PR DESCRIPTION
### Documentation: php.net link review

Reviewed all links, both in user facing documentation as well as in code documentation, for:
* Use of `https`
* Use of `www` (saves a redirect)
* Use of language agnostic permalinks as per https://www.php.net/urlhowto.php

Fixes #480

### Documentation: reviewed other links

... for correctness and use of `https`.

Note: this review explicitly did not change any URLs used in example code or in tests.

