### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: ":bug: Bug report"
-about: If something isn't working as expected.
+about: I got unexpected behavior and think it is a bug.
 ---
 
 ## Summary
@@ -9,7 +9,7 @@ about: If something isn't working as expected.
 
 ### Given the following code sample
 <!-- Please post code as text (using proper markup). Do not post screenshots of code. -->
-<!-- Add a much information as needed to allow for reproducing the issue consistently. -->
+<!-- Add as much information as needed to allow for reproducing the issue consistently. -->
 
 ```php
 ```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: ":bug: Bug report"
+about: If something isn't working as expected.
+---
+
+## Summary
+
+<!-- Provide clear and concise description of the problem you are experiencing. -->
+
+### Given the following code sample
+<!-- Please post code as text (using proper markup). Do not post screenshots of code. -->
+<!-- Add a much information as needed to allow for reproducing the issue consistently. -->
+
+```php
+```
+
+### I'd expect the following behaviour
+<!-- What was the expected (correct) behavior? -->
+
+### Instead this happened
+<!--
+What is the current (buggy) behavior?
+Please provide as much information as possible and relevant, think: exceptions received, the response received etc.
+-->
+
+### Additional context
+<!-- Add any other context about the problem. -->
+
+## Your environment
+<!-- Please include as many details as relevant about the environment you experienced the bug in. -->
+
+| Environment                                                  | Answer
+| ------------------------------------------------------------ | -------
+| Operating system and version (e.g. Ubuntu 20.04, Windows 10) | Linux/Windows/MacOS x.y.z
+| PHP version                                                  | x.y.z
+| Requests version                                             | x.y.z
+| Autoloader used                                              | Composer autoload / Requests native autoloader / Own custom autoloader
+| Link to your project                                         | https://....
+
+## Tested against `develop` branch?
+- [ ] I have verified the issue still exists in the `develop` branch of Requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: ":rocket: Feature request"
-about: I have a suggestion (and may want to implement it)
+about: I have a suggestion (and may want to implement it).
 ---
 
 ## Is your feature request related to a problem?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: ":rocket: Feature request"
+about: I have a suggestion (and may want to implement it)
+---
+
+## Is your feature request related to a problem?
+<!-- Please provide a clear and concise description of what the feature is which you'd like to see implemented. -->
+
+## Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+## Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+## Additional context (optional)
+<!-- Add any other context or screenshots about the feature request here. -->
+
+- [ ] I intend to create a pull request to implement this feature myself.


### PR DESCRIPTION
Add an initial set of basic issue templates.

The initial set consists of a basic _bug report_ and a _feature request_ template, loosely based on the standards proposed by GitHub itself, with adjustments based on experiences in other repos.

The intention is to initially iterate on these templates based on how well people fill them out and how helpful they prove to be to get bugs reported in a reproducible format
Once the templates are relatively stable, we can consider switching them over to Yaml template format.

Fixes #515