### PR TITLE
Response: add `decode_body()` method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     "docs": "https://requests.ryanmccue.info/"
   },
   "require": {
-    "php": ">=5.6"
+    "php": ">=5.6",
+    "ext-json": "*"
   },
   "require-dev": {
     "requests/test-server": "dev-master",

--- a/src/Response.php
+++ b/src/Response.php
@@ -134,7 +134,7 @@ class Response {
 	 * @throws Requests_Exception If `$this->body` is not a valid json
 	 * @return array
 	 */
-	public function json($assoc = true, $depth = 512, $options = 0) {
+	public function json($assoc = true) {
 		static $json_errors = array(
 			JSON_ERROR_DEPTH => 'JSON_ERROR_DEPTH - Maximum stack depth exceeded',
 			JSON_ERROR_STATE_MISMATCH => 'JSON_ERROR_STATE_MISMATCH - Underflow or the modes mismatch',
@@ -143,13 +143,19 @@ class Response {
 			JSON_ERROR_UTF8 => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded'
 		);
 
-		$data = json_decode($this->body, $assoc, $depth, $options);
+		$data = json_decode($this->body, $assoc);
 
-		if (JSON_ERROR_NONE !== json_last_error()) {
-			$last_error = json_last_error();
-			$error = isset($json_errors[$last_error]) ? $json_errors[$last_error] : 'Unknown error';
-			throw new Requests_Exception('Unable to parse JSON data: ' . $error, 'response.invalid', $this);
+		if (function_exists('json_last_error')) {
+			if (JSON_ERROR_NONE !== json_last_error()) {
+				$last_error = json_last_error();
+				$error = isset($json_errors[$last_error]) ? $json_errors[$last_error] : 'Unknown error';
+				throw new Requests_Exception('Unable to parse JSON data: ' . $error, 'response.invalid', $this);
+			}
 		}
+		elseif ($data === null) {
+			throw new Requests_Exception('Unable to parse JSON data.', 'response.invalid', $this);
+		}
+
 
 		return $data;
 	}

--- a/src/Response.php
+++ b/src/Response.php
@@ -136,18 +136,18 @@ class Response {
 	 */
 	public function json($assoc = true, $depth = 512, $options = 0) {
 		static $json_errors = array(
-			JSON_ERROR_DEPTH => 'JSON_ERROR_DEPTH - Maximum stack depth exceeded',
+			JSON_ERROR_DEPTH          => 'JSON_ERROR_DEPTH - Maximum stack depth exceeded',
 			JSON_ERROR_STATE_MISMATCH => 'JSON_ERROR_STATE_MISMATCH - Underflow or the modes mismatch',
-			JSON_ERROR_CTRL_CHAR => 'JSON_ERROR_CTRL_CHAR - Unexpected control character found',
-			JSON_ERROR_SYNTAX => 'JSON_ERROR_SYNTAX - Syntax error, malformed JSON',
-			JSON_ERROR_UTF8 => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded'
+			JSON_ERROR_CTRL_CHAR      => 'JSON_ERROR_CTRL_CHAR - Unexpected control character found',
+			JSON_ERROR_SYNTAX         => 'JSON_ERROR_SYNTAX - Syntax error, malformed JSON',
+			JSON_ERROR_UTF8           => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded',
 		);
 
 		$data = json_decode($this->body, $assoc, $depth, $options);
 
-		if (JSON_ERROR_NONE !== json_last_error()) {
+		if (json_last_error() !== JSON_ERROR_NONE) {
 			$last_error = json_last_error();
-			$error = isset($json_errors[$last_error]) ? $json_errors[$last_error] : 'Unknown error';
+			$error      = isset($json_errors[$last_error]) ? $json_errors[$last_error] : 'Unknown error';
 			throw new Exception('Unable to parse JSON data: ' . $error, 'response.invalid', $this);
 		}
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -134,7 +134,7 @@ class Response {
 	 * @throws \WpOrg\Requests\Exception If `$this->body` is not a valid json
 	 * @return array
 	 */
-	public function json($assoc = true, $depth = 512, $options = 0) {
+	public function decode_body($assoc = true, $depth = 512, $options = 0) {
 		static $json_errors = array(
 			JSON_ERROR_DEPTH          => 'JSON_ERROR_DEPTH - Maximum stack depth exceeded',
 			JSON_ERROR_STATE_MISMATCH => 'JSON_ERROR_STATE_MISMATCH - Underflow or the modes mismatch',

--- a/src/Response.php
+++ b/src/Response.php
@@ -127,4 +127,30 @@ class Response {
 			throw new $exception(null, $this);
 		}
 	}
+
+	/**
+	 * Returns json decoded response
+	 *
+	 * @throws Requests_Exception If `$this->body` is not a valid json
+	 * @return array
+	 */
+	public function json($assoc = true, $depth = 512, $options = 0) {
+		static $json_errors = array(
+			JSON_ERROR_DEPTH => 'JSON_ERROR_DEPTH - Maximum stack depth exceeded',
+			JSON_ERROR_STATE_MISMATCH => 'JSON_ERROR_STATE_MISMATCH - Underflow or the modes mismatch',
+			JSON_ERROR_CTRL_CHAR => 'JSON_ERROR_CTRL_CHAR - Unexpected control character found',
+			JSON_ERROR_SYNTAX => 'JSON_ERROR_SYNTAX - Syntax error, malformed JSON',
+			JSON_ERROR_UTF8 => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded'
+		);
+
+		$data = json_decode($this->body, $assoc, $depth, $options);
+
+		if (JSON_ERROR_NONE !== json_last_error()) {
+			$last_error = json_last_error();
+			$error = isset($json_errors[$last_error]) ? $json_errors[$last_error] : 'Unknown error';
+			throw new Requests_Exception('Unable to parse JSON data: ' . $error, 'response.invalid', $this);
+		}
+
+		return $data;
+	}
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -129,10 +129,26 @@ class Response {
 	}
 
 	/**
-	 * Returns json decoded response
+	 * JSON decode the response body.
 	 *
-	 * @throws \WpOrg\Requests\Exception If `$this->body` is not a valid json
+	 * The method parameters are the same as those for the PHP native `json_decode()` function.
+	 *
+	 * @link https://php.net/json-decode
+	 *
+	 * @param ?bool $associative Optional. When `true`, JSON objects will be returned as associative arrays;
+	 *                           When `false`, JSON objects will be returned as objects.
+	 *                           When `null`, JSON objects will be returned as associative arrays
+	 *                           or objects depending on whether `JSON_OBJECT_AS_ARRAY` is set in the flags.
+	 *                           Defaults to `true` (in contrast to the PHP native default of `null`).
+	 * @param int   $depth       Optional. Maximum nesting depth of the structure being decoded.
+	 *                           Defaults to `512`.
+	 * @param int   $options     Optional. Bitmask of JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE,
+	 *                           JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR.
+	 *                           Defaults to `0` (no options set).
+	 *
 	 * @return array
+	 *
+	 * @throws \WpOrg\Requests\Exception If `$this->body` is not valid json.
 	 */
 	public function decode_body($associative = true, $depth = 512, $options = 0) {
 		$data = json_decode($this->body, $associative, $depth, $options);

--- a/src/Response.php
+++ b/src/Response.php
@@ -131,7 +131,7 @@ class Response {
 	/**
 	 * Returns json decoded response
 	 *
-	 * @throws Requests_Exception If `$this->body` is not a valid json
+	 * @throws \WpOrg\Requests\Exception If `$this->body` is not a valid json
 	 * @return array
 	 */
 	public function json($assoc = true, $depth = 512, $options = 0) {
@@ -148,7 +148,7 @@ class Response {
 		if (JSON_ERROR_NONE !== json_last_error()) {
 			$last_error = json_last_error();
 			$error = isset($json_errors[$last_error]) ? $json_errors[$last_error] : 'Unknown error';
-			throw new Requests_Exception('Unable to parse JSON data: ' . $error, 'response.invalid', $this);
+			throw new Exception('Unable to parse JSON data: ' . $error, 'response.invalid', $this);
 		}
 
 		return $data;

--- a/src/Response.php
+++ b/src/Response.php
@@ -134,8 +134,8 @@ class Response {
 	 * @throws Requests_Exception If `$this->body` is not a valid json
 	 * @return array
 	 */
-	public function json($assoc = true) {
-		$json_errors = array(
+	public function json($assoc = true, $depth = 512, $options = 0) {
+		static $json_errors = array(
 			JSON_ERROR_DEPTH => 'JSON_ERROR_DEPTH - Maximum stack depth exceeded',
 			JSON_ERROR_STATE_MISMATCH => 'JSON_ERROR_STATE_MISMATCH - Underflow or the modes mismatch',
 			JSON_ERROR_CTRL_CHAR => 'JSON_ERROR_CTRL_CHAR - Unexpected control character found',
@@ -143,10 +143,12 @@ class Response {
 			JSON_ERROR_UTF8 => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded'
 		);
 
-		$data = json_decode($this->body, $assoc);
+		$data = json_decode($this->body, $assoc, $depth, $options);
 
-		if (!$data) {
-			throw new Requests_Exception('Unable to parse JSON data.', 'response.invalid', $this);
+		if (JSON_ERROR_NONE !== json_last_error()) {
+			$last_error = json_last_error();
+			$error = isset($json_errors[$last_error]) ? $json_errors[$last_error] : 'Unknown error';
+			throw new Requests_Exception('Unable to parse JSON data: ' . $error, 'response.invalid', $this);
 		}
 
 		return $data;

--- a/src/Response.php
+++ b/src/Response.php
@@ -135,20 +135,11 @@ class Response {
 	 * @return array
 	 */
 	public function decode_body($associative = true, $depth = 512, $options = 0) {
-		static $json_errors = array(
-			JSON_ERROR_DEPTH          => 'JSON_ERROR_DEPTH - Maximum stack depth exceeded',
-			JSON_ERROR_STATE_MISMATCH => 'JSON_ERROR_STATE_MISMATCH - Underflow or the modes mismatch',
-			JSON_ERROR_CTRL_CHAR      => 'JSON_ERROR_CTRL_CHAR - Unexpected control character found',
-			JSON_ERROR_SYNTAX         => 'JSON_ERROR_SYNTAX - Syntax error, malformed JSON',
-			JSON_ERROR_UTF8           => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded',
-		);
-
 		$data = json_decode($this->body, $associative, $depth, $options);
 
 		if (json_last_error() !== JSON_ERROR_NONE) {
-			$last_error = json_last_error();
-			$error      = isset($json_errors[$last_error]) ? $json_errors[$last_error] : 'Unknown error';
-			throw new Exception('Unable to parse JSON data: ' . $error, 'response.invalid', $this);
+			$last_error = json_last_error_msg();
+			throw new Exception('Unable to parse JSON data: ' . $last_error, 'response.invalid', $this);
 		}
 
 		return $data;

--- a/src/Response.php
+++ b/src/Response.php
@@ -135,7 +135,7 @@ class Response {
 	 * @return array
 	 */
 	public function json($assoc = true) {
-		static $json_errors = array(
+		$json_errors = array(
 			JSON_ERROR_DEPTH => 'JSON_ERROR_DEPTH - Maximum stack depth exceeded',
 			JSON_ERROR_STATE_MISMATCH => 'JSON_ERROR_STATE_MISMATCH - Underflow or the modes mismatch',
 			JSON_ERROR_CTRL_CHAR => 'JSON_ERROR_CTRL_CHAR - Unexpected control character found',
@@ -145,17 +145,9 @@ class Response {
 
 		$data = json_decode($this->body, $assoc);
 
-		if (function_exists('json_last_error')) {
-			if (JSON_ERROR_NONE !== json_last_error()) {
-				$last_error = json_last_error();
-				$error = isset($json_errors[$last_error]) ? $json_errors[$last_error] : 'Unknown error';
-				throw new Requests_Exception('Unable to parse JSON data: ' . $error, 'response.invalid', $this);
-			}
-		}
-		elseif ($data === null) {
+		if (!$data) {
 			throw new Requests_Exception('Unable to parse JSON data.', 'response.invalid', $this);
 		}
-
 
 		return $data;
 	}

--- a/src/Response.php
+++ b/src/Response.php
@@ -134,7 +134,7 @@ class Response {
 	 * @throws \WpOrg\Requests\Exception If `$this->body` is not a valid json
 	 * @return array
 	 */
-	public function decode_body($assoc = true, $depth = 512, $options = 0) {
+	public function decode_body($associative = true, $depth = 512, $options = 0) {
 		static $json_errors = array(
 			JSON_ERROR_DEPTH          => 'JSON_ERROR_DEPTH - Maximum stack depth exceeded',
 			JSON_ERROR_STATE_MISMATCH => 'JSON_ERROR_STATE_MISMATCH - Underflow or the modes mismatch',
@@ -143,7 +143,7 @@ class Response {
 			JSON_ERROR_UTF8           => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded',
 		);
 
-		$data = json_decode($this->body, $assoc, $depth, $options);
+		$data = json_decode($this->body, $associative, $depth, $options);
 
 		if (json_last_error() !== JSON_ERROR_NONE) {
 			$last_error = json_last_error();

--- a/tests/Response.php
+++ b/tests/Response.php
@@ -1,29 +1,29 @@
 <?php
 
 class RequestsTest_Response extends PHPUnit_Framework_TestCase {
-    /**
-     * @expectedException Requests_Exception
-     */
-    public function testInvalidJsonResponse() {
-        $response = new Requests_Response();
-        $response->body = 'Invalid JSON';
-        $response->json();
-    }
+	/**
+	 * @expectedException Requests_Exception
+	 */
+	public function testInvalidJsonResponse() {
+		$response = new Requests_Response();
+		$response->body = 'Invalid JSON';
+		$response->json();
+	}
 
-    public function testJsonResponse() {
-        $response = new Requests_Response();
-        $response->body = '{"success": false, "error": [], "data": null}';
-        $decodedBody = $response->json();
+	public function testJsonResponse() {
+		$response = new Requests_Response();
+		$response->body = '{"success": false, "error": [], "data": null}';
+		$decodedBody = $response->json();
 
-        $expected = array(
-            'success' => false,
-            'error' => array(),
-            'data' => null
-        );
+		$expected = array(
+			'success' => false,
+			'error' => array(),
+			'data' => null
+		);
 
-        foreach($expected as $key => $value)
-        {
-            $this->assertEquals($value, $decodedBody[$key]);
-        }
-    }
+		foreach($expected as $key => $value)
+		{
+			$this->assertEquals($value, $decodedBody[$key]);
+		}
+	}
 }

--- a/tests/Response.php
+++ b/tests/Response.php
@@ -1,0 +1,29 @@
+<?php
+
+class RequestsTest_Response extends PHPUnit_Framework_TestCase {
+    /**
+     * @expectedException Requests_Exception
+     */
+    public function testInvalidJsonResponse() {
+        $response = new Requests_Response();
+        $response->body = 'Invalid JSON';
+        $response->json();
+    }
+
+    public function testJsonResponse() {
+        $response = new Requests_Response();
+        $response->body = '{"success": false, "error": [], "data": null}';
+        $decodedBody = $response->json();
+
+        $expected = array(
+            'success' => false,
+            'error' => array(),
+            'data' => null
+        );
+
+        foreach($expected as $key => $value)
+        {
+            $this->assertEquals($value, $decodedBody[$key]);
+        }
+    }
+}

--- a/tests/Response.php
+++ b/tests/Response.php
@@ -1,29 +1,29 @@
 <?php
 
 class RequestsTest_Response extends PHPUnit_Framework_TestCase {
-	/**
-	 * @expectedException Requests_Exception
-	 */
-	public function testInvalidJsonResponse() {
-		$response = new Requests_Response();
-		$response->body = 'Invalid JSON';
-		$response->json();
-	}
+    /**
+     * @expectedException Requests_Exception
+     */
+    public function testInvalidJsonResponse() {
+        $response = new Requests_Response();
+        $response->body = 'Invalid JSON';
+        $response->json();
+    }
 
-	public function testJsonResponse() {
-		$response = new Requests_Response();
-		$response->body = '{"success": false, "error": [], "data": null}';
-		$decodedBody = $response->json();
+    public function testJsonResponse() {
+        $response = new Requests_Response();
+        $response->body = '{"success": false, "error": [], "data": null}';
+        $decodedBody = $response->json();
 
-		$expected = array(
-			'success' => false,
-			'error' => array(),
-			'data' => null
-		);
+        $expected = array(
+            'success' => false,
+            'error' => array(),
+            'data' => null
+        );
 
-		foreach($expected as $key => $value)
-		{
-			$this->assertEquals($value, $decodedBody[$key]);
-		}
-	}
+        foreach($expected as $key => $value)
+        {
+            $this->assertEquals($value, $decodedBody[$key]);
+        }
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -6,30 +6,29 @@ use WpOrg\Requests\Exception;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\TestCase;
 
-class ResponseTest extends TestCase {
+final class ResponseTest extends TestCase {
 
-    public function testInvalidJsonResponse() {
-        $this->expectException(Exception::class);
+	public function testInvalidJsonResponse() {
+		$this->expectException(Exception::class);
 
-        $response = new Response();
-        $response->body = 'Invalid JSON';
-        $response->json();
-    }
+		$response       = new Response();
+		$response->body = 'Invalid JSON';
+		$response->json();
+	}
 
-    public function testJsonResponse() {
-        $response = new Response();
-        $response->body = '{"success": false, "error": [], "data": null}';
-        $decodedBody = $response->json();
+	public function testJsonResponse() {
+		$response       = new Response();
+		$response->body = '{"success": false, "error": [], "data": null}';
+		$decoded_body   = $response->json();
 
-        $expected = array(
-            'success' => false,
-            'error' => array(),
-            'data' => null
-        );
+		$expected = array(
+			'success' => false,
+			'error'   => array(),
+			'data'    => null,
+		);
 
-        foreach($expected as $key => $value)
-        {
-            $this->assertEquals($value, $decodedBody[$key]);
-        }
-    }
+		foreach ($expected as $key => $value) {
+			$this->assertEquals($value, $decoded_body[$key]);
+		}
+	}
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -13,13 +13,13 @@ final class ResponseTest extends TestCase {
 
 		$response       = new Response();
 		$response->body = 'Invalid JSON';
-		$response->json();
+		$response->decode_body();
 	}
 
 	public function testJsonResponse() {
 		$response       = new Response();
 		$response->body = '{"success": false, "error": [], "data": null}';
-		$decoded_body   = $response->json();
+		$decoded_body   = $response->decode_body();
 
 		$expected = array(
 			'success' => false,

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,17 +1,23 @@
 <?php
 
-class RequestsTest_Response extends PHPUnit_Framework_TestCase {
-    /**
-     * @expectedException Requests_Exception
-     */
+namespace WpOrg\Requests\Tests;
+
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Response;
+use WpOrg\Requests\Tests\TestCase;
+
+class ResponseTest extends TestCase {
+
     public function testInvalidJsonResponse() {
-        $response = new Requests_Response();
+        $this->expectException(Exception::class);
+
+        $response = new Response();
         $response->body = 'Invalid JSON';
         $response->json();
     }
 
     public function testJsonResponse() {
-        $response = new Requests_Response();
+        $response = new Response();
         $response->body = '{"success": false, "error": [], "data": null}';
         $decodedBody = $response->json();
 


### PR DESCRIPTION
Recreation of PR #214 as updating that PR failed.

Props @ccrims0n

### Add json() for json responses

* Add json() which returns decoded json from the response body
  if the response body is a valid json else throws an exception

### Fix json_decode() for php 5.2 and 5.3

### Fix json() for php5.4

### Response::json(): revert changes for PHP 5.2 -5.4 compatibility

PHP 5.6 is the new minimum PHP version, so these accommodations for PHP 5.2 - 5.4 can be reverted again.

This reverts commit 8ea4334 and 2d2ecf3.

### Response::json(): update to make code runnable again

* Use namespaced names.
* Namespace test class and rename test file to match.
* Use `expectException()` method instead of annotation.

### Response::json(): update to comply with coding standards

### Response::json(): rename the method

... to be more descriptive.

### Response::decode_body(): rename parameter

... to be in-line with the parameter name used in PHP itself.

Ref: https://www.php.net/json-decode

### Response::decode_body(): modernize the error handling

As of PHP 5.5.0, PHP contains the `json_last_error_msg()` function which will return the last error message.

This removes the need for the error decoding array, which was outdated by now anyway due to new error codes having been introduced in PHP since the PR was originally pulled.

Ref: https://www.php.net/manual/en/function.json-last-error-msg.php

### Response::decode_body(): improve the method documentation

... to be in-line with the documentation for the same parameters in the PHP native function.

Ref: https://www.php.net/json-decode

### Response::decode_body(): improve the tests

* Use type safe `assertSame()` instead of `assertEquals()` and remove the unnecessary `foreach`.
* Rework the "invalid JSON" test to a data provider and add some adidtional test cases.
* Add `@covers` tags.
* Add `@requires` tags for the JSON extension as while that extension has been bundled with PHP for a long time, it could still be disabled until PHP 8.0.
* Add documentation.

### Composer: make the dependency on the JSON extension explicit

Fixes #167
Closes #214