### PR TITLE
Modernize: use the magic ::class constant

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -153,7 +153,7 @@ class Requests {
 	 * @codeCoverageIgnore
 	 */
 	public static function register_autoloader() {
-		spl_autoload_register(array('Requests', 'autoloader'));
+		spl_autoload_register(array(static::class, 'autoloader'));
 	}
 
 	/**
@@ -164,8 +164,8 @@ class Requests {
 	public static function add_transport($transport) {
 		if (empty(self::$transports)) {
 			self::$transports = array(
-				'Requests_Transport_cURL',
-				'Requests_Transport_fsockopen',
+				Requests_Transport_cURL::class,
+				Requests_Transport_fsockopen::class,
 			);
 		}
 
@@ -194,8 +194,8 @@ class Requests {
 
 		if (empty(self::$transports)) {
 			self::$transports = array(
-				'Requests_Transport_cURL',
-				'Requests_Transport_fsockopen',
+				Requests_Transport_cURL::class,
+				Requests_Transport_fsockopen::class,
 			);
 		}
 
@@ -430,7 +430,7 @@ class Requests {
 		$options = array_merge(self::get_default_options(true), $options);
 
 		if (!empty($options['hooks'])) {
-			$options['hooks']->register('transport.internal.parse_response', array('Requests', 'parse_multiple'));
+			$options['hooks']->register('transport.internal.parse_response', array(static::class, 'parse_multiple'));
 			if (!empty($options['complete'])) {
 				$options['hooks']->register('multiple.request.complete', $options['complete']);
 			}
@@ -461,7 +461,7 @@ class Requests {
 
 			// Ensure we only hook in once
 			if ($request['options']['hooks'] !== $options['hooks']) {
-				$request['options']['hooks']->register('transport.internal.parse_response', array('Requests', 'parse_multiple'));
+				$request['options']['hooks']->register('transport.internal.parse_response', array(static::class, 'parse_multiple'));
 				if (!empty($request['options']['complete'])) {
 					$request['options']['hooks']->register('multiple.request.complete', $request['options']['complete']);
 				}

--- a/library/Requests/Exception/HTTP.php
+++ b/library/Requests/Exception/HTTP.php
@@ -58,7 +58,7 @@ class Requests_Exception_HTTP extends Requests_Exception {
 	 */
 	public static function get_class($code) {
 		if (!$code) {
-			return 'Requests_Exception_HTTP_Unknown';
+			return Requests_Exception_HTTP_Unknown::class;
 		}
 
 		$class = sprintf('Requests_Exception_HTTP_%d', $code);
@@ -66,6 +66,6 @@ class Requests_Exception_HTTP extends Requests_Exception {
 			return $class;
 		}
 
-		return 'Requests_Exception_HTTP_Unknown';
+		return Requests_Exception_HTTP_Unknown::class;
 	}
 }

--- a/tests/Auth/BasicTest.php
+++ b/tests/Auth/BasicTest.php
@@ -5,12 +5,15 @@ namespace Requests\Tests\Auth;
 use Requests;
 use Requests\Tests\TestCase;
 use Requests_Auth_Basic;
+use Requests_Exception;
+use Requests_Transport_cURL;
+use Requests_Transport_fsockopen;
 
 class BasicTest extends TestCase {
 	public static function transportProvider() {
 		return array(
-			array('Requests_Transport_fsockopen'),
-			array('Requests_Transport_cURL'),
+			array(Requests_Transport_fsockopen::class),
+			array(Requests_Transport_cURL::class),
 		);
 	}
 
@@ -83,7 +86,7 @@ class BasicTest extends TestCase {
 	}
 
 	public function testMissingPassword() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Invalid number of arguments');
 		new Requests_Auth_Basic(array('user'));
 	}

--- a/tests/IDNAEncoderTest.php
+++ b/tests/IDNAEncoderTest.php
@@ -3,6 +3,7 @@
 namespace Requests\Tests;
 
 use Requests\Tests\TestCase;
+use Requests_Exception;
 use Requests_IDNAEncoder;
 
 class IDNAEncoderTest extends TestCase {
@@ -28,21 +29,21 @@ class IDNAEncoderTest extends TestCase {
 	}
 
 	public function testASCIITooLong() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Provided string is too long');
 		$data = str_repeat('abcd', 20);
 		Requests_IDNAEncoder::encode($data);
 	}
 
 	public function testEncodedTooLong() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Encoded string is too long');
 		$data = str_repeat("\xe4\xbb\x96", 60);
 		Requests_IDNAEncoder::encode($data);
 	}
 
 	public function testAlreadyPrefixed() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Provided string begins with ACE prefix');
 		Requests_IDNAEncoder::encode("xn--\xe4\xbb\x96");
 	}
