### PR TITLE
Composer: update version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,11 +40,11 @@
   },
   "require-dev": {
     "requests/test-server": "dev-master",
-    "squizlabs/php_codesniffer": "^3.5",
+    "squizlabs/php_codesniffer": "^3.6",
     "phpcompatibility/php-compatibility": "^9.0",
     "wp-coding-standards/wpcs": "^2.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-    "php-parallel-lint/php-parallel-lint": "^1.3",
+    "php-parallel-lint/php-parallel-lint": "^1.3.1",
     "php-parallel-lint/php-console-highlighter": "^0.5.0",
     "yoast/phpunit-polyfills": "^1.0.0",
     "roave/security-advisories": "dev-latest"


### PR DESCRIPTION
Update version constraints to versions which are - at least - compatible with PHP 8.0 (and sometimes 8.1), in as far as these are available.

Refs:
* https://github.com/squizlabs/php_codesniffer/releases
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases