### PR TITLE
Implement requests pool 

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -147,20 +147,6 @@ class Requests_Transport_cURL implements Requests_Transport {
 			$this->response_byte_limit = $options['max_bytes'];
 		}
 
-		if (isset($options['verify'])) {
-			if ($options['verify'] === false) {
-				curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
-				curl_setopt($this->handle, CURLOPT_SSL_VERIFYPEER, 0);
-			}
-			elseif (is_string($options['verify'])) {
-				curl_setopt($this->handle, CURLOPT_CAINFO, $options['verify']);
-			}
-		}
-
-		if (isset($options['verifyname']) && $options['verifyname'] === false) {
-			curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
-		}
-
 		curl_exec($this->handle);
 		$response = $this->response_data;
 
@@ -409,6 +395,20 @@ class Requests_Transport_cURL implements Requests_Transport {
 			curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, array($this, 'stream_headers'));
 			curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, array($this, 'stream_body'));
 			curl_setopt($this->handle, CURLOPT_BUFFERSIZE, Requests::BUFFER_SIZE);
+		}
+
+		if (isset($options['verify'])) {
+			if ($options['verify'] === false) {
+				curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
+				curl_setopt($this->handle, CURLOPT_SSL_VERIFYPEER, 0);
+			}
+			elseif (is_string($options['verify'])) {
+				curl_setopt($this->handle, CURLOPT_CAINFO, $options['verify']);
+			}
+		}
+
+		if (isset($options['verifyname']) && $options['verifyname'] === false) {
+			curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
 		}
 	}
 

--- a/tests/Transport/fsockopen.php
+++ b/tests/Transport/fsockopen.php
@@ -29,6 +29,19 @@ class RequestsTest_Transport_fsockopen extends RequestsTest_Transport_Base {
 		parent::testBadDomain();
 	}
 
+	public function testPoolNotImplementedInFsock() {
+		$requests  = array(
+			'test1' => array(
+				'url' => httpbin('/get'),
+			),
+			'test2' => array(
+				'url' => httpbin('/get'),
+			),
+		);
+		$responses = Requests::request_pool($requests, $this->getOptions());
+		$this->assertSame(array(), $responses);
+	}
+
 	/**
 	 * Issue #248.
 	 */


### PR DESCRIPTION
Wordpress/Requests currently lacking of requests pool, which instead of multiple requests, use a max size of simultaneous requests in one shot (pool_size), but allows more requests to handle. 