### PR TITLE
FilteredIteratorTest: improve tests

### DIFF
--- a/tests/Utility/FilteredIteratorTest.php
+++ b/tests/Utility/FilteredIteratorTest.php
@@ -8,8 +8,17 @@ use WpOrg\Requests\Tests\TestCase;
 use WpOrg\Requests\Utility\FilteredIterator;
 
 final class FilteredIteratorTest extends TestCase {
+
 	/**
+	 * Tests against insecure deserialization of untrusted data.
+	 *
+	 * @link https://github.com/WordPress/Requests/security/advisories/GHSA-52qp-jpq7-6c54
+	 *
 	 * @dataProvider dataSerializeDeserializeObjects
+	 *
+	 * @param \ArrayIterator $value Value to test with.
+	 *
+	 * @return void
 	 */
 	public function testDeserializeRequestUtilityFilteredIteratorObjects($value) {
 		$serialized = serialize($value);
@@ -19,18 +28,35 @@ final class FilteredIteratorTest extends TestCase {
 			$property   = $reflection->getProperty('callback');
 			$property->setAccessible(true);
 			$callback_value = $property->getValue($new_value);
-			$this->assertSame(null, $callback_value);
+			$this->assertNull($callback_value, 'Callback is not null');
 		} else {
-			$this->assertEquals($value->count(), unserialize($serialized)->count());
+			$this->assertSame(
+				$value->count(),
+				unserialize($serialized)->count(),
+				'Unserialized count is not equivalent'
+			);
 		}
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
 	public function dataSerializeDeserializeObjects() {
 		return array(
-			array(new FilteredIterator(array(1), 'md5')),
-			array(new FilteredIterator(array(1, 2), 'sha1')),
-			array(new FilteredIterator(array(1, 2, 3), 'doesnotexist')),
-			array(new ArrayIterator(array(1, 2, 3))),
+			'FilteredIterator object with one value, callback: md5' => array(
+				'value' => new FilteredIterator(array(1), 'md5'),
+			),
+			'FilteredIterator object with two values, callback: sha1' => array(
+				'value' => new FilteredIterator(array(1, 2), 'sha1'),
+			),
+			'FilteredIterator object with three values, non-existent callback' => array(
+				'value' => new FilteredIterator(array(1, 2, 3), 'doesnotexist'),
+			),
+			'ArrayIterator object with three values, no callback' => array(
+				'value' => new ArrayIterator(array(1, 2, 3)),
+			),
 		);
 	}
 }

--- a/tests/Utility/FilteredIteratorTest.php
+++ b/tests/Utility/FilteredIteratorTest.php
@@ -7,12 +7,19 @@ use ReflectionClass;
 use WpOrg\Requests\Tests\TestCase;
 use WpOrg\Requests\Utility\FilteredIterator;
 
+/**
+ * @coversDefaultClass \WpOrg\Requests\Utility\FilteredIterator
+ */
 final class FilteredIteratorTest extends TestCase {
 
 	/**
 	 * Tests against insecure deserialization of untrusted data.
 	 *
 	 * @link https://github.com/WordPress/Requests/security/advisories/GHSA-52qp-jpq7-6c54
+	 *
+	 * @covers ::unserialize
+	 * @covers ::__unserialize
+	 * @covers ::__wakeup
 	 *
 	 * @dataProvider dataSerializeDeserializeObjects
 	 *


### PR DESCRIPTION
### FilteredIteratorTest: improve the tests

* Add docblocks to the test methods.
* Add `@covers` tags.
* Use more specific assertions.
* Add the `$message` parameter to each assertion to allow for distinguishing which one failed more easily.
* Use named data sets and indexed array items in the data provider.

### FilteredIteratorTest: add @covers tags 

Note: this class could use some more tests, but at least what's there is now improved.

Related to #497