### PR TITLE
GH Actions: run tests against PHP 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
           coverage: ${{ steps.set_cov.outputs.COV }}
           tools: cs2pr
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,9 @@ jobs:
             experimental: false
 
           # Test against PHP Nightly.
-          # This should be enabled once the PHPUnit version constraints have been widened.
-          #- php: '8.1'
-          #  coverage: false
-          #  experimental: true
+          - php: '8.1'
+            coverage: false
+            experimental: true
 
     name: "Test: PHP ${{ matrix.php }}"
 


### PR DESCRIPTION
Now PR #446 has been merged and the PHPUnit version requirements widened, we can start running the tests against PHP 8.1.

For the time being - until PHP 8.1 is actually released - these builds are allowed to fail (experimental), though fixing as much as possible as soon as possible, would be a good idea ;-)

Fixes #498

---

**Edit**: I've added a second commit.

### GH Actions: set error reporting to E_ALL

Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.