### PR TITLE
PHP 8.1: fix deprecation notices in `Requests_Transport_cURL`

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -342,7 +342,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 				$data = '';
 			}
 			elseif (!is_string($data)) {
-				$data = http_build_query($data, null, '&');
+				$data = http_build_query($data, '', '&');
 			}
 		}
 
@@ -527,7 +527,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 				$query = $url_parts['query'];
 			}
 
-			$query .= '&' . http_build_query($data, null, '&');
+			$query .= '&' . http_build_query($data, '', '&');
 			$query  = trim($query, '&');
 
 			if (empty($url_parts['query'])) {


### PR DESCRIPTION
The `Requests_Transport_cURL::setup_handle()` and `Requests_Transport_cURL::format_get()` methods, both call the PHP native `http_build_query()` function.
The second parameter of which is the _optional_ `$numeric_prefix` parameter which expects a `string`.

A parameter being optional, however, does not automatically make it nullable.

As of PHP 8.1, passing `null` to a non-nullable PHP native function will generate a deprecation notice.
In this case, both these function calls yielded a `http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated` notice.

Changing the `null` to an empty string fixes this without BC-break.

This change is already covered by tests as 15 of the existing tests failed on these function calls when running the tests on PHP 8.1.

Refs:
* https://www.php.net/manual/en/function.http-build-query.php
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg