### PR TITLE
Drop support for HHVM

### DIFF
--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -458,11 +458,6 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 			if (!extension_loaded('openssl') || !function_exists('openssl_x509_parse')) {
 				return false;
 			}
-
-			// Currently broken, thanks to https://github.com/facebook/hhvm/issues/2156
-			if (defined('HHVM_VERSION')) {
-				return false;
-			}
 		}
 
 		return true;


### PR DESCRIPTION
HHVM dropped support for PHP at the end of 2018.

While testing and basic support for HHVM was enabled in Request 1.7.0, it has basically been broken since then and we are currently no longer testing against HHVM anyway.

So, let's formally drop support it and remove all references to it (aside from those in the changelog).

Ref: https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html