### PR TITLE
GH Actions: add GH Pages update workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 .github/ export-ignore
+build/ export-ignore
 docs/ export-ignore
 examples/ export-ignore
 tests/ export-ignore
@@ -6,4 +7,5 @@ tests/ export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .phpcs.xml.dist export-ignore
+phpdoc.dist.xml export-ignore
 phpunit.xml.dist export-ignore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,4 +49,9 @@ jobs:
           composer-options: --ignore-platform-reqs
 
       - name: Lint against parse errors
+        if: ${{ matrix.php >= '7.2' }}
         run: composer lint -- --checkstyle | cs2pr
+
+      - name: Lint against parse errors
+        if: ${{ matrix.php < '7.2' }}
+        run: composer lint -- --exclude build --checkstyle | cs2pr

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -1,0 +1,166 @@
+name: Build website
+
+on:
+  # Trigger the workflow whenever a new release is created.
+  release:
+    types:
+      - published
+  # And whenever this workflow or one of the associated scripts is updated.
+  pull_request:
+    paths:
+      - '.github/workflows/update-website.yml'
+      - 'build/ghpages/**'
+  # Also allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  prepare:
+    name: "Prepare website update"
+    # Don't run on forks.
+    if: github.repository == 'WordPress/Requests'
+
+    runs-on: ubuntu-latest
+    steps:
+      # By default use the `stable` branch as the published docs should always
+      # reflect the latest release.
+      # For testing changes to the workflow or the scripts, use the PR branch
+      # to have access to the latest version of the workflow/scripts.
+      - name: Determine branch to use
+        id: base_branch
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo '::set-output name=BRANCH::${{ github.ref }}'
+          else
+            echo '::set-output name=BRANCH::stable'
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.base_branch.outputs.BRANCH }}
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          ini-values: display_errors=On
+          coverage: none
+
+      # This will install the phpDocumentor PHAR, not the "normal" dependencies.
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: "--working-dir=build/ghpages/"
+
+      - name: Update the phpDoc configuration
+        run: php build/ghpages/update-docgen-config.php
+
+      - name: Generate the phpDoc documentation
+        run: php build/ghpages/vendor/bin/phpdoc
+
+      - name: Transform the markdown docs for use in GH Pages
+        run: php build/ghpages/update-markdown-docs.php
+
+      # Retention is normally 90 days, but this artifact is only for review
+      # and use in the next step, so no need to keep it for more than a day.
+      - name: Upload the artifacts folder
+        uses: actions/upload-artifact@v2
+        if: ${{ success() }}
+        with:
+          name: website-updates
+          path: ./build/ghpages/artifacts
+          if-no-files-found: error
+          retention-days: 1
+
+  createpr:
+    name: "Create website update PR"
+    needs: prepare
+    # Don't run on forks.
+    if: github.repository == 'WordPress/Requests'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Download the prepared artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: website-updates
+          path: artifacts
+
+      # Different version of phpDocumentor may add/remove files for CSS/JS etc.
+      # Similarly, a new Requests major may remove classes.
+      # So we always need to make sure that the old version of the API docs are
+      # cleared out completely.
+      - name: Clear out the API directory
+        run: rm -vrf ./api/*
+
+      - name: Move the updated API doc files
+        run: mv -fv artifacts/api/* ./api/
+
+      # The commit should contain all changes in the API directory, both tracked and untracked!
+      - name: Commit the API docs separately
+        run: |
+          git config user.name 'GitHub Action'
+          git config user.email '${{ github.actor }}@users.noreply.github.com'
+          git add -A ./api/
+          git commit --allow-empty --message="GH Pages: update API docs for Requests ${{ github.ref }}"
+
+      # Similar to the API docs, files could be removed from the prose docs, so
+      # make sure that the directory is cleared out completely beforehand.
+      - name: Clear out the docs directory
+        run: rm -vf ./docs/*
+
+      - name: Move the other updated files
+        run: |
+          mv -fv artifacts/docs/* ./docs
+          mv -fv artifacts/_includes/* ./_includes
+          mv -fv artifacts/index.md ./index.md
+
+      - name: Verify artifacts directory is now empty
+        run: ls -alR artifacts
+
+      # The directory is also gitignored, but just to be sure.
+      - name: Remove the artifacts directory
+        run: rmdir --ignore-fail-on-non-empty --verbose ./artifacts
+
+      # PRs based on the "pull request" event trigger will contain changes from the
+      # current `develop` branch, so should not be published as the website should
+      # always be based on the latest release.
+      - name: Determine PR title prefix, body and more
+        id: get_pr_info
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo '::set-output name=PR_TITLE_PREFIX::[TEST | DO NOT MERGE] '
+            echo '::set-output name=PR_BODY::Test run for the website update after changes to the automated scripts.'
+            echo '::set-output name=DRAFT::true'
+          else
+            echo '::set-output name=PR_TITLE_PREFIX::'
+            echo '::set-output name=PR_BODY::Website update after the release of Requests ${{ github.ref }}.'
+            echo '::set-output name=DRAFT::false'
+          fi
+
+      - name: Show status
+        run: git status -vv --untracked=all
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: gh-pages
+          branch: feature/auto-ghpages-update-${{ github.ref }}
+          delete-branch: true
+          commit-message: "GH Pages: update other docs for Requests ${{ github.ref }}"
+          title: "${{ steps.get_pr_info.outputs.PR_TITLE_PREFIX }}:books: Update GHPages website"
+          body: |
+            ${{ steps.get_pr_info.outputs.PR_BODY }}
+
+            This PR is auto-generated by [create-pull-request](https://github.com/peter-evans/create-pull-request).
+          labels: |
+            "Type: documentation"
+          reviewer: |
+            jrfnl
+            schlessera
+          draft: ${{ steps.get_pr_info.outputs.DRAFT }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ tests/coverage/*
 # Ignore composer related files
 /composer.lock
 /vendor
+build/ghpages/composer.lock
+build/ghpages/vendor
 
 # Ignore local overrides of the PHPCS config file.
 .phpcs.xml
@@ -11,3 +13,8 @@ phpcs.xml
 
 # Ignore PHPUnit results cache file.
 .phpunit.result.cache
+
+# Ignore temporary files for ghpages builds.
+phpdoc.xml
+build/ghpages/.phpdoc
+build/ghpages/artifacts

--- a/build/ghpages/README.md
+++ b/build/ghpages/README.md
@@ -1,0 +1,27 @@
+Scripts to update the GitHub Pages website
+======================================
+
+The scripts in this directory are only for internal use to update the GitHub Pages website associated with this project whenever a new version of the Requests library is released.
+
+They are used in the [`update-website.yml`](https://github.com/WordPress/Requests/blob/develop/.github/workflows/update-website.yml) GitHub Actions workflow.
+
+To run a test build of the GitHub Pages site locally, execute the following steps:
+
+Preparation in this repo:
+* Pre-requisite: use PHP 7.2 or higher.
+* From within this subdirectory, run `composer update -W`.
+* Delete the `build/ghpages/artifacts` subdirectory completely.
+
+Preparation of the GitHub Pages branch:
+* Clone this repo a second time outside of the root of this clone and check out the `gh-pages` branch.
+* Create a new branch (git).
+* Delete the `api` directory completely.
+* Delete the `docs` directory completely.
+
+Switch to the project root directory in this clone and:
+* Run `php build/ghpages/update-docgen-config.php` to retrieve the latest tag number from the GH API and create/update the `phpdoc.xml` config.
+* If this was the first time you ran the above script, you now need to edit the `phpdoc.xml` file and update the path in the `<paths>` - `<output>` config to point to the `root/api` directory of the "gh-pages" clone of the repo.
+* Run `php build/ghpages/vendor/bin/phpdoc` to generate the API docs.
+* Run `php build/ghpages/update-markdown-docs.php --target=path/to/gh-pages/root` to generate versions of the markdown docs suitable for use in GH Pages.
+
+You can then use git diff to verify the GH Pages site was updated correctly.

--- a/build/ghpages/UpdateMarkdown.php
+++ b/build/ghpages/UpdateMarkdown.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Update the markdown based documentation files.
+ *
+ * {@internal This functionality has a minimum PHP requirement of PHP 7.2.}
+ *
+ * @internal
+ *
+ * @package Requests
+ * @subpackage GHPages
+ *
+ * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.stringFound
+ * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.intFound
+ * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.stringFound
+ * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.voidFound
+ * @phpcs:disable PHPCompatibility.FunctionUse.NewFunctionParameters.dirname_levelsFound
+ */
+
+namespace WpOrg\Requests\GHPages;
+
+use RuntimeException;
+
+class UpdateMarkdown {
+
+	/**
+	 * Target directory for the updated/transformed files.
+	 *
+	 * @var string
+	 */
+	private $target = __DIR__ . '/artifacts';
+
+	/**
+	 * Frontmatter for the website homepage.
+	 *
+	 * @var string
+	 */
+	private $home_frontmatter = '---
+layout: home
+title:
+---
+';
+
+	/**
+	 * Frontmatter template for files in the docs directory.
+	 *
+	 * @var string
+	 */
+	private $docs_frontmatter = '---
+layout: documentation
+title: %s
+---
+';
+
+	/**
+	 * Constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		$this->process_cli_args();
+	}
+
+	/**
+	 * Process received CLI arguments.
+	 *
+	 * Only one argument is supported: "--target" to set the target path.
+	 *
+	 * @return void
+	 */
+	private function process_cli_args(): void {
+		$args = $_SERVER['argv'];
+
+		// Remove the call to the script itself.
+		\array_shift($args);
+
+		if (empty($args)) {
+			// No options set.
+			return;
+		}
+
+		foreach ($args as $arg) {
+			preg_match('`--target=([\'"])?([^\'"]+)\1?`', $arg, $matches);
+			if (empty($matches) || isset($matches[2]) === false) {
+				// Not a valid CLI argument, only "target" is supported.
+				continue;
+			}
+
+			$cwd    = getcwd();
+			$target = $matches[2];
+
+			/*
+			 * Attempt some minimal path resolving.
+			 * Note: the target directory may not exist, so just guestimating for most common cases here.
+			 */
+			if (strpos($target, '..') !== 0 && $target[0] === '.') {
+				$this->target = $cwd . substr($target, 1);
+				break;
+			}
+
+			if (strpos($target, '..') === 0) {
+				while (strpos($target, '../') === 0 || strpos($target, '..\\') === 0) {
+					$cwd    = dirname($cwd);
+					$target = substr($target, 3);
+				}
+
+				$this->target = $cwd . '/' . $target;
+				break;
+			}
+
+			/*
+			 * In all other cases, presume it is a valid absolute path.
+			 * The `put_contents()` method will throw appropriate errors if it's not.
+			 */
+			$this->target = $target;
+		}
+	}
+
+	/**
+	 * Run the transformation.
+	 *
+	 * @return int Exit code.
+	 */
+	public function run(): int {
+		$exitcode = 0;
+
+		try {
+			$this->update_homepage();
+			$this->update_docs();
+		} catch (RuntimeException $e) {
+			echo 'ERROR: ', $e->getMessage(), PHP_EOL;
+			$exitcode = 1;
+		}
+
+		return $exitcode;
+	}
+
+	/**
+	 * Transform the repo README to the website homepage.
+	 *
+	 * @return void
+	 */
+	private function update_homepage(): void {
+		// Read the file.
+		$contents = $this->get_contents(dirname(__DIR__, 2) . '/README.md');
+
+		// Remove badges.
+		$contents = preg_replace(
+			'`([=]+[\n\r]+)(?:\[!\[[^\]]+\]\([^\)]+\)\]\([^\)]+\)[\n\r]+)+`',
+			'$1',
+			$contents
+		);
+
+		// Replace repo refs with GH Pages automatic replacement syntax.
+		$contents = preg_replace(
+			'`\brmccue/requests\b`',
+			'{{ site.requests.packagist }}',
+			$contents
+		);
+
+		// Replace version nr refs with GH Pages GH API automatic replacement syntax.
+		$contents = preg_replace(
+			'`"(?:>=1\.0|\^2\.0)"`',
+			'"^{{ site.github.latest_release.tag_name | replace_first: \'v\', \'\' }}"',
+			$contents
+		);
+
+		// Replace clone url refs with GH Pages GH API automatic replacement syntax.
+		$contents = str_replace(
+			'$ git clone git://github.com/WordPress/Requests.git',
+			'$ git clone {{ site.github.clone_url }}',
+			$contents
+		);
+
+		// Replace prose-based documentation link.
+		$contents = preg_replace(
+			'`\[prose-based documentation\]:[^\r\n]+`',
+			'[prose-based documentation]: {{ \'/docs/\' | prepend: site.baseurl }}',
+			$contents
+		);
+
+		// Update links.
+		$contents = $this->update_links($contents);
+
+		// Add frontmatter.
+		$contents = $this->home_frontmatter . "\n" . $contents;
+
+		// Write the file.
+		$target = $this->target . '/index.md';
+		$this->put_contents($target, $contents, 'doc index file');
+	}
+
+	/**
+	 * Transform all docs in the `docs` directory for use in GH Pages.
+	 *
+	 * @return void
+	 */
+	private function update_docs(): void {
+		// Create the file list.
+		$sep       = \DIRECTORY_SEPARATOR;
+		$pattern   = dirname(__DIR__, 2) . $sep . 'docs' . $sep . '*.md';
+		$file_list = glob($pattern, GLOB_NOESCAPE);
+
+		if (empty($file_list)) {
+			throw new RuntimeException('Failed to find doc files.');
+		}
+
+		$base_target = $this->target . '/docs/';
+
+		foreach ($file_list as $file) {
+			$basename = basename($file);
+
+			if ($basename === 'README.md') {
+				$this->update_docs_navigation($file);
+			} else {
+				$target = $base_target . $basename;
+				$this->update_doc($file, $target);
+			}
+		}
+	}
+
+	/**
+	 * Transform a "normal" docs markdown document for use in GHPages.
+	 *
+	 * @param string $source Path to the source file.
+	 * @param string $target Path to the output file.
+	 *
+	 * @return void
+	 */
+	private function update_doc(string $source, string $target): void {
+		// Read the file.
+		$contents = $this->get_contents($source);
+
+		// Grab the title.
+		$title = $this->get_title_from_contents($contents);
+		if (!$title) {
+			throw new RuntimeException(sprintf('Failed to find page title in doc file: %s', $source));
+		}
+
+		// Update links.
+		$contents = $this->update_links($contents);
+
+		// Add the frontmatter.
+		$contents = sprintf($this->docs_frontmatter, $title) . "\n" . $contents;
+
+		// Write the file.
+		$this->put_contents($target, $contents);
+	}
+
+	/**
+	 * Transform the index page of the docs directory into two separate files for use in GHPages.
+	 *
+	 * @param string $source Path to the source file.
+	 *
+	 * @return void
+	 */
+	private function update_docs_navigation(string $source): void {
+		// Read the file.
+		$contents = $this->get_contents($source);
+
+		// Update links.
+		$contents = $this->update_links($contents);
+
+		// Split the file.
+		$parts = explode('<!-- Splitter DO NOT REMOVE Splitter -->', $contents);
+
+		if (count($parts) !== 2) {
+			throw new RuntimeException(sprintf('Failed to split the docs index file: %s', $source));
+		}
+
+		/*
+		 * Create the docs index file.
+		 */
+		$docs_index = trim($parts[0]);
+
+		// Grab the title.
+		$title = $this->get_title_from_contents($contents);
+
+		// Add the frontmatter.
+		$docs_index = sprintf($this->docs_frontmatter, $title) . "\n" . $docs_index;
+
+		// Add the navigation include.
+		$docs_index .= "\n\n" . '{% include navigation.md %}';
+
+		// Write the file.
+		$target = $this->target . '/docs/index.md';
+		$this->put_contents($target, $docs_index, 'doc index file');
+
+		/*
+		 * Create the docs navigation file.
+		 */
+		$navigation = trim($parts[1]);
+
+		// Write the file.
+		$target = $this->target . '/_includes/navigation.md';
+		$this->put_contents($target, $navigation, 'navigation file');
+	}
+
+	/**
+	 * Retrieve the contents of a file.
+	 *
+	 * @param string $source Path to the source file.
+	 *
+	 * @return string
+	 */
+	private function get_contents(string $source): string {
+		$contents = file_get_contents($source);
+		if (!$contents) {
+			throw new RuntimeException(sprintf('Failed to read doc file: %s', $source));
+		}
+
+		return $contents;
+	}
+
+	/**
+	 * Write a string to a file.
+	 *
+	 * @param string $target   Path to the target file.
+	 * @param string $contents File contents to write.
+	 * @param string $type     Type of file to use in error message.
+	 *
+	 * @return string
+	 */
+	private function put_contents(string $target, string $contents, string $type = 'doc file'): void {
+		// Check if the target directory exists and if not, create it.
+		$target_dir = dirname($target);
+
+		// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged -- Silencing warnings when function fails.
+		if (@is_dir($target_dir) === false) {
+			if (@mkdir($target_dir, 0777, true) === false) {
+				throw new RuntimeException(sprintf('Failed to create the %s directory.', $target_dir));
+			}
+		}
+		// phpcs:enable WordPress
+
+		// Make sure the file always ends on a new line.
+		$contents = rtrim($contents) . "\n";
+		if (file_put_contents($target, $contents) === false) {
+			throw new RuntimeException(sprintf('Failed to write %s to target location: %s', $type, $target));
+		}
+	}
+
+	/**
+	 * Retrieve the page title from the content of a markdown file.
+	 *
+	 * @param string $contents Contents of a markdown file.
+	 *
+	 * @return string
+	 */
+	private function get_title_from_contents(string $contents): string {
+		return trim(substr($contents, 0, (strpos($contents, '===') - 1)));
+	}
+
+	/**
+	 * Update links in the contents of a markdown file to make them usable in the context of GHPages.
+	 *
+	 * @param string $contents Markdown document contents.
+	 *
+	 * @return string
+	 */
+	private function update_links(string $contents): string {
+		$contents = str_ireplace('README.md', 'index.md', $contents);
+		$contents = preg_replace('`\b(\S+)\.md\b`i', '$1.html', $contents);
+
+		return $contents;
+	}
+}

