### PR TITLE
Introduce WpOrg\Requests\Port class

### DIFF
--- a/src/Iri.php
+++ b/src/Iri.php
@@ -10,6 +10,7 @@ namespace WpOrg\Requests;
 
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Ipv6;
+use WpOrg\Requests\Port;
 
 /**
  * IRI parser/serialiser/normaliser
@@ -128,19 +129,19 @@ class Iri {
 	 */
 	protected $normalization = array(
 		'acap' => array(
-			'port' => 674
+			'port' => Port::ACAP,
 		),
 		'dict' => array(
-			'port' => 2628
+			'port' => Port::DICT,
 		),
 		'file' => array(
-			'ihost' => 'localhost'
+			'ihost' => 'localhost',
 		),
 		'http' => array(
-			'port' => 80,
+			'port' => Port::HTTP,
 		),
 		'https' => array(
-			'port' => 443,
+			'port' => Port::HTTPS,
 		),
 	);
 

--- a/src/Port.php
+++ b/src/Port.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Port utilities for Requests
+ *
+ * @package Requests
+ * @subpackage Utilities
+ *
+ * @since 2.0.0
+ */
+
+namespace WpOrg\Requests;
+
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
+
+/**
+ * Find the correct port depending on the Request type.
+ *
+ * @package Requests
+ * @subpackage Utilities
+ *
+ * @since 2.0.0
+ */
+final class Port {
+
+	/**
+	 * Port to use with Acap requests.
+	 *
+	 * @var int
+	 */
+	const ACAP = 674;
+
+	/**
+	 * Port to use with Dictionary requests.
+	 *
+	 * @var int
+	 */
+	const DICT = 2628;
+
+	/**
+	 * Port to use with HTTP requests.
+	 *
+	 * @var int
+	 */
+	const HTTP = 80;
+
+	/**
+	 * Port to use with HTTP over SSL requests.
+	 *
+	 * @var int
+	 */
+	const HTTPS = 443;
+
+	/**
+	 * Retrieve the port number to use.
+	 *
+	 * @param string $type Request type.
+	 *                     The following requests types are supported:
+	 *                     'acap', 'dict', 'http' and 'https'.
+	 *
+	 * @return int
+	 *
+	 * @throws WpOrg\Requests\ExceptionInvalidArgument When a non-string input has been passed.
+	 * @throws WpOrg\Requests\Exception                When a non-supported port is requested ('portnotsupported').
+	 */
+	public static function get($type) {
+		if (!is_string($type)) {
+			throw InvalidArgument::create(1, '$type', 'string', gettype($type));
+		}
+
+		$type = strtoupper($type);
+		if (!defined("self::{$type}")) {
+			$message = sprintf('Invalid port type (%s) passed', $type);
+			throw new Exception($message, 'portnotsupported');
+		}
+
+		return constant("self::{$type}");
+	}
+}

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -10,6 +10,7 @@ namespace WpOrg\Requests\Transport;
 
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Port;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Ssl;
 use WpOrg\Requests\Transport;
@@ -90,7 +91,7 @@ final class Fsockopen implements Transport {
 		if (isset($url_parts['scheme']) && strtolower($url_parts['scheme']) === 'https') {
 			$remote_socket = 'ssl://' . $host;
 			if (!isset($url_parts['port'])) {
-				$url_parts['port'] = 443;
+				$url_parts['port'] = Port::HTTPS;
 			}
 
 			$context_options = array(
@@ -133,7 +134,7 @@ final class Fsockopen implements Transport {
 		$this->max_bytes = $options['max_bytes'];
 
 		if (!isset($url_parts['port'])) {
-			$url_parts['port'] = 80;
+			$url_parts['port'] = Port::HTTP;
 		}
 		$remote_socket .= ':' . $url_parts['port'];
 
@@ -196,9 +197,10 @@ final class Fsockopen implements Transport {
 		}
 
 		if (!isset($case_insensitive_headers['Host'])) {
-			$out .= sprintf('Host: %s', $url_parts['host']);
+			$out         .= sprintf('Host: %s', $url_parts['host']);
+			$scheme_lower = strtolower($url_parts['scheme']);
 
-			if ((strtolower($url_parts['scheme']) === 'http' && $url_parts['port'] !== 80) || (strtolower($url_parts['scheme']) === 'https' && $url_parts['port'] !== 443)) {
+			if (($scheme_lower === 'http' && $url_parts['port'] !== Port::HTTP) || ($scheme_lower === 'https' && $url_parts['port'] !== Port::HTTPS)) {
 				$out .= ':' . $url_parts['port'];
 			}
 			$out .= "\r\n";

--- a/tests/PortTest.php
+++ b/tests/PortTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace WpOrg\Requests\Tests;
+
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Port;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Port::get
+ */
+final class PortTest extends TestCase {
+
+	/**
+	 * Test retrieving a port based on a passed input value.
+	 *
+	 * @dataProvider dataGetPort
+	 *
+	 * @param mixed $input    Input to pass to the function.
+	 * @param int   $expected Expected function return value.
+	 *
+	 * @return void
+	 */
+	public function testGetPort($input, $expected) {
+		$this->assertSame($expected, Port::get($input));
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataGetPort() {
+		return array(
+			'lowercase type' => array(
+				'input'    => 'https',
+				'expected' => Port::HTTPS,
+			),
+			'mixed type' => array(
+				'input'    => 'Dict',
+				'expected' => Port::DICT,
+			),
+			'uppercase type' => array(
+				'input'    => 'ACAP',
+				'expected' => Port::ACAP,
+			),
+		);
+	}
+
+	/**
+	 * Test that when a $type parameter of an incorrect type gets passed, an exception gets thrown.
+	 *
+	 * @dataProvider dataGetPortThrowsExceptionOnInvalidInputType
+	 *
+	 * @param mixed $input Input to pass to the function.
+	 *
+	 * @return void
+	 */
+	public function testGetPortThrowsExceptionOnInvalidInputType($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($type) must be of type string');
+
+		Port::get($input);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataGetPortThrowsExceptionOnInvalidInputType() {
+		return array(
+			'null'                => array(null),
+			'integer port number' => array(443),
+		);
+	}
+
+	/**
+	 * Test that when an unsupported port type is requested, an exception gets thrown.
+	 *
+	 * @dataProvider dataGetPortThrowsExceptionOnUnsupportedPortType
+	 *
+	 * @param string $input Input to pass to the function.
+	 *
+	 * @return void
+	 */
+	public function testGetPortThrowsExceptionOnUnsupportedPortType($input) {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Invalid port type');
+
+		Port::get($input);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataGetPortThrowsExceptionOnUnsupportedPortType() {
+		return array(
+			'type not supported' => array('FTP'),
+			'empty string'       => array(''),
+		);
+	}
+}


### PR DESCRIPTION
... to encapsulate Port numbers and allow for retrieving a port number based on a supported request type.

Includes unit tests.

Part of a PR series to address #513