@@ -68,31 +69,31 @@ class IDNAEncoderTest extends TestCase {
 	}
 
 	public function testFiveByteCharacter() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Invalid Unicode codepoint');
 		Requests_IDNAEncoder::encode("\xfb\xb6\xb6\xb6\xb6");
 	}
 
 	public function testSixByteCharacter() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Invalid Unicode codepoint');
 		Requests_IDNAEncoder::encode("\xfd\xb6\xb6\xb6\xb6\xb6");
 	}
 
 	public function testInvalidASCIICharacterWithMultibyte() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Invalid Unicode codepoint');
 		Requests_IDNAEncoder::encode("\0\xc2\xb6");
 	}
 
 	public function testUnfinishedMultibyte() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Invalid Unicode codepoint');
 		Requests_IDNAEncoder::encode("\xc2");
 	}
 
 	public function testPartialMultibyte() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Invalid Unicode codepoint');
 		Requests_IDNAEncoder::encode("\xc2\xc2\xb6");
 	}

--- a/tests/Proxy/HTTPTest.php
+++ b/tests/Proxy/HTTPTest.php
@@ -4,7 +4,10 @@ namespace Requests\Tests\Proxy;
 
 use Requests;
 use Requests\Tests\TestCase;
+use Requests_Exception;
 use Requests_Proxy_HTTP;
+use Requests_Transport_cURL;
+use Requests_Transport_fsockopen;
 
 class HTTPTest extends TestCase {
 	protected function checkProxyAvailable($type = '') {
@@ -25,8 +28,8 @@ class HTTPTest extends TestCase {
 
 	public function transportProvider() {
 		return array(
-			array('Requests_Transport_cURL'),
-			array('Requests_Transport_fsockopen'),
+			array(Requests_Transport_cURL::class),
+			array(Requests_Transport_fsockopen::class),
 		);
 	}
 
@@ -74,7 +77,7 @@ class HTTPTest extends TestCase {
 			'proxy'     => array(REQUESTS_HTTP_PROXY, 'testuser', 'password', 'something'),
 			'transport' => $transport,
 		);
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Invalid number of arguments');
 		Requests::get(httpbin('/get'), array(), $options);
 	}
@@ -134,10 +137,10 @@ class HTTPTest extends TestCase {
 		);
 
 		if (version_compare(phpversion(), '5.5.0', '>=') === true
-			&& $transport === 'Requests_Transport_fsockopen'
+			&& $transport === Requests_Transport_fsockopen::class
 		) {
 			// @TODO fsockopen connection times out on invalid auth instead of returning 407.
-			$this->expectException('Requests_Exception');
+			$this->expectException(Requests_Exception::class);
 			$this->expectExceptionMessage('fsocket timed out');
 		}
 

--- a/tests/RequestsTest.php
+++ b/tests/RequestsTest.php
@@ -6,12 +6,13 @@ use Requests;
 use Requests\Tests\Mock\RawTransportMock;
 use Requests\Tests\Mock\TransportMock;
 use Requests\Tests\TestCase;
+use Requests_Exception;
 use Requests_Response_Headers;
 
 class RequestsTest extends TestCase {
 
 	public function testInvalidProtocol() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Only HTTP(S) requests are handled');
 		Requests::request('ftp://128.0.0.1/');
 	}
@@ -116,7 +117,7 @@ class RequestsTest extends TestCase {
 			'transport' => $transport,
 		);
 
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Response could not be parsed');
 		Requests::get('http://example.com/', array(), $options);
 	}
@@ -132,7 +133,7 @@ class RequestsTest extends TestCase {
 			'transport' => $transport,
 		);
 
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Missing header/body separator');
 		Requests::get('http://example.com/', array(), $options);
 	}
@@ -145,7 +146,7 @@ class RequestsTest extends TestCase {
 			'transport' => $transport,
 		);
 
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Response could not be parsed');
 		Requests::get('http://example.com/', array(), $options);
 	}