--- a/build/ghpages/composer.json
+++ b/build/ghpages/composer.json
@@ -1,0 +1,8 @@
+{
+    "require" : {
+        "php" : ">=7.2"
+    },
+    "require-dev": {
+        "phpdocumentor/shim": "^3"
+    }
+}

--- a/build/ghpages/update-docgen-config.php
+++ b/build/ghpages/update-docgen-config.php
@@ -1,0 +1,91 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Update the phpDocumentor configuration file.
+ *
+ * {@internal This functionality has a minimum PHP requirement of PHP 7.2.}
+ *
+ * @internal
+ *
+ * @package Requests
+ * @subpackage GHPages
+ *
+ * @phpcs:disable PHPCompatibility.FunctionUse.NewFunctionParameters.dirname_levelsFound
+ */
+
+namespace WpOrg\Requests\GHPages;
+
+use WpOrg\Requests\Autoload;
+use WpOrg\Requests\Requests;
+use WpOrg\Requests\Response;
+
+$requests_phpdoc_version_updater = function () {
+	// Include Requests.
+	$project_root = dirname(__DIR__, 2);
+	require_once $project_root . '/src/Autoload.php';
+	Autoload::register();
+
+	// Retrieve the information about the latest release from the GH API.
+	$response = Requests::get(
+		'https://api.github.com/repos/WordPress/Requests/releases/latest',
+		array(
+			'Accept' => 'application/vnd.github.v3+json',
+		)
+	);
+
+	if (!($response instanceof Response) || $response->success !== true || $response->status_code !== 200) {
+		echo 'ERROR: GH API request to retrieve the version number of the last release failed.', PHP_EOL;
+		exit(1);
+	}
+
+	$decoded = json_decode($response->body, true);
+	if (!isset($decoded['tag_name'])) {
+		echo 'ERROR: GH API request to retrieve the version number of the last release failed to retrieve a version number.', PHP_EOL;
+		exit(1);
+	}
+
+	$tagname = ltrim($decoded['tag_name'], 'v');
+
+	if (file_exists($project_root . '/phpdoc.xml')) {
+		echo 'WARNING: Detected pre-existing "phpdoc.xml" file.', PHP_EOL;
+		echo 'Please make sure that this overload file is in sync with the "phpdoc.dist.xml" file.', PHP_EOL;
+		echo 'This is your own responsibility!' . PHP_EOL, PHP_EOL;
+
+		$config = file_get_contents($project_root . '/phpdoc.xml');
+		if (!$config) {
+			echo 'ERROR: Failed to read phpDocumentor configuration template file.', PHP_EOL;
+			exit(1);
+		}
+
+		// Replace the previous version nr in the API doc title with the latest version number.
+		$config = preg_replace(
+			'`<title>Requests ([\#0-9\.]+) API</title>`',
+			"<title>Requests {$tagname} API</title>",
+			$config
+		);
+	} else {
+		$config = file_get_contents($project_root . '/phpdoc.dist.xml');
+		if (!$config) {
+			echo 'ERROR: Failed to read phpDocumentor configuration template file.', PHP_EOL;
+			exit(1);
+		}
+
+		// Replace the "#.#.#" placeholder in the API doc title with the latest version number.
+		$config = str_replace(
+			'<title>Requests #.#.# API</title>',
+			"<title>Requests {$tagname} API</title>",
+			$config
+		);
+	}
+
+	if (file_put_contents($project_root . '/phpdoc.xml', $config) === false) {
+		echo 'ERROR: Failed to write phpDocumentor configuration file.', PHP_EOL;
+		exit(1);
+	} else {
+		echo 'SUCCESFULLY updated/created the phpdoc.xml file!', PHP_EOL;
+	}
+
+	exit(0);
+};
+
+$requests_phpdoc_version_updater();

