### PR TITLE
Use select() syscall to avoid busy waiting

### DIFF
--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -245,6 +245,10 @@ final class Curl implements Transport {
 		do {
 			$active = 0;
 
+			if ($active) {
+				curl_multi_select($multihandle);
+			}
+
 			do {
 				$status = curl_multi_exec($multihandle, $active);
 			}


### PR DESCRIPTION
_Note: this is a recreation of PR #110, which was closed due to the branch rename and the remote no longer existing._
_Please see PR #110 for the original discussion on the PR._

Currently it consumes a lot of CPU, it's a no-brainer i think.

/cc @diegode