### PR TITLE
Modernize: use magic __DIR__ constant in lib code and example code

### DIFF
--- a/examples/basic-auth.php
+++ b/examples/basic-auth.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
+require_once dirname(__DIR__) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/cookie.php
+++ b/examples/cookie.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
+require_once dirname(__DIR__) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/cookie_jar.php
+++ b/examples/cookie_jar.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
+require_once dirname(__DIR__) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/get.php
+++ b/examples/get.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
+require_once dirname(__DIR__) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/multiple.php
+++ b/examples/multiple.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
+require_once dirname(__DIR__) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/post.php
+++ b/examples/post.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
+require_once dirname(__DIR__) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/proxy.php
+++ b/examples/proxy.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
+require_once dirname(__DIR__) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/session.php
+++ b/examples/session.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
+require_once dirname(__DIR__) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/examples/timeout.php
+++ b/examples/timeout.php
@@ -1,7 +1,7 @@
 <?php
 
 // First, include Requests
-require_once dirname(dirname(__FILE__)) . '/library/Requests.php';
+require_once dirname(__DIR__) . '/library/Requests.php';
 
 // Next, make sure Requests can load internal classes
 Requests::register_autoloader();

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -142,8 +142,8 @@ class Requests {
 		}
 
 		$file = str_replace('_', '/', $class);
-		if (file_exists(dirname(__FILE__) . '/' . $file . '.php')) {
-			require_once dirname(__FILE__) . '/' . $file . '.php';
+		if (file_exists(__DIR__ . '/' . $file . '.php')) {
+			require_once __DIR__ . '/' . $file . '.php';
 		}
 	}
 
@@ -539,7 +539,7 @@ class Requests {
 			return self::$certificate_path;
 		}
 
-		return dirname(__FILE__) . '/Requests/Transport/cacert.pem';
+		return __DIR__ . '/Requests/Transport/cacert.pem';
 	}
 
 	/**


### PR DESCRIPTION
### Modernize/Library: use the magic __DIR__ constant

... instead of using `dirname(__FILE__)`.

### Modernize/Examples: use the magic __DIR__ constant

... instead of using `dirname(__FILE__)`.