--- a/build/ghpages/update-markdown-docs.php
+++ b/build/ghpages/update-markdown-docs.php
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Update the markdown based documentation files.
+ *
+ * {@internal This functionality has a minimum PHP requirement of PHP 7.2.}
+ *
+ * @internal
+ *
+ * @package Requests
+ * @subpackage GHPages
+ */
+
+namespace WpOrg\Requests\GHPages;
+
+require_once __DIR__ . '/UpdateMarkdown.php';
+
+$requests_website_updater        = new UpdateMarkdown();
+$requests_website_update_success = $requests_website_updater->run();
+
+exit($requests_website_update_success);

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ here are prose; you might also want to check out the [API documentation][].
 
 [API documentation]: https://requests.ryanmccue.info/api/
 
+<!-- Splitter DO NOT REMOVE Splitter -->
+
 * Introduction
 	* [Goals][goals]
 	* [Why should I use Requests instead of X?][why-requests]

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+    configVersion="3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://www.phpdoc.org"
+    xsi:noNamespaceSchemaLocation="https://docs.phpdoc.org/latest/phpdoc.xsd"
+>
+
+    <title>Requests #.#.# API</title>
+
+    <paths>
+        <output>build/ghpages/artifacts/api/</output>
+        <cache>build/ghpages/.phpdoc/</cache>
+    </paths>
+
+    <version number="latest">
+        <api format="php">
+            <source dsn=".">
+                <path>src</path>
+            </source>
+            <visibility>public</visibility>
+            <visibility>protected</visibility>
+            <ignore-tags>
+                <ignore-tag>codeCoverageIgnore</ignore-tag>
+                <ignore-tag>phpcs</ignore-tag>
+                <ignore-tag>todo</ignore-tag>
+            </ignore-tags>
+        </api>
+    </version>
+
+    <template name="default"/>
+
+</phpdocumentor>


