### PR TITLE
QA: tweak code coverage configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,7 +14,7 @@ coverage:
           - "library"
     patch:
       default:
-        threshold: 0%
+        threshold: 3%
         paths:
           - "library"
 


### PR DESCRIPTION
The code coverage configuration was a little too strict, which is currently making all PRs look as "build failed".