### PR TITLE
PHP 8.0: ensure parameter names are aligned with PHP native param names

### DIFF
--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -58,27 +58,27 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Check if the given item exists
 	 *
-	 * @param string $key Item key
+	 * @param string $offset Item key
 	 * @return boolean Does the item exist?
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetExists($key) {
-		return isset($this->cookies[$key]);
+	public function offsetExists($offset) {
+		return isset($this->cookies[$offset]);
 	}
 
 	/**
 	 * Get the value for the item
 	 *
-	 * @param string $key Item key
+	 * @param string $offset Item key
 	 * @return string|null Item value (null if offsetExists is false)
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetGet($key) {
-		if (!isset($this->cookies[$key])) {
+	public function offsetGet($offset) {
+		if (!isset($this->cookies[$offset])) {
 			return null;
 		}
 
-		return $this->cookies[$key];
+		return $this->cookies[$offset];
 	}
 
 	/**
@@ -86,26 +86,26 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`)
 	 *
-	 * @param string $key Item name
+	 * @param string $offset Item name
 	 * @param string $value Item value
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetSet($key, $value) {
-		if ($key === null) {
+	public function offsetSet($offset, $value) {
+		if ($offset === null) {
 			throw new Exception('Object is a dictionary, not a list', 'invalidset');
 		}
 
-		$this->cookies[$key] = $value;
+		$this->cookies[$offset] = $value;
 	}
 
 	/**
 	 * Unset the given header
 	 *
-	 * @param string $key
+	 * @param string $offset
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetUnset($key) {
-		unset($this->cookies[$key]);
+	public function offsetUnset($offset) {
+		unset($this->cookies[$offset]);
 	}
 
 	/**

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -63,16 +63,16 @@ class Headers extends CaseInsensitiveDictionary {
 	/**
 	 * Get all values for a given header
 	 *
-	 * @param string $key
+	 * @param string $offset
 	 * @return array|null Header values
 	 */
-	public function getValues($key) {
-		$key = strtolower($key);
-		if (!isset($this->data[$key])) {
+	public function getValues($offset) {
+		$offset = strtolower($offset);
+		if (!isset($this->data[$offset])) {
 			return null;
 		}
 
-		return $this->data[$key];
+		return $this->data[$offset];
 	}
 
 	/**

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -26,16 +26,16 @@ class Headers extends CaseInsensitiveDictionary {
 	 * Avoid using this where commas may be used unquoted in values, such as
 	 * Set-Cookie headers.
 	 *
-	 * @param string $key
+	 * @param string $offset
 	 * @return string|null Header value
 	 */
-	public function offsetGet($key) {
-		$key = strtolower($key);
-		if (!isset($this->data[$key])) {
+	public function offsetGet($offset) {
+		$offset = strtolower($offset);
+		if (!isset($this->data[$offset])) {
 			return null;
 		}
 
-		return $this->flatten($this->data[$key]);
+		return $this->flatten($this->data[$offset]);
 	}
 
 	/**
@@ -43,21 +43,21 @@ class Headers extends CaseInsensitiveDictionary {
 	 *
 	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`)
 	 *
-	 * @param string $key Item name
+	 * @param string $offset Item name
 	 * @param string $value Item value
 	 */
-	public function offsetSet($key, $value) {
-		if ($key === null) {
+	public function offsetSet($offset, $value) {
+		if ($offset === null) {
 			throw new Exception('Object is a dictionary, not a list', 'invalidset');
 		}
 
-		$key = strtolower($key);
+		$offset = strtolower($offset);
 
-		if (!isset($this->data[$key])) {
-			$this->data[$key] = array();
+		if (!isset($this->data[$offset])) {
+			$this->data[$offset] = array();
 		}
 
-		$this->data[$key][] = $value;
+		$this->data[$offset][] = $value;
 	}
 
 	/**

--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -42,29 +42,29 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Check if the given item exists
 	 *
-	 * @param string $key Item key
+	 * @param string $offset Item key
 	 * @return boolean Does the item exist?
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetExists($key) {
-		$key = strtolower($key);
-		return isset($this->data[$key]);
+	public function offsetExists($offset) {
+		$offset = strtolower($offset);
+		return isset($this->data[$offset]);
 	}
 
 	/**
 	 * Get the value for the item
 	 *
-	 * @param string $key Item key
+	 * @param string $offset Item key
 	 * @return string|null Item value (null if offsetExists is false)
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetGet($key) {
-		$key = strtolower($key);
-		if (!isset($this->data[$key])) {
+	public function offsetGet($offset) {
+		$offset = strtolower($offset);
+		if (!isset($this->data[$offset])) {
 			return null;
 		}
 
-		return $this->data[$key];
+		return $this->data[$offset];
 	}
 
 	/**
@@ -72,27 +72,27 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`)
 	 *
-	 * @param string $key Item name
+	 * @param string $offset Item name
 	 * @param string $value Item value
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetSet($key, $value) {
-		if ($key === null) {
+	public function offsetSet($offset, $value) {
+		if ($offset === null) {
 			throw new Exception('Object is a dictionary, not a list', 'invalidset');
 		}
 
-		$key              = strtolower($key);
-		$this->data[$key] = $value;
+		$offset              = strtolower($offset);
+		$this->data[$offset] = $value;
 	}
 
 	/**
 	 * Unset the given header
 	 *
-	 * @param string $key
+	 * @param string $offset
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetUnset($key) {
-		unset($this->data[strtolower($key)]);
+	public function offsetUnset($offset) {
+		unset($this->data[strtolower($offset)]);
 	}
 
 	/**

--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -34,8 +34,8 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	 * @param array $data Dictionary/map to convert to case-insensitive
 	 */
 	public function __construct(array $data = array()) {
-		foreach ($data as $key => $value) {
-			$this->offsetSet($key, $value);
+		foreach ($data as $offset => $value) {
+			$this->offsetSet($offset, $value);
 		}
 	}
 

--- a/src/Utility/FilteredIterator.php
+++ b/src/Utility/FilteredIterator.php
@@ -43,7 +43,7 @@ final class FilteredIterator extends ArrayIterator {
 	 * @phpcs:disable PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__unserializeFound
 	 */
 	#[ReturnTypeWillChange]
-	public function __unserialize($serialized) {}
+	public function __unserialize($data) {}
 	// phpcs:enable
 
 	public function __wakeup() {
@@ -70,5 +70,5 @@ final class FilteredIterator extends ArrayIterator {
 	 * @inheritdoc
 	 */
 	#[ReturnTypeWillChange]
-	public function unserialize($serialized) {}
+	public function unserialize($data) {}
 }


### PR DESCRIPTION
### PHP 8.0: ensure parameter names are aligned with PHP native param names [1]

... for the required methods declared in classes implementing the `ArrayAccess` interface, either directly or by extending a class which implements the interface.

This prevents issues with when the PHP 8.0 named parameters feature is used.

Refs:
* https://www.php.net/manual/en/class.arrayaccess.php
* https://wiki.php.net/rfc/named_params

### QA: use consistent param/variable names throughout classes

With the `$key` parameters being changed to `$offset` in the previous commit, for consistency, it makes the code clearer to use the same name in other places in these classes which also use the `$offset`, but were calling it `$key`.

### PHP 8.0: ensure parameter names are aligned with PHP native param names [2]

... for the magic `__unserialize()` method and the `serialize()` method which is overloaded from the extended `ArrayIterator` class.

This prevents issues with when the PHP 8.0 named parameters feature is used.

Refs:
* https://www.php.net/manual/en/class.arrayiterator.php
* https://www.php.net/manual/en/language.oop5.magic.php#object.unserialize
* https://wiki.php.net/rfc/named_params

Related to #533