### PR TITLE
Documentation: review of the `@see` tags

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -26,11 +26,11 @@ interface Auth {
 	/**
 	 * Register hooks as needed
 	 *
-	 * This method is called in {@see \WpOrg\Requests\Requests::request} when the user
+	 * This method is called in {@see \WpOrg\Requests\Requests::request()} when the user
 	 * has set an instance as the 'auth' option. Use this callback to register all the
 	 * hooks you'll need.
 	 *
-	 * @see \WpOrg\Requests\Hooks::register
+	 * @see \WpOrg\Requests\Hooks::register()
 	 * @param \WpOrg\Requests\Hooks $hooks Hook system
 	 */
 	public function register(Hooks $hooks);

--- a/src/Auth/Basic.php
+++ b/src/Auth/Basic.php
@@ -55,8 +55,8 @@ class Basic implements Auth {
 	/**
 	 * Register the necessary callbacks
 	 *
-	 * @see curl_before_send
-	 * @see fsockopen_header
+	 * @see \WpOrg\Requests\Auth\Basic::curl_before_send()
+	 * @see \WpOrg\Requests\Auth\Basic::fsockopen_header()
 	 * @param \WpOrg\Requests\Hooks $hooks Hook system
 	 */
 	public function register(Hooks $hooks) {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -45,7 +45,7 @@ class Exception extends PHPException {
 	}
 
 	/**
-	 * Like {@see getCode()}, but a string code.
+	 * Like {@see \Exception::getCode()}, but a string code.
 	 *
 	 * @codeCoverageIgnore
 	 * @return string

--- a/src/Exception/Http/Status418.php
+++ b/src/Exception/Http/Status418.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 418 I'm A Teapot responses
  *
- * @see https://tools.ietf.org/html/rfc2324
+ * @link https://tools.ietf.org/html/rfc2324
  * @package Requests
  */
 
@@ -13,7 +13,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 418 I'm A Teapot responses
  *
- * @see https://tools.ietf.org/html/rfc2324
+ * @link https://tools.ietf.org/html/rfc2324
  * @package Requests
  */
 class Status418 extends Http {

--- a/src/Exception/Http/Status428.php
+++ b/src/Exception/Http/Status428.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 428 Precondition Required responses
  *
- * @see https://tools.ietf.org/html/rfc6585
+ * @link https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 
@@ -13,7 +13,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 428 Precondition Required responses
  *
- * @see https://tools.ietf.org/html/rfc6585
+ * @link https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 class Status428 extends Http {

--- a/src/Exception/Http/Status429.php
+++ b/src/Exception/Http/Status429.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 429 Too Many Requests responses
  *
- * @see https://tools.ietf.org/html/draft-nottingham-http-new-status-04
+ * @link https://tools.ietf.org/html/draft-nottingham-http-new-status-04
  * @package Requests
  */
 
@@ -13,7 +13,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 429 Too Many Requests responses
  *
- * @see https://tools.ietf.org/html/draft-nottingham-http-new-status-04
+ * @link https://tools.ietf.org/html/draft-nottingham-http-new-status-04
  * @package Requests
  */
 class Status429 extends Http {

--- a/src/Exception/Http/Status431.php
+++ b/src/Exception/Http/Status431.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 431 Request Header Fields Too Large responses
  *
- * @see https://tools.ietf.org/html/rfc6585
+ * @link https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 
@@ -13,7 +13,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 431 Request Header Fields Too Large responses
  *
- * @see https://tools.ietf.org/html/rfc6585
+ * @link https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 class Status431 extends Http {

--- a/src/Exception/Http/Status511.php
+++ b/src/Exception/Http/Status511.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 511 Network Authentication Required responses
  *
- * @see https://tools.ietf.org/html/rfc6585
+ * @link https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 
@@ -13,7 +13,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 511 Network Authentication Required responses
  *
- * @see https://tools.ietf.org/html/rfc6585
+ * @link https://tools.ietf.org/html/rfc6585
  * @package Requests
  */
 class Status511 extends Http {

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -11,14 +11,14 @@ use WpOrg\Requests\Exception;
  *
  * @package Requests
  * @subpackage Utilities
- * @see https://tools.ietf.org/html/rfc3490 IDNA specification
- * @see https://tools.ietf.org/html/rfc3492 Punycode/Bootstrap specification
+ * @link https://tools.ietf.org/html/rfc3490 IDNA specification
+ * @link https://tools.ietf.org/html/rfc3492 Punycode/Bootstrap specification
  */
 class IdnaEncoder {
 	/**
 	 * ACE prefix used for IDNA
 	 *
-	 * @see https://tools.ietf.org/html/rfc3490#section-5
+	 * @link https://tools.ietf.org/html/rfc3490#section-5
 	 * @var string
 	 */
 	const ACE_PREFIX = 'xn--';
@@ -26,7 +26,7 @@ class IdnaEncoder {
 	/**#@+
 	 * Bootstrap constant for Punycode
 	 *
-	 * @see https://tools.ietf.org/html/rfc3492#section-5
+	 * @link https://tools.ietf.org/html/rfc3492#section-5
 	 * @var int
 	 */
 	const BOOTSTRAP_BASE         = 36;
@@ -336,7 +336,7 @@ class IdnaEncoder {
 	/**
 	 * Convert a digit to its respective character
 	 *
-	 * @see https://tools.ietf.org/html/rfc3492#section-5
+	 * @link https://tools.ietf.org/html/rfc3492#section-5
 	 * @throws \WpOrg\Requests\Exception On invalid digit (`idna.invalid_digit`)
 	 *
 	 * @param int $digit Digit in the range 0-35
@@ -356,7 +356,7 @@ class IdnaEncoder {
 	/**
 	 * Adapt the bias
 	 *
-	 * @see https://tools.ietf.org/html/rfc3492#section-6.1
+	 * @link https://tools.ietf.org/html/rfc3492#section-6.1
 	 * @param int $delta
 	 * @param int $numpoints
 	 * @param bool $firsttime

--- a/src/Ipv6.php
+++ b/src/Ipv6.php
@@ -80,7 +80,7 @@ class Ipv6 {
 	 * Example:  FF01:0:0:0:0:0:0:101   ->  FF01::101
 	 *           0:0:0:0:0:0:0:1        ->  ::1
 	 *
-	 * @see uncompress()
+	 * @see \WpOrg\Requests\IPv6::uncompress()
 	 * @param string $ip An IPv6 address
 	 * @return string The compressed IPv6 address
 	 */

--- a/src/Iri.php
+++ b/src/Iri.php
@@ -52,7 +52,7 @@ use WpOrg\Requests\Ipv6;
  * @link http://hg.gsnedders.com/iri/
  *
  * @property string $iri IRI we're working with
- * @property-read string $uri IRI in URI form, {@see to_uri}
+ * @property-read string $uri IRI in URI form, {@see \WpOrg\Requests\IRI::to_uri()}
  * @property string $scheme Scheme part of the IRI
  * @property string $authority Authority part, formatted for a URI (userinfo + host + port)
  * @property string $iauthority Authority part of the IRI (userinfo + host + port)
@@ -990,7 +990,7 @@ class Iri {
 	/**
 	 * Convert an IRI to a URI (or parts thereof)
 	 *
-	 * @param string|bool IRI to convert (or false from {@see get_iri})
+	 * @param string|bool IRI to convert (or false from {@see \WpOrg\Requests\IRI::get_iri()})
 	 * @return string|false URI if IRI is valid, false otherwise.
 	 */
 	protected function to_uri($string) {

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -28,11 +28,11 @@ interface Proxy {
 	/**
 	 * Register hooks as needed
 	 *
-	 * This method is called in {@see \WpOrg\Requests\Requests::request} when the user
+	 * This method is called in {@see \WpOrg\Requests\Requests::request()} when the user
 	 * has set an instance as the 'auth' option. Use this callback to register all the
 	 * hooks you'll need.
 	 *
-	 * @see \WpOrg\Requests\Hooks::register
+	 * @see \WpOrg\Requests\Hooks::register()
 	 * @param \WpOrg\Requests\Hooks $hooks Hook system
 	 */
 	public function register(Hooks $hooks);

--- a/src/Proxy/Http.php
+++ b/src/Proxy/Http.php
@@ -82,10 +82,10 @@ class Http implements Proxy {
 	 * Register the necessary callbacks
 	 *
 	 * @since 1.6
-	 * @see curl_before_send
-	 * @see fsockopen_remote_socket
-	 * @see fsockopen_remote_host_path
-	 * @see fsockopen_header
+	 * @see \WpOrg\Requests\Proxy\HTTP::curl_before_send()
+	 * @see \WpOrg\Requests\Proxy\HTTP::fsockopen_remote_socket()
+	 * @see \WpOrg\Requests\Proxy\HTTP::fsockopen_remote_host_path()
+	 * @see \WpOrg\Requests\Proxy\HTTP::fsockopen_header()
 	 * @param \WpOrg\Requests\Hooks $hooks Hook system
 	 */
 	public function register(Hooks $hooks) {

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -106,7 +106,7 @@ class Requests {
 	/**
 	 * Selected transport name
 	 *
-	 * Use {@see get_transport()} instead
+	 * Use {@see \WpOrg\Requests\Requests::get_transport()} instead
 	 *
 	 * @var array
 	 */
@@ -200,7 +200,7 @@ class Requests {
 	}
 
 	/**#@+
-	 * @see request()
+	 * @see \WpOrg\Requests\Requests::request()
 	 * @param string $url
 	 * @param array $headers
 	 * @param array $options
@@ -236,7 +236,7 @@ class Requests {
 	/**#@-*/
 
 	/**#@+
-	 * @see request()
+	 * @see \WpOrg\Requests\Requests::request()
 	 * @param string $url
 	 * @param array $headers
 	 * @param array $data
@@ -266,8 +266,8 @@ class Requests {
 	/**
 	 * Send a PATCH request
 	 *
-	 * Note: Unlike {@see post} and {@see put}, `$headers` is required, as the
-	 * specification recommends that should send an ETag
+	 * Note: Unlike {@see \WpOrg\Requests\Requests::post()} and {@see \WpOrg\Requests\Requests::put()},
+	 * `$headers` is required, as the specification recommends that should send an ETag
 	 *
 	 * @link https://tools.ietf.org/html/rfc5789
 	 */
@@ -312,8 +312,8 @@ class Requests {
 	 *    (boolean, default: true)
 	 * - `transport`: Custom transport. Either a class name, or a
 	 *    transport object. Defaults to the first working transport from
-	 *    {@see getTransport()}
-	 *    (string|\WpOrg\Requests\Transport, default: {@see getTransport()})
+	 *    {@see \WpOrg\Requests\Requests::getTransport()}
+	 *    (string|\WpOrg\Requests\Transport, default: {@see \WpOrg\Requests\Requests::getTransport()})
 	 * - `hooks`: Hooks handler.
 	 *    (\WpOrg\Requests\Hooker, default: new WpOrg\Requests\Hooks())
 	 * - `verify`: Should we verify SSL certificates? Allows passing in a custom

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -729,7 +729,7 @@ class Requests {
 	/**
 	 * Decoded a chunked body as per RFC 2616
 	 *
-	 * @see https://tools.ietf.org/html/rfc2616#section-3.6.1
+	 * @link https://tools.ietf.org/html/rfc2616#section-3.6.1
 	 * @param string $data Chunked body
 	 * @return string Decoded body
 	 */

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -376,16 +376,16 @@ class Requests {
 	 * The request fields value is an associative array with the following keys:
 	 *
 	 * - `url`: Request URL Same as the `$url` parameter to
-	 *    {@see \WpOrg\Requests\Requests::request}
+	 *    {@see \WpOrg\Requests\Requests::request()}
 	 *    (string, required)
 	 * - `headers`: Associative array of header fields. Same as the `$headers`
-	 *    parameter to {@see \WpOrg\Requests\Requests::request}
+	 *    parameter to {@see \WpOrg\Requests\Requests::request()}
 	 *    (array, default: `array()`)
 	 * - `data`: Associative array of data fields or a string. Same as the
-	 *    `$data` parameter to {@see \WpOrg\Requests\Requests::request}
+	 *    `$data` parameter to {@see \WpOrg\Requests\Requests::request()}
 	 *    (array|string, default: `array()`)
 	 * - `type`: HTTP request type (use \WpOrg\Requests\Requests constants). Same as the `$type`
-	 *    parameter to {@see \WpOrg\Requests\Requests::request}
+	 *    parameter to {@see \WpOrg\Requests\Requests::request()}
 	 *    (string, default: `\WpOrg\Requests\Requests::GET`)
 	 * - `cookies`: Associative array of cookie name to value, or cookie jar.
 	 *    (array|\WpOrg\Requests\Cookie\Jar)
@@ -403,7 +403,7 @@ class Requests {
 	 *    (callback)
 	 *
 	 * @param array $requests Requests data (see description for more information)
-	 * @param array $options Global and default options (see {@see \WpOrg\Requests\Requests::request})
+	 * @param array $options Global and default options (see {@see \WpOrg\Requests\Requests::request()})
 	 * @return array Responses (either \WpOrg\Requests\Response or a \WpOrg\Requests\Exception object)
 	 */
 	public static function request_multiple($requests, $options = array()) {

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -20,7 +20,7 @@ class Headers extends CaseInsensitiveDictionary {
 	/**
 	 * Get the given header
 	 *
-	 * Unlike {@see self::getValues()}, this returns a string. If there are
+	 * Unlike {@see \WpOrg\Requests\Response\Headers::getValues()}, this returns a string. If there are
 	 * multiple values, it concatenates them with a comma as per RFC2616.
 	 *
 	 * Avoid using this where commas may be used unquoted in values, such as

--- a/src/Session.php
+++ b/src/Session.php
@@ -127,7 +127,7 @@ class Session {
 	}
 
 	/**#@+
-	 * @see request()
+	 * @see \WpOrg\Requests\Session::request()
 	 * @param string $url
 	 * @param array $headers
 	 * @param array $options
@@ -156,7 +156,7 @@ class Session {
 	/**#@-*/
 
 	/**#@+
-	 * @see request()
+	 * @see \WpOrg\Requests\Session::request()
 	 * @param string $url
 	 * @param array $headers
 	 * @param array $data
@@ -180,8 +180,8 @@ class Session {
 	/**
 	 * Send a PATCH request
 	 *
-	 * Note: Unlike {@see post} and {@see put}, `$headers` is required, as the
-	 * specification recommends that should send an ETag
+	 * Note: Unlike {@see \WpOrg\Requests\Session::post()} and {@see \WpOrg\Requests\Session::put()},
+	 * `$headers` is required, as the specification recommends that should send an ETag
 	 *
 	 * @link https://tools.ietf.org/html/rfc5789
 	 */
@@ -238,7 +238,7 @@ class Session {
 	/**
 	 * Merge a request's data with the default data
 	 *
-	 * @param array $request Request data (same form as {@see request_multiple})
+	 * @param array $request Request data (same form as {@see \WpOrg\Requests\Session::request_multiple()})
 	 * @param boolean $merge_options Should we merge options as well?
 	 * @return array Request data
 	 */

--- a/src/Session.php
+++ b/src/Session.php
@@ -204,7 +204,7 @@ class Session {
 	 * @param array $headers Extra headers to send with the request
 	 * @param array|null $data Data to send either as a query string for GET/HEAD requests, or in the body for POST requests
 	 * @param string $type HTTP request type (use \WpOrg\Requests\Requests constants)
-	 * @param array $options Options for the request (see {@see \WpOrg\Requests\Requests::request})
+	 * @param array $options Options for the request (see {@see \WpOrg\Requests\Requests::request()})
 	 * @return \WpOrg\Requests\Response
 	 */
 	public function request($url, $headers = array(), $data = array(), $type = Requests::GET, $options = array()) {
@@ -218,8 +218,8 @@ class Session {
 	 *
 	 * @see \WpOrg\Requests\Requests::request_multiple()
 	 *
-	 * @param array $requests Requests data (see {@see \WpOrg\Requests\Requests::request_multiple})
-	 * @param array $options Global and default options (see {@see \WpOrg\Requests\Requests::request})
+	 * @param array $requests Requests data (see {@see \WpOrg\Requests\Requests::request_multiple()})
+	 * @param array $options Global and default options (see {@see \WpOrg\Requests\Requests::request()})
 	 * @return array Responses (either \WpOrg\Requests\Response or a \WpOrg\Requests\Exception object)
 	 */
 	public function request_multiple($requests, $options = array()) {

--- a/src/Ssl.php
+++ b/src/Ssl.php
@@ -23,7 +23,7 @@ class Ssl {
 	 * Unfortunately, PHP doesn't check the certificate against the alternative
 	 * names, leading things like 'https://www.github.com/' to be invalid.
 	 *
-	 * @see https://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
+	 * @link https://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
 	 *
 	 * @throws \WpOrg\Requests\Exception On not obtaining a match for the host (`fsockopen.ssl.no_match`)
 	 * @param string $host Host name to verify against

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -29,7 +29,7 @@ interface Transport {
 	/**
 	 * Send multiple requests simultaneously
 	 *
-	 * @param array $requests Request data (array of 'url', 'headers', 'data', 'options') as per {@see \WpOrg\Requests\Transport::request}
+	 * @param array $requests Request data (array of 'url', 'headers', 'data', 'options') as per {@see \WpOrg\Requests\Transport::request()}
 	 * @param array $options Global options, see {@see \WpOrg\Requests\Requests::response()} for documentation
 	 * @return array Array of \WpOrg\Requests\Response objects (may contain \WpOrg\Requests\Exception or string responses as well)
 	 */

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -43,7 +43,7 @@ class Curl implements Transport {
 	/**
 	 * Information on the current request
 	 *
-	 * @var array cURL information array, see {@see https://www.php.net/curl_getinfo}
+	 * @var array cURL information array, see {@link https://www.php.net/curl_getinfo}
 	 */
 	public $info;
 
@@ -546,7 +546,7 @@ class Curl implements Transport {
 	 * Format a URL given GET data
 	 *
 	 * @param string $url
-	 * @param array|object $data Data to build query using, see {@see https://www.php.net/http_build_query}
+	 * @param array|object $data Data to build query using, see {@link https://www.php.net/http_build_query}
 	 * @return string URL with data
 	 */
 	protected static function format_get($url, $data) {

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -334,7 +334,7 @@ class Fsockopen implements Transport {
 	/**
 	 * Send multiple requests simultaneously
 	 *
-	 * @param array $requests Request data (array of 'url', 'headers', 'data', 'options') as per {@see \WpOrg\Requests\Transport::request}
+	 * @param array $requests Request data (array of 'url', 'headers', 'data', 'options') as per {@see \WpOrg\Requests\Transport::request()}
 	 * @param array $options Global options, see {@see \WpOrg\Requests\Requests::response()} for documentation
 	 * @return array Array of \WpOrg\Requests\Response objects (may contain \WpOrg\Requests\Exception or string responses as well)
 	 */

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -39,7 +39,7 @@ class Fsockopen implements Transport {
 	/**
 	 * Stream metadata
 	 *
-	 * @var array Associative array of properties, see {@see https://www.php.net/stream_get_meta_data}
+	 * @var array Associative array of properties, see {@link https://www.php.net/stream_get_meta_data}
 	 */
 	public $info;
 
@@ -384,7 +384,7 @@ class Fsockopen implements Transport {
 	 * Format a URL given GET data
 	 *
 	 * @param array $url_parts
-	 * @param array|object $data Data to build query using, see {@see https://www.php.net/http_build_query}
+	 * @param array|object $data Data to build query using, see {@link https://www.php.net/http_build_query}
 	 * @return string URL with data
 	 */
 	protected static function format_get($url_parts, $data) {
@@ -434,7 +434,7 @@ class Fsockopen implements Transport {
 	 * names, leading things like 'https://www.github.com/' to be invalid.
 	 * Instead
 	 *
-	 * @see https://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
+	 * @link https://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
 	 *
 	 * @throws \WpOrg\Requests\Exception On failure to connect via TLS (`fsockopen.ssl.connect_error`)
 	 * @throws \WpOrg\Requests\Exception On not obtaining a match for the host (`fsockopen.ssl.no_match`)


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [ ] New feature
- [x] Code quality improvement

## Context

Improving the generated documentation for the website.


## Detailed Description

### Docs: use @link tags for external references

### Docs: use parentheses when referencing a function in a @see tag

### Docs: use fully qualified names in @see tags [1]

... for Requests native classes to prevent confusion.

### Docs: use fully qualified names in @see tags [2]

... for external (PHP native) classes.

Previously, APIGen would add an incorrect link for this reference, which had to be removed for each website update.
With this change, that manual update can now hopefully be prevented.




## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.
