### PR TITLE
PHP 8.1: fix deprecation warnings

### DIFF
--- a/library/Requests/Cookie/Jar.php
+++ b/library/Requests/Cookie/Jar.php
@@ -60,6 +60,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Item key
 	 * @return boolean Does the item exist?
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetExists($key) {
 		return isset($this->cookies[$key]);
 	}
@@ -70,6 +71,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Item key
 	 * @return string|null Item value (null if offsetExists is false)
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetGet($key) {
 		if (!isset($this->cookies[$key])) {
 			return null;
@@ -86,6 +88,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Item name
 	 * @param string $value Item value
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetSet($key, $value) {
 		if ($key === null) {
 			throw new Requests_Exception('Object is a dictionary, not a list', 'invalidset');
@@ -99,6 +102,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @param string $key
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetUnset($key) {
 		unset($this->cookies[$key]);
 	}
@@ -108,6 +112,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @return ArrayIterator
 	 */
+	#[ReturnTypeWillChange]
 	public function getIterator() {
 		return new ArrayIterator($this->cookies);
 	}

--- a/library/Requests/Utility/CaseInsensitiveDictionary.php
+++ b/library/Requests/Utility/CaseInsensitiveDictionary.php
@@ -37,6 +37,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 * @param string $key Item key
 	 * @return boolean Does the item exist?
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetExists($key) {
 		$key = strtolower($key);
 		return isset($this->data[$key]);
@@ -48,6 +49,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 * @param string $key Item key
 	 * @return string|null Item value (null if offsetExists is false)
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetGet($key) {
 		$key = strtolower($key);
 		if (!isset($this->data[$key])) {
@@ -65,6 +67,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 * @param string $key Item name
 	 * @param string $value Item value
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetSet($key, $value) {
 		if ($key === null) {
 			throw new Requests_Exception('Object is a dictionary, not a list', 'invalidset');
@@ -79,6 +82,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 *
 	 * @param string $key
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetUnset($key) {
 		unset($this->data[strtolower($key)]);
 	}
@@ -88,6 +92,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 *
 	 * @return ArrayIterator
 	 */
+	#[ReturnTypeWillChange]
 	public function getIterator() {
 		return new ArrayIterator($this->data);
 	}

--- a/library/Requests/Utility/FilteredIterator.php
+++ b/library/Requests/Utility/FilteredIterator.php
@@ -37,6 +37,7 @@ class Requests_Utility_FilteredIterator extends ArrayIterator {
 	 *
 	 * @return string
 	 */
+	#[ReturnTypeWillChange]
 	public function current() {
 		$value = parent::current();
 
@@ -50,6 +51,7 @@ class Requests_Utility_FilteredIterator extends ArrayIterator {
 	/**
 	 * @inheritdoc
 	 */
+	#[ReturnTypeWillChange]
 	public function unserialize($serialized) {}
 
 	/**
@@ -57,6 +59,7 @@ class Requests_Utility_FilteredIterator extends ArrayIterator {
 	 *
 	 * @phpcs:disable PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__unserializeFound
 	 */
+	#[ReturnTypeWillChange]
 	public function __unserialize($serialized) {}
 
 	public function __wakeup() {


### PR DESCRIPTION
As of PHP 8.1, PHP will start throwing deprecation warnings along the lines of:
```
Deprecated:  Return type of [CLASS]::[METHOD]() should either be compatible with [PHP NATIVE INTERFACE]::[METHOD](): [TYPE], or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

These type of deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared.
The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

As this package atill has a minimum PHP requirement of PHP 5.6 based on the `composer.json` file, the return type (PHP 7.0 feature) can not be added, so I've added the attribute instead.

While attributes are a PHP 8.0 feature only, due to the syntax choice for `#[]`, they will ignored in PHP < 8 and can be safely added.

👉🏻 Note: when namespaces will be/would be added to these classes, a `use` statement for `ReturnTypeWillChange` needs to be added!