### PR TITLE
Clean up: remove previously deprecated methods

### DIFF
--- a/examples/cookie.php
+++ b/examples/cookie.php
@@ -10,7 +10,7 @@ Requests::register_autoloader();
 $c = new Requests_Cookie('login_uid', 'something');
 
 // Now let's make a request!
-$request = Requests::get('http://httpbin.org/cookies', array('Cookie' => $c->formatForHeader()));
+$request = Requests::get('http://httpbin.org/cookies', array('Cookie' => $c->format_for_header()));
 
 // Check what we received
 var_dump($request);

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -803,18 +803,6 @@ class Requests {
 	}
 
 	/**
-	 * Convert a key => value array to a 'key: value' array for headers
-	 *
-	 * @codeCoverageIgnore
-	 * @deprecated Misspelling of {@see Requests::flatten}
-	 * @param array $array Dictionary of header values
-	 * @return array List of headers
-	 */
-	public static function flattern($array) {
-		return self::flatten($array);
-	}
-
-	/**
 	 * Decompress an encoded body
 	 *
 	 * Implements gzip, compress and deflate. Guesses which it is by attempting

--- a/library/Requests/Cookie.php
+++ b/library/Requests/Cookie.php
@@ -317,17 +317,6 @@ class Requests_Cookie {
 	}
 
 	/**
-	 * Format a cookie for a Cookie header
-	 *
-	 * @codeCoverageIgnore
-	 * @deprecated Use {@see Requests_Cookie::format_for_header}
-	 * @return string
-	 */
-	public function formatForHeader() {
-		return $this->format_for_header();
-	}
-
-	/**
 	 * Format a cookie for a Set-Cookie header
 	 *
 	 * This is used when sending cookies to clients. This isn't really
@@ -352,17 +341,6 @@ class Requests_Cookie {
 			$header_value .= '; ' . implode('; ', $parts);
 		}
 		return $header_value;
-	}
-
-	/**
-	 * Format a cookie for a Set-Cookie header
-	 *
-	 * @codeCoverageIgnore
-	 * @deprecated Use {@see Requests_Cookie::format_for_set_cookie}
-	 * @return string
-	 */
-	public function formatForSetCookie() {
-		return $this->format_for_set_cookie();
 	}
 
 	/**
@@ -490,16 +468,5 @@ class Requests_Cookie {
 		}
 
 		return $cookies;
-	}
-
-	/**
-	 * Parse all Set-Cookie headers from request headers
-	 *
-	 * @codeCoverageIgnore
-	 * @deprecated Use {@see Requests_Cookie::parse_from_headers}
-	 * @return array
-	 */
-	public static function parseFromHeaders(Requests_Response_Headers $headers) {
-		return self::parse_from_headers($headers);
 	}
 }

--- a/library/Requests/Cookie/Jar.php
+++ b/library/Requests/Cookie/Jar.php
@@ -44,17 +44,6 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	}
 
 	/**
-	 * Normalise cookie data into a Requests_Cookie
-	 *
-	 * @codeCoverageIgnore
-	 * @deprecated Use {@see Requests_Cookie_Jar::normalize_cookie}
-	 * @return Requests_Cookie
-	 */
-	public function normalizeCookie($cookie, $key = null) {
-		return $this->normalize_cookie($cookie, $key);
-	}
-
-	/**
 	 * Check if the given item exists
 	 *
 	 * @param string $key Item key


### PR DESCRIPTION
* The `Requests::flattern()` method was deprecated in 2013/ v1.6.0 via commit 4a34e398b90a7d0a45dc03380305ad6b3b2f7b5c.
* The `Cookie::formatForHeader()` method was deprecated in 2015 / v 1.7.0 via commit 83d963b2c9ece289aba68c68f46b863fc44f922c
* The `Cookie::formatForSetCookie()` method was deprecated in 2015 / v 1.7.0 via commit 83d963b2c9ece289aba68c68f46b863fc44f922c
* The `Cookie::parseFromHeaders()` method was deprecated in 2015 / v 1.7.0 via commit 83d963b2c9ece289aba68c68f46b863fc44f922c
* The `Cookie_Jar::normalizeCookie()` method was deprecated in 2015 / v 1.7.0 via commit 83d963b2c9ece289aba68c68f46b863fc44f922c