### PR TITLE
FsockopenTest: add regression test for HTTP string

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Access localhost on port 9002
         run: curl -i http://localhost:9002
 
+      - name: Show available locales
+        run: locale -a
+
       - name: Show PHPUnit version
         run: vendor/bin/phpunit --version
 

--- a/tests/Transport/FsockopenTest.php
+++ b/tests/Transport/FsockopenTest.php
@@ -53,4 +53,33 @@ class FsockopenTest extends BaseTestCase {
 	public function checkContentLengthHeader($headers) {
 		$this->assertStringContainsString('Content-Length: 0', $headers);
 	}
+
+	/**
+	 * Issue #335/#339.
+	 */
+	public function testHTTPVersionHeader() {
+		// Remember the original locale.
+		$locale = setlocale(LC_NUMERIC, 0);
+
+		// Set the locale to one using commas for the decimal point.
+		setlocale(LC_NUMERIC, 'de_DE@euro', 'de_DE', 'de', 'ge');
+
+		// Make sure the locale was changed.
+		$this->assertNotSame($locale, setlocale(LC_NUMERIC, 0), 'Changing the locale failed');
+
+		$hooks = new Requests_Hooks();
+		$hooks->register('fsockopen.after_headers', array($this, 'checkHTTPVersionHeader'));
+
+		Requests::post(httpbin('/post'), array(), array(), $this->getOptions(array('hooks' => $hooks)));
+
+		// Reset the locale.
+		setlocale(LC_NUMERIC, $locale);
+	}
+
+	/**
+	 * Issue #335/#339.
+	 */
+	public function checkHTTPVersionHeader($headers) {
+		$this->assertStringContainsString('HTTP/1.1', $headers, 'HTTP header is influenced by the system locale');
+	}
 }


### PR DESCRIPTION
PR #339 made a change to safeguard that the HTTP string would always contain a decimal point, never a comma.

The original bug was related to the current locale influencing the results of the call to `sprintf()`.

At the time, no test was added to safeguard the fix against regressions.

This PR now adds this regression test.

I've verified that without the fix as merged in #339, this test would fail.

Includes adjusting the GH Actions workflows to install extra locales as otherwise the test would fail on the locale being changed to in the test not being available.