### PR TITLE
Ssl: improve tests

### DIFF
--- a/src/Ssl.php
+++ b/src/Ssl.php
@@ -131,8 +131,9 @@ final class Ssl {
 		}
 
 		// Calculate the valid wildcard match if the host is not an IP address
-		// Also validates that the host has 3 parts or more, as per Firefox's
-		// ruleset.
+		// Also validates that the host has 3 parts or more, as per Firefox's ruleset,
+		// as a wildcard reference is only allowed with 3 parts or more, so the
+		// comparison will never match if host doesn't contain 3 parts or more as well.
 		if (ip2long($host) === false) {
 			$parts    = explode('.', $host);
 			$parts[0] = '*';

--- a/src/Ssl.php
+++ b/src/Ssl.php
@@ -33,7 +33,7 @@ final class Ssl {
 		$has_dns_alt = false;
 
 		// Check the subjectAltName
-		if (!empty($cert['extensions']) && !empty($cert['extensions']['subjectAltName'])) {
+		if (!empty($cert['extensions']['subjectAltName'])) {
 			$altnames = explode(',', $cert['extensions']['subjectAltName']);
 			foreach ($altnames as $altname) {
 				$altname = trim($altname);

--- a/src/Ssl.php
+++ b/src/Ssl.php
@@ -51,15 +51,17 @@ final class Ssl {
 					return true;
 				}
 			}
+
+			if ($has_dns_alt === true) {
+				return false;
+			}
 		}
 
 		// Fall back to checking the common name if we didn't get any dNSName
 		// alt names, as per RFC2818
-		if (!$has_dns_alt && !empty($cert['subject']['CN'])) {
+		if (!empty($cert['subject']['CN'])) {
 			// Check for a match
-			if (self::match_domain($host, $cert['subject']['CN']) === true) {
-				return true;
-			}
+			return (self::match_domain($host, $cert['subject']['CN']) === true);
 		}
 
 		return false;

--- a/tests/SslTest.php
+++ b/tests/SslTest.php
@@ -6,12 +6,43 @@ use WpOrg\Requests\Ssl;
 use WpOrg\Requests\Tests\TestCase;
 
 final class SslTest extends TestCase {
+
+	/**
+	 * @dataProvider domainMatchProvider
+	 */
+	public function testMatch($base, $dnsname) {
+		$this->assertTrue(Ssl::match_domain($base, $dnsname));
+	}
+
+	/**
+	 * @dataProvider domainMatchProvider
+	 */
+	public function testMatchViaCertificate($base, $dnsname) {
+		$certificate = $this->fakeCertificate($dnsname);
+		$this->assertTrue(Ssl::verify_certificate($base, $certificate));
+	}
+
 	public static function domainMatchProvider() {
 		return array(
 			array('example.com', 'example.com'),
 			array('test.example.com', 'test.example.com'),
 			array('test.example.com', '*.example.com'),
 		);
+	}
+
+	/**
+	 * @dataProvider domainNoMatchProvider
+	 */
+	public function testNoMatch($base, $dnsname) {
+		$this->assertFalse(Ssl::match_domain($base, $dnsname));
+	}
+
+	/**
+	 * @dataProvider domainNoMatchProvider
+	 */
+	public function testNoMatchViaCertificate($base, $dnsname) {
+		$certificate = $this->fakeCertificate($dnsname);
+		$this->assertFalse(Ssl::verify_certificate($base, $certificate));
 	}
 
 	public static function domainNoMatchProvider() {
@@ -36,20 +67,6 @@ final class SslTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider domainMatchProvider
-	 */
-	public function testMatch($base, $dnsname) {
-		$this->assertTrue(Ssl::match_domain($base, $dnsname));
-	}
-
-	/**
-	 * @dataProvider domainNoMatchProvider
-	 */
-	public function testNoMatch($base, $dnsname) {
-		$this->assertFalse(Ssl::match_domain($base, $dnsname));
-	}
-
 	private function fakeCertificate($dnsname, $with_san = true) {
 		$certificate = array(
 			'subject' => array(
@@ -68,22 +85,6 @@ final class SslTest extends TestCase {
 		}
 
 		return $certificate;
-	}
-
-	/**
-	 * @dataProvider domainMatchProvider
-	 */
-	public function testMatchViaCertificate($base, $dnsname) {
-		$certificate = $this->fakeCertificate($dnsname);
-		$this->assertTrue(Ssl::verify_certificate($base, $certificate));
-	}
-
-	/**
-	 * @dataProvider domainNoMatchProvider
-	 */
-	public function testNoMatchViaCertificate($base, $dnsname) {
-		$certificate = $this->fakeCertificate($dnsname);
-		$this->assertFalse(Ssl::verify_certificate($base, $certificate));
 	}
 
 	public function testCNFallback() {

--- a/tests/SslTest.php
+++ b/tests/SslTest.php
@@ -228,6 +228,11 @@ final class SslTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Test helper to mock a certificate.
+	 *
+	 * @return array
+	 */
 	private function fakeCertificate($dnsname, $with_san = true) {
 		$certificate = array(
 			'subject' => array(

--- a/tests/SslTest.php
+++ b/tests/SslTest.php
@@ -5,12 +5,17 @@ namespace WpOrg\Requests\Tests;
 use WpOrg\Requests\Ssl;
 use WpOrg\Requests\Tests\TestCase;
 
+/**
+ * @coversDefaultClass \WpOrg\Requests\Ssl
+ */
 final class SslTest extends TestCase {
 
 	/**
 	 * Test handling of matching host and DNS names.
 	 *
 	 * @dataProvider dataMatch
+	 *
+	 * @covers ::match_domain
 	 *
 	 * @param string $host      Host name to verify.
 	 * @param string $reference DNS name to match against.
@@ -26,6 +31,8 @@ final class SslTest extends TestCase {
 	 *
 	 * @dataProvider dataMatch
 	 * @dataProvider dataMatchViaCertificate
+	 *
+	 * @covers ::verify_certificate
 	 *
 	 * @param string      $host      Host name to verify.
 	 * @param string      $reference DNS name to match against.
@@ -103,6 +110,8 @@ final class SslTest extends TestCase {
 	 *
 	 * @dataProvider dataNoMatch
 	 *
+	 * @covers ::match_domain
+	 *
 	 * @param string $host      Host name to verify.
 	 * @param string $reference DNS name to match against.
 	 *
@@ -117,6 +126,8 @@ final class SslTest extends TestCase {
 	 *
 	 * @dataProvider dataNoMatch
 	 * @dataProvider dataNoMatchViaCertificate
+	 *
+	 * @covers ::verify_certificate
 	 *
 	 * @param string      $host      Host name to verify.
 	 * @param string      $reference DNS name to match against.
@@ -260,6 +271,8 @@ final class SslTest extends TestCase {
 	 * the value of the CN field.
 	 *
 	 * @link https://tools.ietf.org/html/rfc2818#section-3.1
+	 *
+	 * @covers ::verify_certificate
 	 */
 	public function testIgnoreCNWithSAN() {
 		$certificate = $this->fakeCertificate('example.net', 'DNS: example.com');

--- a/tests/SslTest.php
+++ b/tests/SslTest.php
@@ -198,10 +198,10 @@ final class SslTest extends TestCase {
 		if ($with_san !== false) {
 			// If SAN is set to true, default it to the dNSName
 			if ($with_san === true) {
-				$with_san = $dnsname;
+				$with_san = 'DNS: ' . $dnsname;
 			}
 			$certificate['extensions'] = array(
-				'subjectAltName' => 'DNS: ' . $with_san,
+				'subjectAltName' => $with_san,
 			);
 		}
 
@@ -217,7 +217,7 @@ final class SslTest extends TestCase {
 	 * @link https://tools.ietf.org/html/rfc2818#section-3.1
 	 */
 	public function testIgnoreCNWithSAN() {
-		$certificate = $this->fakeCertificate('example.net', 'example.com');
+		$certificate = $this->fakeCertificate('example.net', 'DNS: example.com');
 
 		$this->assertTrue(Ssl::verify_certificate('example.com', $certificate), 'Checking SAN validation');
 		$this->assertFalse(Ssl::verify_certificate('example.net', $certificate), 'Checking CN non-validation');

--- a/tests/SslTest.php
+++ b/tests/SslTest.php
@@ -8,25 +8,53 @@ use WpOrg\Requests\Tests\TestCase;
 final class SslTest extends TestCase {
 
 	/**
-	 * @dataProvider domainMatchProvider
+	 * Test handling of matching host and DNS names.
+	 *
+	 * @dataProvider dataMatch
+	 *
+	 * @param string $host      Host name to verify.
+	 * @param string $reference DNS name to match against.
+	 *
+	 * @return void
 	 */
-	public function testMatch($base, $dnsname) {
-		$this->assertTrue(Ssl::match_domain($base, $dnsname));
+	public function testMatch($host, $reference) {
+		$this->assertTrue(Ssl::match_domain($host, $reference));
 	}
 
 	/**
-	 * @dataProvider domainMatchProvider
+	 * Test handling of matching host and DNS names based on certificate.
+	 *
+	 * @dataProvider dataMatch
+	 *
+	 * @param string $host      Host name to verify.
+	 * @param string $reference DNS name to match against.
+	 *
+	 * @return void
 	 */
-	public function testMatchViaCertificate($base, $dnsname) {
-		$certificate = $this->fakeCertificate($dnsname);
-		$this->assertTrue(Ssl::verify_certificate($base, $certificate));
+	public function testMatchViaCertificate($host, $reference) {
+		$certificate = $this->fakeCertificate($reference);
+		$this->assertTrue(Ssl::verify_certificate($host, $certificate));
 	}
 
-	public static function domainMatchProvider() {
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataMatch() {
 		return array(
-			array('example.com', 'example.com'),
-			array('test.example.com', 'test.example.com'),
-			array('test.example.com', '*.example.com'),
+			'top-level domain' => array(
+				'host'      => 'example.com',
+				'reference' => 'example.com',
+			),
+			'subdomain' => array(
+				'host'      => 'test.example.com',
+				'reference' => 'test.example.com',
+			),
+			'subdomain with wildcard reference' => array(
+				'host'      => 'test.example.com',
+				'reference' => '*.example.com',
+			),
 		);
 	}
 

--- a/tests/SslTest.php
+++ b/tests/SslTest.php
@@ -135,6 +135,16 @@ final class SslTest extends TestCase {
 				'host'      => '192.168.0.1',
 				'reference' => '192.168.0.*',
 			),
+
+			// IP vs named address.
+			'IP address vs named address' => array(
+				'host'      => '192.168.0.1',
+				'reference' => '*.example.com',
+			),
+			'Named address vs IP address' => array(
+				'host'      => 'example.com',
+				'reference' => '192.168.0.1',
+			),
 		);
 	}
 


### PR DESCRIPTION
### SslTest: rearrange the method order in the test class

... grouping tests using the same data provider together, with the data provider they are using directly below it.

### SslTest: improve "match" tests

* Add docblock documentation to the tests and the data provider.
* Use same parameter names in the test method, as used in the functions under test.
* Rename the data provider method to match the test name(s) it applies to.
* Remove `static` keyword from data provider.
* Used named datasets and keyed data entries in the data provider

### SslTest: improve "no-match" tests

* Add docblock documentation to the tests and the data provider.
* Use same parameter names in the test method, as used in the functions under test.
* Rename the data provider method to match the test name(s) it applies to.
* Remove `static` keyword from data provider.
* Used named datasets and keyed data entries in the data provider

### SslTest: add extra "no-match" test cases

... to cover a previously uncovered code path and safeguard against regressions.

### SslTest: refactor additional verify_certificate() tests

Merge two additional tests into the base test methods.

As these additional methods are specific to the `verify_certificate()` method and do not apply to the `match_domain()` method, they are placed in separate data providers (yes, you can have multiple data providers for one test), but having them in a data provider allows for more easily adding more additional test cases at a later point in time.

I'm leaving the `SslTest::testIgnoreCNWithSAN()` test method in place as that's testing something very specific and the test method documentation explains that case well.

### SslTest::fakeCertificate(): make test helper a little more flexible

... to allow for testing more edge cases.

### SslTest: add extra "no-match" test cases specifically for `verify_certificate()`

... to cover a previously uncovered code path and safeguard against regressions.

### Ssl::verify_certificate(): remove unnecessary condition

No need to check whether `$cert['extensions']` is empty if we're going to check if `$cert['extensions']['subjectAltName']` is empty anyway.

See: https://3v4l.org/Z1hgQ

### Ssl::verify_certificate(): minor code tweaks

... to reduce the number of possible paths which can be taken through the function / lower complexity.

### SslTest: add docblock to helper function

### SslTest: add @covers tags

Related to #497