### PR TITLE
Add Requests::has_capability() which can be used to determine if SSL is available.

### DIFF
--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -56,6 +56,16 @@ Alternatively, if you want to disable verification completely, this is possible
 with `'verify' => false`, but note that this is extremely insecure and should be
 avoided.
 
+Note that SSL verification might not be available depending on what extensions
+are enabled for your PHP environment. You can test whether Requests has
+access to a transport with SSL capabilities with the following call:
+
+```php
+use WpOrg\Requests\Capability;
+
+$ssl_available = WpOrg\Requests\Requests::test(array(Capability::SSL => true));
+```
+
 ### Security Note
 Requests supports SSL across both cURL and fsockopen in a transparent manner.
 Unlike other PHP HTTP libraries, support for verifying the certificate name is

--- a/src/Capability.php
+++ b/src/Capability.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Capability interface declaring the known capabilities.
+ *
+ * @package Requests\Utilities
+ */
+
+namespace WpOrg\Requests;
+
+/**
+ * Capability interface declaring the known capabilities.
+ *
+ * This is used as the authoritative source for which capabilities can be queried.
+ *
+ * @package Requests\Utilities
+ */
+interface Capability {
+
+	/**
+	 * Support for SSL.
+	 *
+	 * @var string
+	 */
+	const SSL = 'ssl';
+
+	/**
+	 * Collection of all capabilities supported in Requests.
+	 *
+	 * Note: this does not automatically mean that the capability will be supported for your chosen transport!
+	 *
+	 * @var array<string>
+	 */
+	const ALL = array(
+		self::SSL,
+	);
+}

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -34,8 +34,12 @@ interface Transport {
 	public function request_multiple($requests, $options);
 
 	/**
-	 * Self-test whether the transport can be used
-	 * @return bool
+	 * Self-test whether the transport can be used.
+	 *
+	 * The available capabilities to test for can be found in {@see \WpOrg\Requests\Capability}.
+	 *
+	 * @param array<string, bool> $capabilities Optional. Associative array of capabilities to test against, i.e. `['<capability>' => true]`.
+	 * @return bool Whether the transport can be used.
 	 */
-	public static function test();
+	public static function test($capabilities = array());
 }

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -9,6 +9,7 @@ namespace WpOrg\Requests\Transport;
 
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
+use WpOrg\Requests\Capability;
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Exception\Transport\Curl as CurlException;
@@ -563,10 +564,13 @@ final class Curl implements Transport {
 	}
 
 	/**
-	 * Whether this transport is valid
+	 * Self-test whether the transport can be used.
+	 *
+	 * The available capabilities to test for can be found in {@see \WpOrg\Requests\Capability}.
 	 *
 	 * @codeCoverageIgnore
-	 * @return boolean True if the transport is valid, false otherwise.
+	 * @param array<string, bool> $capabilities Optional. Associative array of capabilities to test against, i.e. `['<capability>' => true]`.
+	 * @return bool Whether the transport can be used.
 	 */
 	public static function test($capabilities = array()) {
 		if (!function_exists('curl_init') || !function_exists('curl_exec')) {
@@ -574,7 +578,7 @@ final class Curl implements Transport {
 		}
 
 		// If needed, check that our installed curl version supports SSL
-		if (isset($capabilities['ssl']) && $capabilities['ssl']) {
+		if (isset($capabilities[Capability::SSL]) && $capabilities[Capability::SSL]) {
 			$curl_version = curl_version();
 			if (!(CURL_VERSION_SSL & $curl_version['features'])) {
 				return false;

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -7,6 +7,7 @@
 
 namespace WpOrg\Requests\Transport;
 
+use WpOrg\Requests\Capability;
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Port;
@@ -448,10 +449,13 @@ final class Fsockopen implements Transport {
 	}
 
 	/**
-	 * Whether this transport is valid
+	 * Self-test whether the transport can be used.
+	 *
+	 * The available capabilities to test for can be found in {@see \WpOrg\Requests\Capability}.
 	 *
 	 * @codeCoverageIgnore
-	 * @return boolean True if the transport is valid, false otherwise.
+	 * @param array<string, bool> $capabilities Optional. Associative array of capabilities to test against, i.e. `['<capability>' => true]`.
+	 * @return bool Whether the transport can be used.
 	 */
 	public static function test($capabilities = array()) {
 		if (!function_exists('fsockopen')) {
@@ -459,7 +463,7 @@ final class Fsockopen implements Transport {
 		}
 
 		// If needed, check that streams support SSL
-		if (isset($capabilities['ssl']) && $capabilities['ssl']) {
+		if (isset($capabilities[Capability::SSL]) && $capabilities[Capability::SSL]) {
 			if (!extension_loaded('openssl') || !function_exists('openssl_x509_parse')) {
 				return false;
 			}

--- a/tests/Fixtures/RawTransportMock.php
+++ b/tests/Fixtures/RawTransportMock.php
@@ -18,7 +18,7 @@ final class RawTransportMock implements Transport {
 
 		return $requests;
 	}
-	public static function test() {
+	public static function test($capabilities = array()) {
 		return true;
 	}
 }

--- a/tests/Fixtures/TestTransportMock.php
+++ b/tests/Fixtures/TestTransportMock.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Fixtures;
+
+use WpOrg\Requests\Transport;
+
+final class TestTransportMock implements Transport {
+	public function request($url, $headers = array(), $data = array(), $options = array()) {
+		return '';
+	}
+	public function request_multiple($requests, $options) {
+		return array();
+	}
+	public static function test($capabilities = array()) {
+		// Time travel is not yet supported by this transport.
+		if (isset($capabilities['time-travel']) && $capabilities['time-travel']) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/tests/Fixtures/TransportMock.php
+++ b/tests/Fixtures/TransportMock.php
@@ -91,7 +91,7 @@ final class TransportMock implements Transport {
 		return $responses;
 	}
 
-	public static function test() {
+	public static function test($capabilities = array()) {
 		return true;
 	}
 }

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -3,6 +3,7 @@
 namespace WpOrg\Requests\Tests\Transport;
 
 use stdClass;
+use WpOrg\Requests\Capability;
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\Http\StatusUnknown;
 use WpOrg\Requests\Exception\InvalidArgument;
@@ -17,15 +18,17 @@ abstract class BaseTestCase extends TestCase {
 	protected $skip_https = false;
 
 	public function set_up() {
-		$callback  = array($this->transport, 'test');
-		$supported = call_user_func($callback);
+		// Intermediary variable $test_method. This can be simplified (removed) once the minimum supported PHP version is 7.0 or higher.
+		$test_method = array($this->transport, 'test');
+
+		$supported = $test_method();
 
 		if (!$supported) {
 			$this->markTestSkipped($this->transport . ' is not available');
 			return;
 		}
 
-		$ssl_supported = call_user_func($callback, array('ssl' => true));
+		$ssl_supported = $test_method(array(Capability::SSL => true));
 		if (!$ssl_supported) {
 			$this->skip_https = true;
 		}


### PR DESCRIPTION
_Note: this is a recreation of PR #251, which was closed due to the branch rename and the remote no longer existing._
_Please see PR #251 for the original discussion on the PR._

Add `Requests::has_capability()` which can be used to determine if SSL is available.

An example of it's usage: `Requests::has_capability( array( Capability::SSL => true ) );`

See #250 and #251

/cc @dd32


---

After review of the original PR, the following additional changes have been made and are included in this commit:
* Add a `WpOrg\Requests\Capability` interface which holds constants for the queryable capabilities.
* Split the `Requests::get_transport()` method in two:
    * `Requests::get_transport_class()` which will retrieve the fully qualified class name for a working transport and will cache the result.
    * `Requests::get_transport()` to get an instantiated instance of a working transport, same as before.
* Adjusting the `Transport` interface and classes implementing it, to take a `$capabilities` parameter for the `test()` method and use the constants from the `Capability` interface internally.
* Add tests for the new `Requests::has_capabilities()` method.
* Update the `Transport` related tests and mocks.
* Add a usage example to the prose documentation.