### PR TITLE
Auth\Basic: improve tests

### DIFF
--- a/tests/Auth/BasicTest.php
+++ b/tests/Auth/BasicTest.php
@@ -13,10 +13,7 @@ final class BasicTest extends TestCase {
 	 * @dataProvider transportProvider
 	 */
 	public function testUsingArray($transport) {
-		if (!call_user_func(array($transport, 'test'))) {
-			$this->markTestSkipped($transport . ' is not available');
-			return;
-		}
+		$this->skipWhenTransportNotAvailable($transport);
 
 		$options = array(
 			'auth'      => array('user', 'passwd'),
@@ -34,10 +31,7 @@ final class BasicTest extends TestCase {
 	 * @dataProvider transportProvider
 	 */
 	public function testUsingInstantiation($transport) {
-		if (!call_user_func(array($transport, 'test'))) {
-			$this->markTestSkipped($transport . ' is not available');
-			return;
-		}
+		$this->skipWhenTransportNotAvailable($transport);
 
 		$options = array(
 			'auth'      => new Basic(array('user', 'passwd')),
@@ -55,10 +49,7 @@ final class BasicTest extends TestCase {
 	 * @dataProvider transportProvider
 	 */
 	public function testPOSTUsingInstantiation($transport) {
-		if (!call_user_func(array($transport, 'test'))) {
-			$this->markTestSkipped($transport . ' is not available');
-			return;
-		}
+		$this->skipWhenTransportNotAvailable($transport);
 
 		$options = array(
 			'auth'      => new Basic(array('user', 'passwd')),
@@ -83,4 +74,16 @@ final class BasicTest extends TestCase {
 		new Basic(array('user'));
 	}
 
+	/**
+	 * Helper function to skip select tests when the transport under test is not available.
+	 *
+	 * @param string $transport Transport to use.
+	 *
+	 * @return void
+	 */
+	public function skipWhenTransportNotAvailable($transport) {
+		if (!$transport::test()) {
+			$this->markTestSkipped('Transport "' . $transport . '" is not available');
+		}
+	}
 }

--- a/tests/Auth/BasicTest.php
+++ b/tests/Auth/BasicTest.php
@@ -5,6 +5,7 @@ namespace WpOrg\Requests\Tests\Auth;
 use WpOrg\Requests\Auth\Basic;
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Requests;
+use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\TestCase;
 
 final class BasicTest extends TestCase {
@@ -20,11 +21,36 @@ final class BasicTest extends TestCase {
 			'transport' => $transport,
 		);
 		$request = Requests::get(httpbin('/basic-auth/user/passwd'), array(), $options);
-		$this->assertSame(200, $request->status_code);
 
+		// Verify the request succeeded.
+		$this->assertInstanceOf(
+			Response::class,
+			$request,
+			'GET request did not return an instance of `Requests\Response`'
+		);
+		$this->assertSame(
+			200,
+			$request->status_code,
+			'GET request failed. Expected status: 200. Received status: ' . $request->status_code
+		);
+
+		// Verify the response confirms that the request was authenticated.
 		$result = json_decode($request->body);
-		$this->assertTrue($result->authenticated);
-		$this->assertSame('user', $result->user);
+		$this->assertIsObject($result, 'Decoded response body is not an object');
+
+		$this->assertObjectHasAttribute(
+			'authenticated',
+			$result,
+			'Property "authenticated" not available in decoded response'
+		);
+		$this->assertTrue($result->authenticated, 'Authentication failed');
+
+		$this->assertObjectHasAttribute(
+			'user',
+			$result,
+			'Property "user" not available in decoded response'
+		);
+		$this->assertSame('user', $result->user, 'Unexpected value encountered for "user"');
 	}
 
 	/**
@@ -38,11 +64,36 @@ final class BasicTest extends TestCase {
 			'transport' => $transport,
 		);
 		$request = Requests::get(httpbin('/basic-auth/user/passwd'), array(), $options);
-		$this->assertSame(200, $request->status_code);
 
+		// Verify the request succeeded.
+		$this->assertInstanceOf(
+			Response::class,
+			$request,
+			'GET request did not return an instance of `Requests\Response`'
+		);
+		$this->assertSame(
+			200,
+			$request->status_code,
+			'GET request failed. Expected status: 200. Received status: ' . $request->status_code
+		);
+
+		// Verify the response confirms that the request was authenticated.
 		$result = json_decode($request->body);
-		$this->assertTrue($result->authenticated);
-		$this->assertSame('user', $result->user);
+		$this->assertIsObject($result, 'Decoded response body is not an object');
+
+		$this->assertObjectHasAttribute(
+			'authenticated',
+			$result,
+			'Property "authenticated" not available in decoded response'
+		);
+		$this->assertTrue($result->authenticated, 'Authentication failed');
+
+		$this->assertObjectHasAttribute(
+			'user',
+			$result,
+			'Property "user" not available in decoded response'
+		);
+		$this->assertSame('user', $result->user, 'Unexpected value encountered for "user"');
 	}
 
 	/**
@@ -57,15 +108,45 @@ final class BasicTest extends TestCase {
 		);
 		$data    = 'test';
 		$request = Requests::post(httpbin('/post'), array(), $data, $options);
-		$this->assertSame(200, $request->status_code);
 
+		// Verify the request succeeded.
+		$this->assertInstanceOf(
+			Response::class,
+			$request,
+			'POST request did not return an instance of `Requests\Response`'
+		);
+		$this->assertSame(
+			200,
+			$request->status_code,
+			'POST request failed. Expected status: 200. Received status: ' . $request->status_code
+		);
+
+		// Verify the response confirms that the request was authenticated.
 		$result = json_decode($request->body);
+
+		$this->assertIsObject($result, 'Decoded response body is not an object');
+		$this->assertObjectHasAttribute(
+			'headers',
+			$result,
+			'Property "headers" not available in decoded response'
+		);
+		$this->assertObjectHasAttribute(
+			'Authorization',
+			$result->headers,
+			'Property "headers->Authorization" not available in decoded response'
+		);
 
 		$auth = $result->headers->Authorization;
 		$auth = explode(' ', $auth);
+		$this->assertArrayHasKey(1, $auth, 'Authorization header failed to be split into two parts');
+		$this->assertSame(base64_encode('user:passwd'), $auth[1], 'Unexpected authorization string in headers');
 
-		$this->assertSame(base64_encode('user:passwd'), $auth[1]);
-		$this->assertSame('test', $result->data);
+		$this->assertObjectHasAttribute(
+			'data',
+			$result,
+			'Property "data" not available in decoded response'
+		);
+		$this->assertSame('test', $result->data, 'Unexpected data value encountered');
 	}
 
 	public function testMissingPassword() {

--- a/tests/Auth/BasicTest.php
+++ b/tests/Auth/BasicTest.php
@@ -149,10 +149,33 @@ final class BasicTest extends TestCase {
 		$this->assertSame('test', $result->data, 'Unexpected data value encountered');
 	}
 
-	public function testMissingPassword() {
+	/**
+	 * Verify that an exception is thrown when the class is instantiated with an invalid number of arguments.
+	 *
+	 * @dataProvider dataInvalidArgumentCount
+	 *
+	 * @param mixed $input Input data.
+	 *
+	 * @return void
+	 */
+	public function testInvalidArgumentCount($input) {
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid number of arguments');
-		new Basic(array('user'));
+
+		new Basic($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidArgumentCount() {
+		return array(
+			'empty array'                 => array(array()),
+			'array with only one element' => array(array('user')),
+			'array with extra element'    => array(array('user', 'psw', 'port')),
+		);
 	}
 
 	/**

--- a/tests/Auth/BasicTest.php
+++ b/tests/Auth/BasicTest.php
@@ -8,10 +8,17 @@ use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\TestCase;
 
+/**
+ * @covers \WpOrg\Requests\Auth\Basic
+ */
 final class BasicTest extends TestCase {
 
 	/**
 	 * @dataProvider transportProvider
+	 *
+	 * @param string $transport Transport to use.
+	 *
+	 * @return void
 	 */
 	public function testUsingArray($transport) {
 		$this->skipWhenTransportNotAvailable($transport);
@@ -55,6 +62,10 @@ final class BasicTest extends TestCase {
 
 	/**
 	 * @dataProvider transportProvider
+	 *
+	 * @param string $transport Transport to use.
+	 *
+	 * @return void
 	 */
 	public function testUsingInstantiation($transport) {
 		$this->skipWhenTransportNotAvailable($transport);
@@ -98,6 +109,10 @@ final class BasicTest extends TestCase {
 
 	/**
 	 * @dataProvider transportProvider
+	 *
+	 * @param string $transport Transport to use.
+	 *
+	 * @return void
 	 */
 	public function testPOSTUsingInstantiation($transport) {
 		$this->skipWhenTransportNotAvailable($transport);


### PR DESCRIPTION
### Auth\BasicTest: move test skipping to helper method

* Move the (duplicate) test skipping code to a test helper function with a descriptive name.
* Use a dynamic function call to call the `test()` method instead of using `call_user_func()`.
* Make the skip message slightly more descriptive.

### Auth\BasicTest: stabilize the tests

* Remove assumptions from the tests in favour of explicitly verifying those assumptions via assertions.
* Add `$message` parameter to each assertion as there are multiple assertions in each test.

### Auth\BasicTest: improve test for invalid argument count exception

* Use a dataprovider with named data sets to test that the exception is thrown in all situations in which it should be thrown.
* Rename the test method to a more descriptive name for the fact that multiple situations are now being tested.
* Add documentation to the test method.

### Auth\BasicTest: improve docblocks

... and add a class level `@covers` tag.

Related to #497