### PR DESCRIPTION
### GH Pages: switch from APIGen to phpDocumentor

1. APIGen 4.x does not support "modern" PHP, and that includes such things as the PHP 5.5 `::class` syntax.
2. There is an APIGen 5.x RC available, but that version is in its current state is no longer installable.
3. APIGen has not seen a release in over four years, nor a commit in more than three years and is currently unmaintained.

With that in mind, I've taken the decision to switch to the actively maintained phpDocumentor library to generate the API documentation.

This commit actions that decision by:
* Adding a base `phpdoc.dist.xml` configuration file.
* Adding a separate `composer.json` file for use when generating the API docs.
    The `require-dev` will pull in the phpDocumentor Phar via the shim package rather than install the individual dependencies.
* Adding this file and the `build` directory to the `.gitattributes` file for ignoring in distribution zips
* Adding the structure cache directory which will be used and the config overload file to the `.gitignore` file.

In a sister-PR to the `gh-pages` branch, the old `apigen.neon` config file will be removed.

Refs:
* https://github.com/ApiGen/ApiGen/releases
* https://tomasvotruba.com/blog/2017/09/04/how-apigen-survived-its-own-death/
* https://www.phpdoc.org/
* https://github.com/phpDocumentor/phpDocumentor/releases
* https://github.com/phpDocumentor/shim

