### PR TITLE
GH Pages: add QA workflow

### DIFF
--- a/.github/workflows/test-ghpages.yml
+++ b/.github/workflows/test-ghpages.yml
@@ -1,0 +1,27 @@
+name: Test Jekyll Build
+
+on:
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  #### TEST THAT THE GH PAGES SITE GETS BUILT WITHOUT ERRORS ####
+  test:
+    name: "Test GHPages site"
+    if: github.repository == 'WordPress/Requests'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Use the version as per https://pages.github.com/versions/.
+          ruby-version: 2.7.3
+          bundler-cache: true
+
+      - name: Test building the GH Pages site
+        run: bundle exec jekyll build


### PR DESCRIPTION
This commit adds a workflow which tests that the GH Pages site can be generated by Jekyll without errors for pull requests to the `gh-pages` branch.

Notes:
* The workflow has got a safeguard in place to prevent these workflows from running on forks which can't deploy the GH Pages website.