### PR TITLE
Add .editorconfig file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 codecov:
-    notify:
-        after_n_builds: 2
+  notify:
+    after_n_builds: 2
 
 coverage:
   round: nearest

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{*.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/composer.json
+++ b/composer.json
@@ -1,64 +1,74 @@
 {
-    "name": "rmccue/requests",
-    "description": "A HTTP library written in PHP, for human beings.",
-    "homepage": "https://requests.ryanmccue.info/",
-    "license": "ISC",
-    "keywords": ["http", "idna", "iri", "ipv6", "curl", "sockets", "fsockopen"],
-    "authors": [
-        {
-            "name": "Ryan McCue",
-            "homepage": "https://rmccue.io/"
-        },
-        {
-            "name" : "Alain Schlesser",
-            "homepage" : "https://github.com/schlessera"
-        },
-        {
-            "name" : "Juliette Reinders Folmer",
-            "homepage" : "https://github.com/jrfnl"
-        },
-        {
-            "name" : "Contributors",
-            "homepage" : "https://github.com/WordPress/Requests/graphs/contributors"
-        }
-    ],
-    "support" : {
-        "issues" : "https://github.com/WordPress/Requests/issues",
-        "source" : "https://github.com/WordPress/Requests",
-        "docs"   : "https://requests.ryanmccue.info/"
+  "name": "rmccue/requests",
+  "description": "A HTTP library written in PHP, for human beings.",
+  "homepage": "https://requests.ryanmccue.info/",
+  "license": "ISC",
+  "keywords": [
+    "http",
+    "idna",
+    "iri",
+    "ipv6",
+    "curl",
+    "sockets",
+    "fsockopen"
+  ],
+  "authors": [
+    {
+      "name": "Ryan McCue",
+      "homepage": "https://rmccue.io/"
     },
-    "require": {
-        "php": ">=5.6"
+    {
+      "name": "Alain Schlesser",
+      "homepage": "https://github.com/schlessera"
     },
-    "require-dev": {
-        "requests/test-server": "dev-master",
-        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
-        "squizlabs/php_codesniffer": "^3.5",
-        "phpcompatibility/php-compatibility": "^9.0",
-        "wp-coding-standards/wpcs": "^2.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "php-parallel-lint/php-parallel-lint": "^1.3",
-        "php-parallel-lint/php-console-highlighter": "^0.5.0"
+    {
+      "name": "Juliette Reinders Folmer",
+      "homepage": "https://github.com/jrfnl"
     },
-    "type": "library",
-    "autoload": {
-        "psr-0": {"Requests": "library/"}
-    },
-    "scripts" : {
-        "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
-        ],
-        "checkcs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
-        ],
-        "fixcs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
-        ],
-        "test": [
-            "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
-        ],
-        "coverage": [
-            "@php ./vendor/phpunit/phpunit/phpunit"
-        ]
+    {
+      "name": "Contributors",
+      "homepage": "https://github.com/WordPress/Requests/graphs/contributors"
     }
+  ],
+  "support": {
+    "issues": "https://github.com/WordPress/Requests/issues",
+    "source": "https://github.com/WordPress/Requests",
+    "docs": "https://requests.ryanmccue.info/"
+  },
+  "require": {
+    "php": ">=5.6"
+  },
+  "require-dev": {
+    "requests/test-server": "dev-master",
+    "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
+    "squizlabs/php_codesniffer": "^3.5",
+    "phpcompatibility/php-compatibility": "^9.0",
+    "wp-coding-standards/wpcs": "^2.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+    "php-parallel-lint/php-parallel-lint": "^1.3",
+    "php-parallel-lint/php-console-highlighter": "^0.5.0"
+  },
+  "type": "library",
+  "autoload": {
+    "psr-0": {
+      "Requests": "library/"
+    }
+  },
+  "scripts": {
+    "lint": [
+      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+    ],
+    "checkcs": [
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+    ],
+    "fixcs": [
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+    ],
+    "test": [
+      "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+    ],
+    "coverage": [
+      "@php ./vendor/phpunit/phpunit/phpunit"
+    ]
+  }
 }


### PR DESCRIPTION
This PR adds an `.editorconfig` file to let the IDE know how to handle newlines, tabs/spaces, etc. for the project.

This avoids commits like this one, as the IDE will automatically deal with this: https://github.com/WordPress/Requests/pull/446/commits/228ec26ce827ee9081743a16fbdfc35dba45e320