### PR TITLE
Exception\Http\StatusUnknown: add perfunctory unit tests

### DIFF
--- a/src/Exception/Http/StatusUnknown.php
+++ b/src/Exception/Http/StatusUnknown.php
@@ -41,7 +41,7 @@ final class StatusUnknown extends Http {
 	 */
 	public function __construct($reason = null, $data = null) {
 		if ($data instanceof Response) {
-			$this->code = $data->status_code;
+			$this->code = (int) $data->status_code;
 		}
 
 		parent::__construct($reason, $data);

--- a/tests/Exception/Http/StatusUnknownTest.php
+++ b/tests/Exception/Http/StatusUnknownTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Exception\Http;
+
+use WpOrg\Requests\Exception\Http\StatusUnknown;
+use WpOrg\Requests\Response;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Exception\Http\StatusUnknown
+ */
+final class StatusUnknownTest extends TestCase {
+
+	/**
+	 * Test that the error code is set correctly.
+	 *
+	 * @dataProvider dataException
+	 *
+	 * @param int   $expected_code Expected error code.
+	 * @param mixed $data          Optional. Input for the Exception constructor argument.
+	 *
+	 * @return void
+	 */
+	public function testException($expected_code, $data = null) {
+		$this->expectException(StatusUnknown::class);
+		$this->expectExceptionCode($expected_code);
+
+		throw new StatusUnknown('testing-1-2-3', $data);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataException() {
+		$response_with_status              = new Response();
+		$response_with_status->status_code = 12345;
+
+		$response_without_status = new Response();
+
+		return array(
+			'null (or not passed)' => array(
+				'expectedCode' => 0,
+			),
+			'integer error code as data' => array(
+				'expectedCode' => 0,
+				'data'         => 507,
+			),
+			'Response object with status code' => array(
+				'expectedCode' => 12345,
+				'data'         => $response_with_status,
+			),
+			'Response object without status code' => array(
+				'expectedCode' => 0,
+				'data'         => $response_without_status,
+			),
+		);
+	}
+}


### PR DESCRIPTION
### Exception\Http\StatusUnknown: add perfunctory unit test

### Exception\Http\StatusUnknown: minor bug fix

The default value of the `Requests\Response::$status_code` property is `false` and that value is also meant to be used for non-blocking errors.

If, in that case, as `StatusUnknown` error would be thrown, the `$error_code` for the Exception would be set to the invalid value `false`, while this should always be an integer.

Fixed now.

Related to #497