### PR TITLE
InvalidArgument: add new `create()` method

### DIFF
--- a/src/Exception/InvalidArgument.php
+++ b/src/Exception/InvalidArgument.php
@@ -10,4 +10,32 @@ use InvalidArgumentException;
  * @package Requests
  * @since   2.0.0
  */
-final class InvalidArgument extends InvalidArgumentException {}
+final class InvalidArgument extends InvalidArgumentException {
+
+	/**
+	 * Create a new invalid argument exception with a standardized text.
+	 *
+	 * @param int    $position The argument position in the function signature. 1-based.
+	 * @param string $name     The argument name in the function signature.
+	 * @param string $expected The argument type expected as a string.
+	 * @param string $received The actual argument type received.
+	 *
+	 * @return \WpOrg\Requests\Exception\InvalidArgument
+	 */
+	public static function create($position, $name, $expected, $received) {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+		return new self(
+			sprintf(
+				'%s::%s(): Argument #%d (%s) must be of type %s, %s given',
+				$stack[1]['class'],
+				$stack[1]['function'],
+				$position,
+				$name,
+				$expected,
+				$received
+			)
+		);
+	}
+}

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -146,16 +146,7 @@ final class Curl implements Transport {
 			} elseif (is_int($data) || is_float($data)) {
 				$data = (string) $data;
 			} else {
-				throw new InvalidArgument(
-					sprintf(
-						'%s: Argument #%d (%s) must be of type %s, %s given',
-						__METHOD__,
-						3,
-						'$data',
-						'array|string',
-						gettype($data)
-					)
-				);
+				throw InvalidArgument::create(3, '$data', 'array|string', gettype($data));
 			}
 		}
 

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -71,16 +71,7 @@ final class Fsockopen implements Transport {
 			} elseif (is_int($data) || is_float($data)) {
 				$data = (string) $data;
 			} else {
-				throw new InvalidArgument(
-					sprintf(
-						'%s: Argument #%d (%s) must be of type %s, %s given',
-						__METHOD__,
-						3,
-						'$data',
-						'array|string',
-						gettype($data)
-					)
-				);
+				throw InvalidArgument::create(3, '$data', 'array|string', gettype($data));
 			}
 		}
 

--- a/tests/Exception/InvalidArgumentTest.php
+++ b/tests/Exception/InvalidArgumentTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Exception;
+
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Exception\InvalidArgument
+ */
+final class InvalidArgumentTest extends TestCase {
+
+	/**
+	 * Test that the text of the exception is as expected.
+	 *
+	 * @return void
+	 */
+	public function testCreate() {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('InvalidArgumentTest::testCreate(): Argument #2 ($dummy) must be of type int|null, string given');
+
+		throw InvalidArgument::create(2, '$dummy', 'int|null', 'string');
+	}
+}


### PR DESCRIPTION
### InvalidArgument: add new create() method

... to allow for standardizing the messages thrown via this Exception.

Note: the `parent::__construct()` method is not overloaded with a `private` version, so variation is still possible, just not recommended.

Includes adding a perfunctory unit test for the new method.

### Transport classes: implement use of the new `InvalidArgument::create()` method

