### PR TITLE
Requests: set default options as a constant

### DIFF
--- a/src/Requests.php
+++ b/src/Requests.php
@@ -108,6 +108,38 @@ class Requests {
 	const DEFAULT_CERT_PATH = __DIR__ . '/../certificates/cacert.pem';
 
 	/**
+	 * Option defaults.
+	 *
+	 * @see \WpOrg\Requests\Requests::get_default_options()
+	 * @see \WpOrg\Requests\Requests::request() for values returned by this method
+	 *
+	 * @since 2.0.0
+	 *
+	 * @var array
+	 */
+	const OPTION_DEFAULTS = array(
+		'timeout'          => 10,
+		'connect_timeout'  => 10,
+		'useragent'        => 'php-requests/' . self::VERSION,
+		'protocol_version' => 1.1,
+		'redirected'       => 0,
+		'redirects'        => 10,
+		'follow_redirects' => true,
+		'blocking'         => true,
+		'type'             => self::GET,
+		'filename'         => false,
+		'auth'             => false,
+		'proxy'            => false,
+		'cookies'          => false,
+		'max_bytes'        => false,
+		'idn'              => true,
+		'hooks'            => null,
+		'transport'        => null,
+		'verify'           => null,
+		'verifyname'       => true,
+	);
+
+	/**
 	 * Current version of Requests
 	 *
 	 * @var string
@@ -493,27 +525,9 @@ class Requests {
 	 * @return array Default option values
 	 */
 	protected static function get_default_options($multirequest = false) {
-		$defaults = array(
-			'timeout'          => 10,
-			'connect_timeout'  => 10,
-			'useragent'        => 'php-requests/' . self::VERSION,
-			'protocol_version' => 1.1,
-			'redirected'       => 0,
-			'redirects'        => 10,
-			'follow_redirects' => true,
-			'blocking'         => true,
-			'type'             => self::GET,
-			'filename'         => false,
-			'auth'             => false,
-			'proxy'            => false,
-			'cookies'          => false,
-			'max_bytes'        => false,
-			'idn'              => true,
-			'hooks'            => null,
-			'transport'        => null,
-			'verify'           => self::get_certificate_path(),
-			'verifyname'       => true,
-		);
+		$defaults           = static::OPTION_DEFAULTS;
+		$defaults['verify'] = self::get_certificate_path();
+
 		if ($multirequest !== false) {
 			$defaults['complete'] = null;
 		}


### PR DESCRIPTION
These values do not change during the request, so should be a constant and as the minimum PHP version is now PHP 5.6, we can use constant scalar expressions and constant arrays in constants.

Note: as this class is not final, I'm using `static` for the option defaults, but for security purposes, using `self` for the call to `get_certificate_path()`.
👉🏻 Should the `Requests::get_certificate_path()` method be made `final` ?

Part of a PR series to address #513