### PR TITLE
Add Roave security advisories for dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "php-parallel-lint/php-parallel-lint": "^1.3",
     "php-parallel-lint/php-console-highlighter": "^0.5.0",
-    "yoast/phpunit-polyfills": "^1.0.0"
+    "yoast/phpunit-polyfills": "^1.0.0",
+    "roave/security-advisories": "dev-latest"
   },
   "type": "library",
   "autoload": {


### PR DESCRIPTION
Adding the `roave/security-advisories` package ensure that no vulnerable packages can be pulled in during a `composer install`|`composer update`.

See https://github.com/Roave/SecurityAdvisories