### PR TITLE
max_bytes not respected in a performant manner

### DIFF
--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -210,7 +210,7 @@ final class Curl implements Transport {
 
 		if ($curl_errno === CURLE_WRITE_ERROR
 			&& $this->response_byte_limit
-			&& $this->response_bytes === $this->response_byte_limit
+			&& $this->response_bytes >= $this->response_byte_limit
 		) {
 			// Not actually an error in this case. We've drained all the data from the request that we want.
 			$curl_errno = false;
@@ -497,7 +497,7 @@ final class Curl implements Transport {
 		$curl_errno = curl_errno($this->handle);
 		if ($curl_errno === CURLE_WRITE_ERROR
 			&& $this->response_byte_limit
-			&& $this->response_bytes === $this->response_byte_limit
+			&& $this->response_bytes >= $this->response_byte_limit
 		) {
 			// Not actually an error in this case. We've drained all the data from the request that we want.
 			$curl_errno = false;
@@ -566,7 +566,9 @@ final class Curl implements Transport {
 		}
 
 		if ($this->stream_handle) {
-			fwrite($this->stream_handle, $data);
+			if ($data !== '') {
+				fwrite($this->stream_handle, $data);
+			}
 		} else {
 			$this->response_data .= $data;
 		}

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -208,8 +208,11 @@ final class Curl implements Transport {
 
 		$curl_errno = curl_errno($this->handle);
 
-		if ($curl_errno === CURLE_WRITE_ERROR && $this->response_byte_limit && $this->response_byte_limit === $this->response_bytes) {
-			// Not actually an error in this case. We've drained as much data from the request that we want.
+		if ($curl_errno === CURLE_WRITE_ERROR
+			&& $this->response_byte_limit
+			&& $this->response_bytes === $this->response_byte_limit
+		) {
+			// Not actually an error in this case. We've drained all the data from the request that we want.
 			$curl_errno = false;
 		}
 
@@ -492,8 +495,11 @@ final class Curl implements Transport {
 		}
 
 		$curl_errno = curl_errno($this->handle);
-		if ($curl_errno === CURLE_WRITE_ERROR && $this->response_byte_limit && $this->response_byte_limit === $this->response_bytes) {
-			// Not actually an error in this case. We've drained as much data from the request that we want.
+		if ($curl_errno === CURLE_WRITE_ERROR
+			&& $this->response_byte_limit
+			&& $this->response_bytes === $this->response_byte_limit
+		) {
+			// Not actually an error in this case. We've drained all the data from the request that we want.
 			$curl_errno = false;
 		}
 

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -206,7 +206,14 @@ final class Curl implements Transport {
 
 		$options['hooks']->dispatch('curl.after_send', []);
 
-		if (curl_errno($this->handle) === CURLE_WRITE_ERROR || curl_errno($this->handle) === CURLE_BAD_CONTENT_ENCODING) {
+		$curl_errno = curl_errno($this->handle);
+
+		if ($curl_errno === CURLE_WRITE_ERROR && $this->response_byte_limit && $this->response_byte_limit === $this->response_bytes) {
+			// Not actually an error in this case. We've drained as much data from the request that we want.
+			$curl_errno = false;
+		}
+
+		if ($curl_errno === CURLE_WRITE_ERROR || $curl_errno === CURLE_BAD_CONTENT_ENCODING) {
 			// Reset encoding and try again
 			curl_setopt($this->handle, CURLOPT_ENCODING, 'none');
 
@@ -484,7 +491,13 @@ final class Curl implements Transport {
 			$this->headers .= $response;
 		}
 
-		if (curl_errno($this->handle)) {
+		$curl_errno = curl_errno($this->handle);
+		if ($curl_errno === CURLE_WRITE_ERROR && $this->response_byte_limit && $this->response_byte_limit === $this->response_bytes) {
+			// Not actually an error in this case. We've drained as much data from the request that we want.
+			$curl_errno = false;
+		}
+
+		if ($curl_errno) {
 			$error = sprintf(
 				'cURL error %s: %s',
 				curl_errno($this->handle),
@@ -539,15 +552,10 @@ final class Curl implements Transport {
 
 		// Are we limiting the response size?
 		if ($this->response_byte_limit) {
-			if ($this->response_bytes === $this->response_byte_limit) {
-				// Already at maximum, move on
-				return $data_length;
-			}
-
 			if (($this->response_bytes + $data_length) > $this->response_byte_limit) {
 				// Limit the length
-				$limited_length = ($this->response_byte_limit - $this->response_bytes);
-				$data           = substr($data, 0, $limited_length);
+				$data_length = ($this->response_byte_limit - $this->response_bytes);
+				$data        = substr($data, 0, $data_length);
 			}
 		}
 
@@ -557,7 +565,7 @@ final class Curl implements Transport {
 			$this->response_data .= $data;
 		}
 
-		$this->response_bytes += strlen($data);
+		$this->response_bytes += $data_length;
 		return $data_length;
 	}
 

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -305,8 +305,8 @@ final class Fsockopen implements Transport {
 			if ($doingbody) {
 				$options['hooks']->dispatch('request.progress', [$block, $size, $this->max_bytes]);
 				$data_length = strlen($block);
-				if ($this->max_bytes) {
 
+				if ($this->max_bytes) {
 					if (($size + $data_length) > $this->max_bytes) {
 						// Limit the length
 						$data_length = ($this->max_bytes - $size);

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -306,23 +306,24 @@ final class Fsockopen implements Transport {
 				$options['hooks']->dispatch('request.progress', [$block, $size, $this->max_bytes]);
 				$data_length = strlen($block);
 				if ($this->max_bytes) {
-					// Have we already hit a limit?
-					if ($size === $this->max_bytes) {
-						continue;
-					}
 
 					if (($size + $data_length) > $this->max_bytes) {
 						// Limit the length
-						$limited_length = ($this->max_bytes - $size);
-						$block          = substr($block, 0, $limited_length);
+						$data_length = ($this->max_bytes - $size);
+						$block       = substr($block, 0, $data_length);
 					}
 				}
 
-				$size += strlen($block);
+				$size += $data_length;
 				if ($download) {
 					fwrite($download, $block);
 				} else {
 					$body .= $block;
+				}
+
+				// Have we hit a limit?
+				if ($this->max_bytes && $size === $this->max_bytes) {
+					break;
 				}
 			}
 		}

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -322,7 +322,7 @@ final class Fsockopen implements Transport {
 				}
 
 				// Have we hit a limit?
-				if ($this->max_bytes && $size === $this->max_bytes) {
+				if ($this->max_bytes && $size >= $this->max_bytes) {
 					break;
 				}
 			}

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -55,8 +55,9 @@ abstract class BaseTestCase extends TestCase {
 		$limit    = 104;
 		$options  = [
 			'max_bytes' => $limit,
+			'hooks'     => $this->getMaxBytesAssertionHooks(),
 		];
-		$response = Requests::get($this->httpbin('/bytes/325'), [], $this->getOptions($options));
+		$response = Requests::get($this->httpbin('/bytes/1000000'), [], $this->getOptions($options));
 		$this->assertSame($limit, strlen($response->body));
 	}
 
@@ -64,6 +65,7 @@ abstract class BaseTestCase extends TestCase {
 		$limit    = 300;
 		$options  = [
 			'max_bytes' => $limit,
+			'hooks'     => $this->getMaxBytesAssertionHooks(),
 			'filename'  => tempnam(sys_get_temp_dir(), 'RLT'), // RequestsLibraryTest
 		];
 		$response = Requests::get($this->httpbin('/bytes/482'), [], $this->getOptions($options));
@@ -1194,5 +1196,31 @@ abstract class BaseTestCase extends TestCase {
 
 		$this->assertSame(200, $request->status_code);
 		$this->assertSame('/get', substr($request->url, -4));
+	}
+
+	/**
+	 * Get a Hooks instance that asserts correct enforcement for max_bytes.
+	 *
+	 * @return Hooks
+	 */
+	protected function getMaxBytesAssertionHooks()
+	{
+		$hooks = new Hooks();
+
+		$hooks->register(
+			'request.progress',
+			function ($block, $size, $max_bytes) {
+				static $passed_max_bytes = false;
+				$this->assertFalse(
+					$passed_max_bytes,
+					'Failed asserting that body download was stopped as soon as max_bytes was reached.'
+				);
+				if ($size >= $max_bytes) {
+					$passed_max_bytes = true;
+				}
+			}
+		);
+
+		return $hooks;
 	}
 }

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -1209,13 +1209,13 @@ abstract class BaseTestCase extends TestCase {
 		$hooks->register(
 			'request.progress',
 			function ($block, $size, $max_bytes) {
-				static $passed_max_bytes = false;
+				static $surpassed_max_bytes = false;
 				$this->assertFalse(
-					$passed_max_bytes,
+					$surpassed_max_bytes,
 					'Failed asserting that body download was stopped as soon as max_bytes was reached.'
 				);
 				if ($size >= $max_bytes) {
-					$passed_max_bytes = true;
+					$surpassed_max_bytes = true;
 				}
 			}
 		);

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -1214,7 +1214,7 @@ abstract class BaseTestCase extends TestCase {
 					$surpassed_max_bytes,
 					'Failed asserting that body download was stopped as soon as max_bytes was reached.'
 				);
-				if ($size >= $max_bytes) {
+				if ((strlen($block) + $size) >= $max_bytes) {
 					$surpassed_max_bytes = true;
 				}
 			}

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -68,7 +68,7 @@ abstract class BaseTestCase extends TestCase {
 			'hooks'     => $this->getMaxBytesAssertionHooks(),
 			'filename'  => tempnam(sys_get_temp_dir(), 'RLT'), // RequestsLibraryTest
 		];
-		$response = Requests::get($this->httpbin('/bytes/482'), [], $this->getOptions($options));
+		$response = Requests::get($this->httpbin('/bytes/1000000'), [], $this->getOptions($options));
 		$this->assertEmpty($response->body);
 		$this->assertSame($limit, filesize($options['filename']));
 		unlink($options['filename']);
@@ -1203,8 +1203,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @return Hooks
 	 */
-	protected function getMaxBytesAssertionHooks()
-	{
+	protected function getMaxBytesAssertionHooks() {
 		$hooks = new Hooks();
 
 		$hooks->register(

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -1209,14 +1209,11 @@ abstract class BaseTestCase extends TestCase {
 		$hooks->register(
 			'request.progress',
 			function ($block, $size, $max_bytes) {
-				static $surpassed_max_bytes = false;
-				$this->assertFalse(
-					$surpassed_max_bytes,
+				$this->assertLessThanOrEqual(
+					$max_bytes,
+					$size,
 					'Failed asserting that body download was stopped as soon as max_bytes was reached.'
 				);
-				if ((strlen($block) + $size) >= $max_bytes) {
-					$surpassed_max_bytes = true;
-				}
 			}
 		);
 


### PR DESCRIPTION
_Note: this is a recreation of PR #337, which was closed due to the branch rename and the remote no longer existing._
_Please see PR #337 for the original discussion on the PR._

With some testing I was noticing that a request for 100 byes from a 10MB file was timing out after 5 seconds.

Turns out that the cause was that Requests downloads the full 10MB file in order to return the first 100 bytes of it.

This PR simply aborts the connection when enough bytes have been read from the stream.

/cc @dd32