@@ -164,7 +165,7 @@ class RequestsTest extends TestCase {
 
 	public function testTimeoutException() {
 		$options = array('timeout' => 0.5);
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('timed out');
 		Requests::get(httpbin('/delay/3'), array(), $options);
 	}

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -3,6 +3,7 @@
 namespace Requests\Tests\Response;
 
 use Requests\Tests\TestCase;
+use Requests_Exception;
 use Requests_Response_Headers;
 
 class HeadersTest extends TestCase {
@@ -43,7 +44,7 @@ class HeadersTest extends TestCase {
 	}
 
 	public function testInvalidKey() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Object is a dictionary, not a list');
 		$headers   = new Requests_Response_Headers();
 		$headers[] = 'text/plain';

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -3,6 +3,7 @@
 namespace Requests\Tests;
 
 use Requests\Tests\TestCase;
+use Requests_Response;
 use Requests_Session;
 
 class SessionTest extends TestCase {
@@ -138,7 +139,7 @@ class SessionTest extends TestCase {
 
 		// test1
 		$this->assertNotEmpty($responses['test1']);
-		$this->assertInstanceOf('Requests_Response', $responses['test1']);
+		$this->assertInstanceOf(Requests_Response::class, $responses['test1']);
 		$this->assertSame(200, $responses['test1']->status_code);
 
 		$result = json_decode($responses['test1']->body, true);
@@ -147,7 +148,7 @@ class SessionTest extends TestCase {
 
 		// test2
 		$this->assertNotEmpty($responses['test2']);
-		$this->assertInstanceOf('Requests_Response', $responses['test2']);
+		$this->assertInstanceOf(Requests_Response::class, $responses['test2']);
 		$this->assertSame(200, $responses['test2']->status_code);
 
 		$result = json_decode($responses['test2']->body, true);

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -6,8 +6,10 @@ use Requests;
 use Requests\Tests\Mock\TransportMock;
 use Requests\Tests\TestCase;
 use Requests_Exception;
+use Requests_Exception_HTTP_Unknown;
 use Requests_Hooks;
 use Requests_Response;
+use stdClass;
 
 abstract class BaseTestCase extends TestCase {
 	public function set_up() {
@@ -334,7 +336,7 @@ abstract class BaseTestCase extends TestCase {
 		$options = array(
 			'redirects' => 10, // default, but force just in case
 		);
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('Too many redirects');
 		Requests::get(httpbin('/redirect/11'), array(), $this->getOptions($options));
 	}
@@ -425,7 +427,7 @@ abstract class BaseTestCase extends TestCase {
 				$this->expectExceptionCode($code);
 			}
 			elseif ($code >= 300 && $code < 400) {
-				$this->expectException('Requests_Exception');
+				$this->expectException(Requests_Exception::class);
 			}
 		}
 
@@ -485,7 +487,7 @@ abstract class BaseTestCase extends TestCase {
 		);
 
 		$request = Requests::get(httpbin('/status/599'), array(), $options);
-		$this->expectException('Requests_Exception_HTTP_Unknown');
+		$this->expectException(Requests_Exception_HTTP_Unknown::class);
 		$this->expectExceptionMessage('599 Unknown');
 		$request->throw_for_status(true);
 	}
@@ -547,7 +549,7 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testBadIP() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		Requests::get('http://256.256.256.0/', array(), $this->getOptions());
 	}
 
@@ -570,7 +572,7 @@ abstract class BaseTestCase extends TestCase {
 			return;
 		}
 
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		Requests::get('https://testssl-expire.disig.sk/index.en.html', array(), $this->getOptions());
 	}
 
@@ -580,7 +582,7 @@ abstract class BaseTestCase extends TestCase {
 			return;
 		}
 
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		Requests::get('https://testssl-revoked.disig.sk/index.en.html', array(), $this->getOptions());
 	}
 
@@ -593,7 +595,7 @@ abstract class BaseTestCase extends TestCase {
 			return;
 		}
 
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		Requests::head('https://wrong.host.badssl.com/', array(), $this->getOptions());
 	}
 
@@ -644,7 +646,7 @@ abstract class BaseTestCase extends TestCase {
 		$options = array(
 			'timeout' => 1,
 		);
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('timed out');
 		Requests::get(httpbin('/delay/10'), array(), $this->getOptions($options));
 	}
@@ -662,7 +664,7 @@ abstract class BaseTestCase extends TestCase {
 
 		// test1
 		$this->assertNotEmpty($responses['test1']);
-		$this->assertInstanceOf('Requests_Response', $responses['test1']);
+		$this->assertInstanceOf(Requests_Response::class, $responses['test1']);
 		$this->assertSame(200, $responses['test1']->status_code);
 
 		$result = json_decode($responses['test1']->body, true);
@@ -671,7 +673,7 @@ abstract class BaseTestCase extends TestCase {
 
 		// test2
 		$this->assertNotEmpty($responses['test2']);
-		$this->assertInstanceOf('Requests_Response', $responses['test2']);
+		$this->assertInstanceOf(Requests_Response::class, $responses['test2']);
 		$this->assertSame(200, $responses['test2']->status_code);
 
 		$result = json_decode($responses['test2']->body, true);
@@ -718,7 +720,7 @@ abstract class BaseTestCase extends TestCase {
 		);
 		$responses = Requests::request_multiple($requests, $this->getOptions());
 		$this->assertSame(200, $responses['success']->status_code);
-		$this->assertInstanceOf('Requests_Exception', $responses['timeout']);
+		$this->assertInstanceOf(Requests_Exception::class, $responses['timeout']);
 	}
 
 	public function testMultipleUsingCallback() {
@@ -826,7 +828,7 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testProgressCallback() {
-		$mock = $this->getMockBuilder('stdClass')->setMethods(array('progress'))->getMock();
+		$mock = $this->getMockBuilder(stdClass::class)->setMethods(array('progress'))->getMock();
 		$mock->expects($this->atLeastOnce())->method('progress');
 		$hooks = new Requests_Hooks();
 		$hooks->register('request.progress', array($mock, 'progress'));
@@ -839,7 +841,7 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testAfterRequestCallback() {
-		$mock = $this->getMockBuilder('stdClass')
+		$mock = $this->getMockBuilder(stdClass::class)
 			->setMethods(array('after_request'))
 			->getMock();
 

--- a/tests/Transport/CURLTest.php
+++ b/tests/Transport/CURLTest.php
@@ -4,24 +4,26 @@ namespace Requests\Tests\Transport;
 
 use Requests;
 use Requests\Tests\Transport\BaseTestCase;
+use Requests_Exception;
+use Requests_Transport_cURL;
 
 class CurlTest extends BaseTestCase {
-	protected $transport = 'Requests_Transport_cURL';
+	protected $transport = Requests_Transport_cURL::class;
 
 	public function testBadIP() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('t resolve host');
 		parent::testBadIP();
 	}
 
 	public function testExpiredHTTPS() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('certificate subject name');
 		parent::testExpiredHTTPS();
 	}
 
 	public function testRevokedHTTPS() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('certificate subject name');
 		parent::testRevokedHTTPS();
 	}
@@ -30,7 +32,7 @@ class CurlTest extends BaseTestCase {
 	 * Test that SSL fails with a bad certificate
 	 */
 	public function testBadDomain() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('certificate subject name');
 		parent::testBadDomain();
 	}

--- a/tests/Transport/FsockopenTest.php
+++ b/tests/Transport/FsockopenTest.php
@@ -4,24 +4,26 @@ namespace Requests\Tests\Transport;
 
 use Requests;
 use Requests\Tests\Transport\BaseTestCase;
+use Requests_Exception;
 use Requests_Hooks;
+use Requests_Transport_fsockopen;
 
 class FsockopenTest extends BaseTestCase {
-	protected $transport = 'Requests_Transport_fsockopen';
+	protected $transport = Requests_Transport_fsockopen::class;
 
 	public function testBadIP() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		parent::testBadIP();
 	}
 
 	public function testExpiredHTTPS() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('SSL certificate did not match the requested domain name');
 		parent::testExpiredHTTPS();
 	}
 
 	public function testRevokedHTTPS() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('SSL certificate did not match the requested domain name');
 		parent::testRevokedHTTPS();
 	}
@@ -30,7 +32,7 @@ class FsockopenTest extends BaseTestCase {
 	 * Test that SSL fails with a bad certificate
 	 */
 	public function testBadDomain() {
-		$this->expectException('Requests_Exception');
+		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('SSL certificate did not match the requested domain name');
 		parent::testBadDomain();
 	}

--- a/tests/Utility/FilteredIteratorTest.php
+++ b/tests/Utility/FilteredIteratorTest.php
@@ -13,9 +13,9 @@ class FilteredIteratorTest extends TestCase {
 	 */
 	public function testDeserializeRequestUtilityFilteredIteratorObjects($value) {
 		$serialized = serialize($value);
-		if (get_class($value) === 'Requests_Utility_FilteredIterator') {
+		if (get_class($value) === Requests_Utility_FilteredIterator::class) {
 			$new_value  = unserialize($serialized);
-			$reflection = new ReflectionClass('Requests_Utility_FilteredIterator');
+			$reflection = new ReflectionClass(Requests_Utility_FilteredIterator::class);
 			$property   = $reflection->getProperty('callback');
 			$property->setAccessible(true);
 			$callback_value = $property->getValue($new_value);


### PR DESCRIPTION
... in all the appropriate places.

Note: in the `Requests` class where it would result in a "self" reference, I've chosen to use `static` to allow for child classes overloading the referenced methods.