### GH Pages: add script to update/generate phpDoc config

This commit adds a script which can be run both locally as well as in a GH Actions workflow.

The script:
* Will retrieve the version number of the latest Requests release from the GH API.
* If no `phpdoc.xml` file exists, it will create a `phpdoc.xml` file based on the existing `phpdoc.dist.xml` file and make sure the title contains the correct version number.
* If a `phpdoc.xml` already exists, it will just and only update the title for the docs with the correct version number.

Includes a minor tweak to the PHP `lint` workflow to exclude the scripts in the `build/ghpages` directory from linting on PHP < 7.2.

Open question: once Requests 2.0.0 has been released, should we update the website to only contain the API docs for Requests 2.0.0 or should we keep a copy of the last Requests 1.x docs available as well ?

### GH Pages: add script to update prose docs

This commit adds a script which can be run both locally as well as in a GH Actions workflow.

The script:
* Will take the `README.md` file from the main repo as well as the `md` files in the `/docs/` directory and prepare them for use in the GH Pages website.
    This preparation includes:
    - Adding frontmatter to the files for use by Jekyll.
    - Replacing `md` in links with `html`.
    - Various other tweaks depending on the file.
* The script will, by default, place the adjusted files in the `build/ghpages/artifacts` directory. For local runs where there is already a separate clone of this repo available which has the `gh-pages` branch checked out, a `--target=path/to/ghpages` CLI argument can be passed to place the files directory in the `gh-pages` clone.

