### PR TITLE
Response\Headers: improve tests

### DIFF
--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -8,7 +8,7 @@ use WpOrg\Requests\Tests\TestCase;
 
 final class HeadersTest extends TestCase {
 
-	public function testInvalidKey() {
+	public function testOffsetSetInvalidKey() {
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Object is a dictionary, not a list');
 

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -6,10 +6,15 @@ use WpOrg\Requests\Exception;
 use WpOrg\Requests\Response\Headers;
 use WpOrg\Requests\Tests\TestCase;
 
+/**
+ * @coversDefaultClass \WpOrg\Requests\Response\Headers
+ */
 final class HeadersTest extends TestCase {
 
 	/**
 	 * Test receiving an Exception when no key is provided when setting an entry.
+	 *
+	 * @covers ::offsetSet
 	 *
 	 * @return void
 	 */
@@ -23,6 +28,9 @@ final class HeadersTest extends TestCase {
 
 	/**
 	 * Test array access for the object is supported and supported in a case-insensitive manner.
+	 *
+	 * @covers ::offsetSet
+	 * @covers ::offsetGet
 	 *
 	 * @dataProvider dataCaseInsensitiveArrayAccess
 	 *
@@ -54,6 +62,10 @@ final class HeadersTest extends TestCase {
 	 * Test that when multiple headers are set using the same key, requesting the key will return the
 	 * combined values flattened into a single, comma-separated string.
 	 *
+	 * @covers ::offsetSet
+	 * @covers ::offsetGet
+	 * @covers ::flatten
+	 *
 	 * @return void
 	 */
 	public function testMultipleHeaders() {
@@ -67,6 +79,8 @@ final class HeadersTest extends TestCase {
 	/**
 	 * Test that null is returned when a non-registered header is requested.
 	 *
+	 * @covers ::offsetGet
+	 *
 	 * @return void
 	 */
 	public function testOffsetGetReturnsNullForNonRegisteredHeader() {
@@ -78,6 +92,8 @@ final class HeadersTest extends TestCase {
 
 	/**
 	 * Test retrieving all values for a given header (case-insensitively).
+	 *
+	 * @covers ::getValues
 	 *
 	 * @dataProvider dataGetValues
 	 *
@@ -139,6 +155,9 @@ final class HeadersTest extends TestCase {
 	 * Includes making sure that:
 	 * - keys are handled case-insensitively.
 	 * - multiple keys with the same name are flattened into one value.
+	 *
+	 * @covers ::getIterator
+	 * @covers ::flatten
 	 *
 	 * @return void
 	 */

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -54,7 +54,12 @@ final class HeadersTest extends TestCase {
 	}
 
 	/**
-	 * @depends testArrayAccess
+	 * Test iterator access for the object is supported.
+	 *
+	 * Includes making sure that:
+	 * - keys are handled case-insensitively.
+	 *
+	 * @return void
 	 */
 	public function testIteration() {
 		$headers                   = new Headers();
@@ -64,13 +69,13 @@ final class HeadersTest extends TestCase {
 		foreach ($headers as $name => $value) {
 			switch (strtolower($name)) {
 				case 'content-type':
-					$this->assertSame('text/plain', $value);
+					$this->assertSame('text/plain', $value, 'Content-Type header does not match');
 					break;
 				case 'content-length':
-					$this->assertSame('10', $value);
+					$this->assertSame('10', $value, 'Content-Length header does not match');
 					break;
 				default:
-					throw new Exception('Invalid name: ' . $name);
+					throw new Exception('Invalid offset key: ' . $name);
 			}
 		}
 	}

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -54,6 +54,18 @@ final class HeadersTest extends TestCase {
 	}
 
 	/**
+	 * Test that null is returned when a non-registered header is requested.
+	 *
+	 * @return void
+	 */
+	public function testOffsetGetReturnsNullForNonRegisteredHeader() {
+		$headers                 = new Headers();
+		$headers['Content-Type'] = 'text/plain';
+
+		$this->assertNull($headers['not-content-type']);
+	}
+
+	/**
 	 * Test iterator access for the object is supported.
 	 *
 	 * Includes making sure that:

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -66,6 +66,63 @@ final class HeadersTest extends TestCase {
 	}
 
 	/**
+	 * Test retrieving all values for a given header (case-insensitively).
+	 *
+	 * @dataProvider dataGetValues
+	 *
+	 * @param string      $key      Key to request.
+	 * @param string|null $expected Expected return value.
+	 *
+	 * @return void
+	 */
+	public function testGetValues($key, $expected) {
+		$headers                   = new Headers();
+		$headers['Content-Type']   = 'text/plain';
+		$headers['Content-Length'] = 10;
+		$headers['Accept']         = 'text/html;q=1.0';
+		$headers['Accept']         = '*/*;q=0.1';
+
+		$this->assertSame($expected, $headers->getValues($key));
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataGetValues() {
+		return array(
+			'using case as set, single entry header' => array(
+				'key'      => 'Content-Type',
+				'expected' => array(
+					'text/plain',
+				),
+			),
+			'using lowercase, single entry header' => array(
+				'key'      => 'content-length',
+				'expected' => array(
+					10,
+				),
+			),
+			'using uppercase, multiple entry header' => array(
+				'key'      => 'ACCEPT',
+				'expected' => array(
+					'text/html;q=1.0',
+					'*/*;q=0.1',
+				),
+			),
+			'non-registered string key' => array(
+				'key'      => 'my-custom-header',
+				'expected' => null,
+			),
+			'non-registered integer key' => array(
+				'key'      => 10,
+				'expected' => null,
+			),
+		);
+	}
+
+	/**
 	 * Test iterator access for the object is supported.
 	 *
 	 * Includes making sure that:

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -8,6 +8,11 @@ use WpOrg\Requests\Tests\TestCase;
 
 final class HeadersTest extends TestCase {
 
+	/**
+	 * Test receiving an Exception when no key is provided when setting an entry.
+	 *
+	 * @return void
+	 */
 	public function testOffsetSetInvalidKey() {
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Object is a dictionary, not a list');
@@ -45,6 +50,12 @@ final class HeadersTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Test that when multiple headers are set using the same key, requesting the key will return the
+	 * combined values flattened into a single, comma-separated string.
+	 *
+	 * @return void
+	 */
 	public function testMultipleHeaders() {
 		$headers           = new Headers();
 		$headers['Accept'] = 'text/html;q=1.0';

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -58,6 +58,7 @@ final class HeadersTest extends TestCase {
 	 *
 	 * Includes making sure that:
 	 * - keys are handled case-insensitively.
+	 * - multiple keys with the same name are flattened into one value.
 	 *
 	 * @return void
 	 */
@@ -65,9 +66,14 @@ final class HeadersTest extends TestCase {
 		$headers                   = new Headers();
 		$headers['Content-Type']   = 'text/plain';
 		$headers['Content-Length'] = 10;
+		$headers['Accept']         = 'text/html;q=1.0';
+		$headers['Accept']         = '*/*;q=0.1';
 
 		foreach ($headers as $name => $value) {
 			switch (strtolower($name)) {
+				case 'accept':
+					$this->assertSame('text/html;q=1.0,*/*;q=0.1', $value, 'Accept header does not match');
+					break;
 				case 'content-type':
 					$this->assertSame('text/plain', $value, 'Content-Type header does not match');
 					break;

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -7,6 +7,15 @@ use WpOrg\Requests\Response\Headers;
 use WpOrg\Requests\Tests\TestCase;
 
 final class HeadersTest extends TestCase {
+
+	public function testInvalidKey() {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Object is a dictionary, not a list');
+
+		$headers   = new Headers();
+		$headers[] = 'text/plain';
+	}
+
 	public function testArrayAccess() {
 		$headers                 = new Headers();
 		$headers['Content-Type'] = 'text/plain';
@@ -19,6 +28,14 @@ final class HeadersTest extends TestCase {
 
 		$this->assertSame('text/plain', $headers['CONTENT-TYPE']);
 		$this->assertSame('text/plain', $headers['content-type']);
+	}
+
+	public function testMultipleHeaders() {
+		$headers           = new Headers();
+		$headers['Accept'] = 'text/html;q=1.0';
+		$headers['Accept'] = '*/*;q=0.1';
+
+		$this->assertSame('text/html;q=1.0,*/*;q=0.1', $headers['Accept']);
 	}
 
 	/**
@@ -41,20 +58,5 @@ final class HeadersTest extends TestCase {
 					throw new Exception('Invalid name: ' . $name);
 			}
 		}
-	}
-
-	public function testInvalidKey() {
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Object is a dictionary, not a list');
-		$headers   = new Headers();
-		$headers[] = 'text/plain';
-	}
-
-	public function testMultipleHeaders() {
-		$headers           = new Headers();
-		$headers['Accept'] = 'text/html;q=1.0';
-		$headers['Accept'] = '*/*;q=0.1';
-
-		$this->assertSame('text/html;q=1.0,*/*;q=0.1', $headers['Accept']);
 	}
 }

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -16,18 +16,33 @@ final class HeadersTest extends TestCase {
 		$headers[] = 'text/plain';
 	}
 
-	public function testArrayAccess() {
+	/**
+	 * Test array access for the object is supported and supported in a case-insensitive manner.
+	 *
+	 * @dataProvider dataCaseInsensitiveArrayAccess
+	 *
+	 * @param string $key Key to request.
+	 *
+	 * @return void
+	 */
+	public function testCaseInsensitiveArrayAccess($key) {
 		$headers                 = new Headers();
 		$headers['Content-Type'] = 'text/plain';
 
-		$this->assertSame('text/plain', $headers['Content-Type']);
+		$this->assertSame('text/plain', $headers[$key]);
 	}
-	public function testCaseInsensitiveArrayAccess() {
-		$headers                 = new Headers();
-		$headers['Content-Type'] = 'text/plain';
 
-		$this->assertSame('text/plain', $headers['CONTENT-TYPE']);
-		$this->assertSame('text/plain', $headers['content-type']);
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataCaseInsensitiveArrayAccess() {
+		return array(
+			'access using case as set' => array('Content-Type'),
+			'access using lowercase'   => array('content-type'),
+			'access using uppercase'   => array('CONTENT-TYPE'),
+		);
 	}
 
 	public function testMultipleHeaders() {


### PR DESCRIPTION
### HeadersTest: rearrange the method order in the test class

... grouping tests related to array access together.

### HeadersTest: rename a test to be more descriptive

### HeadersTest: refactor array access tests

* Merge two tests doing the exact same thing, into one test using a data provider with named data sets.
* Add docblock documentation to the test and the data provider.

### HeadersTest::testIteration(): various minor tweaks

* Add `$message` parameter to each assertion as there are multiple assertions in the test.
* Make the exception more descriptive (not that I expect it to ever be thrown).
* Add a docblock to the test.
* Remove the `@depends` annotation which doesn't make any sense here.

### HeadersTest::testIteration(): safeguard the flattening

The `Header::getIterator()` method uses the `Header::flatten()` method, but there was no test safeguarding this functionality against regressions.

Fixed now by adding an additional check to the `HeadersTest::testIteration()` method.

### HeadersTest: add extra test for offsetGet()

.. for functionality previously not covered by a test.

### HeadersTest: add test for getValues()

... which was, so far, not covered by tests yet.

### HeadersTest: add docblocks to the rest of the tests

### HeadersTest: add @covers tags 

Related to #497