### PR TITLE
Various minor docs fixes

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -35,13 +35,13 @@ Available Hooks
     Set cURL options before the transport sets any (note that Requests may
     override these).
 
-    Parameters: `cURL resource &$fp`
+    Parameters: `cURL resource|CurlHandle &$fp`
 
 * **`curl.before_send`**
 
     Set cURL options just before the request is actually sent via `curl_exec()`.
 
-    Parameters: `cURL resource &$fp`
+    Parameters: `cURL resource|CurlHandle &$fp`
 
 * **`curl.after_request`**
 

--- a/src/Auth/Basic.php
+++ b/src/Auth/Basic.php
@@ -67,7 +67,7 @@ class Basic implements Auth {
 	/**
 	 * Set cURL parameters before the data is sent
 	 *
-	 * @param resource $handle cURL resource
+	 * @param resource|\CurlHandle $handle cURL handle
 	 */
 	public function curl_before_send(&$handle) {
 		curl_setopt($handle, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);

--- a/src/Exception/Http.php
+++ b/src/Exception/Http.php
@@ -49,7 +49,9 @@ class Http extends Exception {
 	}
 
 	/**
-	 * Get the status message
+	 * Get the status message.
+	 *
+	 * @return string
 	 */
 	public function getReason() {
 		return $this->reason;

--- a/src/Exception/Transport/Curl.php
+++ b/src/Exception/Transport/Curl.php
@@ -33,6 +33,14 @@ class Curl extends Transport {
 	 */
 	protected $reason = 'Unknown';
 
+	/**
+	 * Create a new exception.
+	 *
+	 * @param string $message Exception message.
+	 * @param string $type    Exception type.
+	 * @param mixed  $data    Associated data, if applicable.
+	 * @param int    $code    Exception numerical code, if applicable.
+	 */
 	public function __construct($message, $type, $data = null, $code = 0) {
 		if ($type !== null) {
 			$this->type = $type;

--- a/src/Exception/Transport/Curl.php
+++ b/src/Exception/Transport/Curl.php
@@ -51,7 +51,9 @@ class Curl extends Transport {
 	}
 
 	/**
-	 * Get the error message
+	 * Get the error message.
+	 *
+	 * @return string
 	 */
 	public function getReason() {
 		return $this->reason;

--- a/src/Proxy/Http.php
+++ b/src/Proxy/Http.php
@@ -102,7 +102,7 @@ class Http implements Proxy {
 	 * Set cURL parameters before the data is sent
 	 *
 	 * @since 1.6
-	 * @param resource $handle cURL resource
+	 * @param resource|\CurlHandle $handle cURL handle
 	 */
 	public function curl_before_send(&$handle) {
 		curl_setopt($handle, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -901,7 +901,7 @@ class Requests {
 		// If the data is Huffman Encoded, we must first strip the leading 2
 		// byte Huffman marker for gzinflate()
 		// The response is Huffman coded by many compressors such as
-		// java.util.zip.Deflater, Ruby’s Zlib::Deflate, and .NET's
+		// java.util.zip.Deflater, Ruby's Zlib::Deflate, and .NET's
 		// System.IO.Compression.DeflateStream.
 		//
 		// See https://decompres.blogspot.com/ for a quick explanation of this

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -95,7 +95,9 @@ class Headers extends CaseInsensitiveDictionary {
 	/**
 	 * Get an iterator for the data
 	 *
-	 * Converts the internal
+	 * Converts the internally stored values to a comma-separated string if there is more
+	 * than one value for a key.
+	 *
 	 * @return \ArrayIterator
 	 */
 	public function getIterator() {

--- a/src/Ssl.php
+++ b/src/Ssl.php
@@ -25,7 +25,6 @@ class Ssl {
 	 *
 	 * @link https://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
 	 *
-	 * @throws \WpOrg\Requests\Exception On not obtaining a match for the host (`fsockopen.ssl.no_match`)
 	 * @param string $host Host name to verify against
 	 * @param array $cert Certificate data from openssl_x509_parse()
 	 * @return bool

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -57,7 +57,7 @@ class Curl implements Transport {
 	/**
 	 * cURL handle
 	 *
-	 * @var resource
+	 * @var resource|\CurlHandle Resource in PHP < 8.0, Instance of CurlHandle in PHP >= 8.0.
 	 */
 	protected $handle;
 
@@ -315,7 +315,7 @@ class Curl implements Transport {
 	 * @param array $headers Associative array of request headers
 	 * @param string|array $data Data to send either as the POST body, or as parameters in the URL for a GET/HEAD
 	 * @param array $options Request options, see {@see \WpOrg\Requests\Requests::response()} for documentation
-	 * @return resource Subrequest's cURL handle
+	 * @return resource|\CurlHandle Subrequest's cURL handle
 	 */
 	public function &get_subrequest_handle($url, $headers, $data, $options) {
 		$this->setup_handle($url, $headers, $data, $options);
@@ -484,7 +484,7 @@ class Curl implements Transport {
 	/**
 	 * Collect the headers as they are received
 	 *
-	 * @param resource $handle cURL resource
+	 * @param resource|\CurlHandle $handle cURL handle
 	 * @param string $headers Header string
 	 * @return integer Length of provided header
 	 */
@@ -509,7 +509,7 @@ class Curl implements Transport {
 	 *
 	 * @since 1.6.1
 	 *
-	 * @param resource $handle cURL resource
+	 * @param resource|\CurlHandle $handle cURL handle
 	 * @param string $data Body data
 	 * @return integer Length of provided data
 	 */

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -213,7 +213,7 @@ class Curl implements Transport {
 		$this->process_response($response, $options);
 
 		// Need to remove the $this reference from the curl handle.
-		// Otherwise \WpOrg\Requests\Transport\Curl wont be garbage collected and the curl_close() will never be called.
+		// Otherwise \WpOrg\Requests\Transport\Curl won't be garbage collected and the curl_close() will never be called.
 		curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, null);
 		curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, null);
 


### PR DESCRIPTION
### Docs: remove stray unicode character from docs

### Ssl: remove incorrect @throws tag

This method does not throw.

### Docs: add missing @return tags

### Docs: add missing method docblock

### Headers::getIterator() fix up comment in docblock

... which was clearly unfinished.

### Documentation: fix minor grammar error 

### Documentation: fix references to Curl resources

The PHP Curl extension worked with a Curl resource in PHP 4/5/7. As of PHP 8.0, `curl_init()` returns an instance of `CurlHandle` instead of a resource.

This updates the documentation to indicate that either a `resource` or `CurlHandle` instance can be expected in certain places in the code base (and that both are supported).

Ref: https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.resource2object