Includes a minor tweaks to the `docs/README.md` file for easier processing of that file.

This script effectively replaces the `build.py` script which is in the `gh-pages` branch. That script will be removed in a sister-PR to that branch.

### GH Pages: add a README

... to the new directory containing the scripts documenting how these scripts can be run locally to test what changes would be made when the website would be updated.

### GH Actions: add an "update website" workflow

This new workflow will run when:
* A new release of Requests has been published.
* A pull request has been send in which updates the scripts which are involved in updating the website.

The workflow can also be manually triggered, but will not run in forks of this repo (as they can't update or publish the website).

👉 Open question: should the workflow always run for pushes to `stable` ?
Those will normally be the release pushes and the "next" version nr may not be known yet in that case, but if something is "off" with the website, an update to regen the website would now require a new tag (or manual trigger, but we'll have to see how well that works for this).

The script will:
* In the `prepare` job:
    - (Re-)Generate the API docs using phpDocumentor.
    - Prepare the `README` and the files in the `docs` directory for use in the website.
    - Upload the results as an artifact.
        The artifact will only be available for one day as it's only used in the next job.
* In the `createpr` job:
    - Download the artifact.
    - Remove outdated files and replace them with the newly generated ones.
        Note: files can be updated, as well as added/removed, so for the commits we need to make sure that both tracked as well as untracked changes are committed.
    - Create a PR to the `gh-pages` branch containing two commits:
        1. A commit for the API docs update.
            This commit _may_ be empty if no inline docs have been updated, though I suspect that will be exceedingly rare.
        2. A commit containing the remaining changes (docs + homepage).

For PRs created because the workflow or the associated scripts have changed, the PR title will be prefixed with `[TEST | DO NOT MERGE]` so the effect of workflow/script changes can still be verified, without updating the website with the docs for an unreleased `develop` version of Requests.
For those PRs, the website change PR will be based on the feature branch against `develop` as otherwise the action doesn't have access to the latest version of the workflow/scripts. For releases and manual triggering, the website change PR will always be based on the `stable` branch.

Note: these steps could be combined into one job, but for debugging, it felt cleaner to separate it into two jobs.

👉 Note: we'll need to monitor if a PR correctly gets created when there are no changes to the prose docs (committed via the `create-pr` action), but there are API doc changes (committed manually), I hope it will be, but we'll have to see.

Refs:
* https://github.com/marketplace/actions/create-pull-request
* https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md


Fixes #466