### PR TITLE
Requests: set default transports as a constant

### DIFF
--- a/src/Requests.php
+++ b/src/Requests.php
@@ -140,6 +140,18 @@ class Requests {
 	);
 
 	/**
+	 * Default supported Transport classes.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @var array
+	 */
+	const DEFAULT_TRANSPORTS = array(
+		Curl::class      => Curl::class,
+		Fsockopen::class => Fsockopen::class,
+	);
+
+	/**
 	 * Current version of Requests
 	 *
 	 * @var string
@@ -186,13 +198,10 @@ class Requests {
 	 */
 	public static function add_transport($transport) {
 		if (empty(self::$transports)) {
-			self::$transports = array(
-				Curl::class,
-				Fsockopen::class,
-			);
+			self::$transports = self::DEFAULT_TRANSPORTS;
 		}
 
-		self::$transports = array_merge(self::$transports, array($transport));
+		self::$transports[$transport] = $transport;
 	}
 
 	/**
@@ -216,10 +225,7 @@ class Requests {
 		// @codeCoverageIgnoreEnd
 
 		if (empty(self::$transports)) {
-			self::$transports = array(
-				Curl::class,
-				Fsockopen::class,
-			);
+			self::$transports = self::DEFAULT_TRANSPORTS;
 		}
 
 		// Find us a working transport

--- a/tests/Auth/BasicTest.php
+++ b/tests/Auth/BasicTest.php
@@ -6,16 +6,8 @@ use WpOrg\Requests\Auth\Basic;
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
-use WpOrg\Requests\Transport\Curl;
-use WpOrg\Requests\Transport\Fsockopen;
 
 final class BasicTest extends TestCase {
-	public static function transportProvider() {
-		return array(
-			array(Fsockopen::class),
-			array(Curl::class),
-		);
-	}
 
 	/**
 	 * @dataProvider transportProvider

--- a/tests/Proxy/HttpTest.php
+++ b/tests/Proxy/HttpTest.php
@@ -6,7 +6,6 @@ use WpOrg\Requests\Exception;
 use WpOrg\Requests\Proxy\Http;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
-use WpOrg\Requests\Transport\Curl;
 use WpOrg\Requests\Transport\Fsockopen;
 
 final class HttpTest extends TestCase {
@@ -24,13 +23,6 @@ final class HttpTest extends TestCase {
 		if (!$has_proxy) {
 			$this->markTestSkipped('Proxy not available');
 		}
-	}
-
-	public function transportProvider() {
-		return array(
-			array(Curl::class),
-			array(Fsockopen::class),
-		);
 	}
 
 	/**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,24 @@
 
 namespace WpOrg\Requests\Tests;
 
+use WpOrg\Requests\Requests;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase as Polyfill_TestCase;
 
 abstract class TestCase extends Polyfill_TestCase {
 
+	/**
+	 * Data provider for use in tests which need to be run against all default supported transports.
+	 *
+	 * @var array
+	 */
+	public function transportProvider() {
+		$data = array();
+
+		foreach (Requests::DEFAULT_TRANSPORTS as $transport) {
+			$name        = substr($transport, (strrpos($transport, '\\') + 1));
+			$data[$name] = array($transport);
+		}
+
+		return $data;
+	}
 }


### PR DESCRIPTION
The default supported transports do not change during the request, so should be a constant and as the minimum PHP version is now PHP 5.6, we can use constant arrays.

I've elected to set this array with the same value for key and value to allow using `isset()` against the array.
I've also adjusted the `Requests::add_transport()` method to set the key as well, which automatically allows us to get rid of the expensive and unnecessary `array_merge()`.

The list of supported constants was also used in multiple (duplicate) data providers in the tests.
This duplication has been removed by adding this data provider to the base `TestCase`, making it available to all tests.

The data provider in the base `TestCase`:
* Makes use of the new constant to always provide the list of all supported transport classes.
* Has been set up to provide named data sets to allow for more descriptive tests when running the tests using `--testdox` and for easier debugging.

Part of a PR series to address #513