### PR TITLE
QA/PHP 8.0 | Don't use reserved keywords as param names

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -146,19 +146,19 @@ class Cookie {
 	/**
 	 * Check if a cookie is valid for a given domain
 	 *
-	 * @param string $string Domain to check
+	 * @param string $domain Domain to check
 	 * @return boolean Whether the cookie is valid for the given domain
 	 */
-	public function domain_matches($string) {
+	public function domain_matches($domain) {
 		if (!isset($this->attributes['domain'])) {
 			// Cookies created manually; cookies created by Requests will set
 			// the domain to the requested domain
 			return true;
 		}
 
-		$domain_string = $this->attributes['domain'];
-		if ($domain_string === $string) {
-			// The domain string and the string are identical.
+		$cookie_domain = $this->attributes['domain'];
+		if ($cookie_domain === $domain) {
+			// The cookie domain and the passed domain are identical.
 			return true;
 		}
 
@@ -168,26 +168,26 @@ class Cookie {
 			return false;
 		}
 
-		if (strlen($string) <= strlen($domain_string)) {
-			// For obvious reasons, the string cannot be a suffix if the domain
-			// is shorter than the domain string
+		if (strlen($domain) <= strlen($cookie_domain)) {
+			// For obvious reasons, the cookie domain cannot be a suffix if the passed domain
+			// is shorter than the cookie domain
 			return false;
 		}
 
-		if (substr($string, -1 * strlen($domain_string)) !== $domain_string) {
-			// The domain string should be a suffix of the string.
+		if (substr($domain, -1 * strlen($cookie_domain)) !== $cookie_domain) {
+			// The cookie domain should be a suffix of the passed domain.
 			return false;
 		}
 
-		$prefix = substr($string, 0, strlen($string) - strlen($domain_string));
+		$prefix = substr($domain, 0, strlen($domain) - strlen($cookie_domain));
 		if (substr($prefix, -1) !== '.') {
-			// The last character of the string that is not included in the
+			// The last character of the passed domain that is not included in the
 			// domain string should be a %x2E (".") character.
 			return false;
 		}
 
-		// The string should be a host name (i.e., not an IP address).
-		return !preg_match('#^(.+\.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$#', $string);
+		// The passed domain should be a host name (i.e., not an IP address).
+		return !preg_match('#^(.+\.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$#', $domain);
 	}
 
 	/**

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -365,15 +365,15 @@ class Cookie {
 	 * is an intentional deviation from RFC 2109 and RFC 2616. RFC 6265
 	 * specifies some of this handling, but not in a thorough manner.
 	 *
-	 * @param string Cookie header value (from a Set-Cookie header)
+	 * @param string $cookie_header Cookie header value (from a Set-Cookie header)
 	 * @return \WpOrg\Requests\Cookie Parsed cookie object
 	 */
-	public static function parse($string, $name = '', $reference_time = null) {
-		$parts   = explode(';', $string);
+	public static function parse($cookie_header, $name = '', $reference_time = null) {
+		$parts   = explode(';', $cookie_header);
 		$kvparts = array_shift($parts);
 
 		if (!empty($name)) {
-			$value = $string;
+			$value = $cookie_header;
 		}
 		elseif (strpos($kvparts, '=') === false) {
 			// Some sites might only have a value without the equals separator.

--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -166,16 +166,16 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Parse all cookies from a response and attach them to the response
 	 *
-	 * @var \WpOrg\Requests\Response $response
+	 * @param \WpOrg\Requests\Response $response
 	 */
-	public function before_redirect_check(Response $return) {
-		$url = $return->url;
+	public function before_redirect_check(Response $response) {
+		$url = $response->url;
 		if (!$url instanceof Iri) {
 			$url = new Iri($url);
 		}
 
-		$cookies         = Cookie::parse_from_headers($return->headers, $url);
-		$this->cookies   = array_merge($this->cookies, $cookies);
-		$return->cookies = $this;
+		$cookies           = Cookie::parse_from_headers($response->headers, $url);
+		$this->cookies     = array_merge($this->cookies, $cookies);
+		$response->cookies = $this;
 	}
 }

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -131,14 +131,14 @@ class IdnaEncoder {
 	}
 
 	/**
-	 * Prepare a string for use as an IDNA name
+	 * Prepare a text string for use as an IDNA name
 	 *
 	 * @todo Implement this based on RFC 3491 and the newer 5891
-	 * @param string $string
+	 * @param string $text
 	 * @return string Prepared string
 	 */
-	protected static function nameprep($string) {
-		return $string;
+	protected static function nameprep($text) {
+		return $text;
 	}
 
 	/**

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -119,15 +119,15 @@ class IdnaEncoder {
 	}
 
 	/**
-	 * Check whether a given string contains only ASCII characters
+	 * Check whether a given text string contains only ASCII characters
 	 *
 	 * @internal (Testing found regex was the fastest implementation)
 	 *
-	 * @param string $string
-	 * @return bool Is the string ASCII-only?
+	 * @param string $text
+	 * @return bool Is the text string ASCII-only?
 	 */
-	protected static function is_ascii($string) {
-		return (preg_match('/(?:[^\x00-\x7F])/', $string) !== 1);
+	protected static function is_ascii($text) {
+		return (preg_match('/(?:[^\x00-\x7F])/', $text) !== 1);
 	}
 
 	/**

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -64,58 +64,58 @@ class IdnaEncoder {
 	}
 
 	/**
-	 * Convert a UTF-8 string to an ASCII string using Punycode
+	 * Convert a UTF-8 text string to an ASCII string using Punycode
 	 *
 	 * @throws \WpOrg\Requests\Exception Provided string longer than 64 ASCII characters (`idna.provided_too_long`)
 	 * @throws \WpOrg\Requests\Exception Prepared string longer than 64 ASCII characters (`idna.prepared_too_long`)
 	 * @throws \WpOrg\Requests\Exception Provided string already begins with xn-- (`idna.provided_is_prefixed`)
 	 * @throws \WpOrg\Requests\Exception Encoded string longer than 64 ASCII characters (`idna.encoded_too_long`)
 	 *
-	 * @param string $string ASCII or UTF-8 string (max length 64 characters)
+	 * @param string $text ASCII or UTF-8 string (max length 64 characters)
 	 * @return string ASCII string
 	 */
-	public static function to_ascii($string) {
-		// Step 1: Check if the string is already ASCII
-		if (self::is_ascii($string)) {
+	public static function to_ascii($text) {
+		// Step 1: Check if the text is already ASCII
+		if (self::is_ascii($text)) {
 			// Skip to step 7
-			if (strlen($string) < self::MAX_LENGTH) {
-				return $string;
+			if (strlen($text) < self::MAX_LENGTH) {
+				return $text;
 			}
 
-			throw new Exception('Provided string is too long', 'idna.provided_too_long', $string);
+			throw new Exception('Provided string is too long', 'idna.provided_too_long', $text);
 		}
 
 		// Step 2: nameprep
-		$string = self::nameprep($string);
+		$text = self::nameprep($text);
 
 		// Step 3: UseSTD3ASCIIRules is false, continue
 		// Step 4: Check if it's ASCII now
-		if (self::is_ascii($string)) {
+		if (self::is_ascii($text)) {
 			// Skip to step 7
-			if (strlen($string) < self::MAX_LENGTH) {
-				return $string;
+			if (strlen($text) < self::MAX_LENGTH) {
+				return $text;
 			}
 
-			throw new Exception('Prepared string is too long', 'idna.prepared_too_long', $string);
+			throw new Exception('Prepared string is too long', 'idna.prepared_too_long', $text);
 		}
 
 		// Step 5: Check ACE prefix
-		if (strpos($string, self::ACE_PREFIX) === 0) {
-			throw new Exception('Provided string begins with ACE prefix', 'idna.provided_is_prefixed', $string);
+		if (strpos($text, self::ACE_PREFIX) === 0) {
+			throw new Exception('Provided string begins with ACE prefix', 'idna.provided_is_prefixed', $text);
 		}
 
 		// Step 6: Encode with Punycode
-		$string = self::punycode_encode($string);
+		$text = self::punycode_encode($text);
 
 		// Step 7: Prepend ACE prefix
-		$string = self::ACE_PREFIX . $string;
+		$text = self::ACE_PREFIX . $text;
 
 		// Step 8: Check size
-		if (strlen($string) < self::MAX_LENGTH) {
-			return $string;
+		if (strlen($text) < self::MAX_LENGTH) {
+			return $text;
 		}
 
-		throw new Exception('Encoded string is too long', 'idna.encoded_too_long', $string);
+		throw new Exception('Encoded string is too long', 'idna.encoded_too_long', $text);
 	}
 
 	/**

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -52,11 +52,11 @@ class IdnaEncoder {
 	/**
 	 * Encode a hostname using Punycode
 	 *
-	 * @param string $string Hostname
+	 * @param string $hostname Hostname
 	 * @return string Punycode-encoded hostname
 	 */
-	public static function encode($string) {
-		$parts = explode('.', $string);
+	public static function encode($hostname) {
+		$parts = explode('.', $hostname);
 		foreach ($parts as &$part) {
 			$part = self::to_ascii($part);
 		}

--- a/src/Iri.php
+++ b/src/Iri.php
@@ -991,11 +991,11 @@ class Iri {
 	/**
 	 * Convert an IRI to a URI (or parts thereof)
 	 *
-	 * @param string|bool IRI to convert (or false from {@see \WpOrg\Requests\IRI::get_iri()})
+	 * @param string|bool $iri IRI to convert (or false from {@see \WpOrg\Requests\IRI::get_iri()})
 	 * @return string|false URI if IRI is valid, false otherwise.
 	 */
-	protected function to_uri($string) {
-		if (!is_string($string)) {
+	protected function to_uri($iri) {
+		if (!is_string($iri)) {
 			return false;
 		}
 
@@ -1005,14 +1005,14 @@ class Iri {
 		}
 
 		$position = 0;
-		$strlen = strlen($string);
-		while (($position += strcspn($string, $non_ascii, $position)) < $strlen) {
-			$string = substr_replace($string, sprintf('%%%02X', ord($string[$position])), $position, 1);
+		$strlen = strlen($iri);
+		while (($position += strcspn($iri, $non_ascii, $position)) < $strlen) {
+			$iri = substr_replace($iri, sprintf('%%%02X', ord($iri[$position])), $position, 1);
 			$position += 3;
 			$strlen += 2;
 		}
 
-		return $string;
+		return $iri;
 	}
 
 	/**

--- a/src/Iri.php
+++ b/src/Iri.php
@@ -419,18 +419,18 @@ class Iri {
 	/**
 	 * Replace invalid character with percent encoding
 	 *
-	 * @param string $string Input string
+	 * @param string $text Input string
 	 * @param string $extra_chars Valid characters not in iunreserved or
 	 *                            iprivate (this is ASCII-only)
 	 * @param bool $iprivate Allow iprivate
 	 * @return string
 	 */
-	protected function replace_invalid_with_pct_encoding($string, $extra_chars, $iprivate = false) {
+	protected function replace_invalid_with_pct_encoding($text, $extra_chars, $iprivate = false) {
 		// Normalize as many pct-encoded sections as possible
-		$string = preg_replace_callback('/(?:%[A-Fa-f0-9]{2})+/', array($this, 'remove_iunreserved_percent_encoded'), $string);
+		$text = preg_replace_callback('/(?:%[A-Fa-f0-9]{2})+/', array($this, 'remove_iunreserved_percent_encoded'), $text);
 
 		// Replace invalid percent characters
-		$string = preg_replace('/%(?![A-Fa-f0-9]{2})/', '%25', $string);
+		$text = preg_replace('/%(?![A-Fa-f0-9]{2})/', '%25', $text);
 
 		// Add unreserved and % to $extra_chars (the latter is safe because all
 		// pct-encoded sections are now valid).
@@ -438,9 +438,9 @@ class Iri {
 
 		// Now replace any bytes that aren't allowed with their pct-encoded versions
 		$position = 0;
-		$strlen = strlen($string);
-		while (($position += strspn($string, $extra_chars, $position)) < $strlen) {
-			$value = ord($string[$position]);
+		$strlen = strlen($text);
+		while (($position += strspn($text, $extra_chars, $position)) < $strlen) {
+			$value = ord($text[$position]);
 
 			// Start position
 			$start = $position;
@@ -477,7 +477,7 @@ class Iri {
 			if ($remaining) {
 				if ($position + $length <= $strlen) {
 					for ($position++; $remaining; $position++) {
-						$value = ord($string[$position]);
+						$value = ord($text[$position]);
 
 						// Check that the byte is valid, then add it to the character:
 						if (($value & 0xC0) === 0x80) {
@@ -528,7 +528,7 @@ class Iri {
 				}
 
 				for ($j = $start; $j <= $position; $j++) {
-					$string = substr_replace($string, sprintf('%%%02X', ord($string[$j])), $j, 1);
+					$text = substr_replace($text, sprintf('%%%02X', ord($text[$j])), $j, 1);
 					$j += 2;
 					$position += 2;
 					$strlen += 2;
@@ -536,7 +536,7 @@ class Iri {
 			}
 		}
 
-		return $string;
+		return $text;
 	}
 
 	/**

--- a/src/Iri.php
+++ b/src/Iri.php
@@ -545,13 +545,13 @@ class Iri {
 	 * Removes sequences of percent encoded bytes that represent UTF-8
 	 * encoded characters in iunreserved
 	 *
-	 * @param array $match PCRE match
+	 * @param array $regex_match PCRE match
 	 * @return string Replacement
 	 */
-	protected function remove_iunreserved_percent_encoded($match) {
+	protected function remove_iunreserved_percent_encoded($regex_match) {
 		// As we just have valid percent encoded sequences we can just explode
 		// and ignore the first member of the returned array (an empty string).
-		$bytes = explode('%', $match[0]);
+		$bytes = explode('%', $regex_match[0]);
 
 		// Initialize the new string (this is what will be returned) and that
 		// there are no bytes remaining in the current sequence (unsurprising

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -802,12 +802,12 @@ class Requests {
 	/**
 	 * Convert a key => value array to a 'key: value' array for headers
 	 *
-	 * @param array $array Dictionary of header values
+	 * @param array $dictionary Dictionary of header values
 	 * @return array List of headers
 	 */
-	public static function flatten($array) {
+	public static function flatten($dictionary) {
 		$return = array();
-		foreach ($array as $key => $value) {
+		foreach ($dictionary as $key => $value) {
 			$return[] = sprintf('%s: %s', $key, $value);
 		}
 		return $return;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,13 +2,13 @@
 
 date_default_timezone_set('UTC');
 
-function define_from_env($name, $default = false) {
+function define_from_env($name, $fallback = false) {
 	$env = getenv($name);
 	if ($env) {
 		define($name, $env);
 	}
 	else {
-		define($name, $default);
+		define($name, $fallback);
 	}
 }
 


### PR DESCRIPTION
While using reserved keywords as parameter names is perfectly valid PHP, I would strongly recommend against it as this decreases the comprehensibility/readability of code when these parameter names are subsequently used in function calls using named parameters (PHP 8.0+).

Related to #533

### QA/PHP 8.0 | Jar::before_redirect_check(): don't use reserved keywords as param names

This changes the parameter name for the `Jar::before_redirect_check()` function from `$return` to `$response` and updates all uses of the parameter in the function to match.

Includes fixing the docblock, in which the parameter name already didn't match the previous parameter name.

### QA/PHP 8.0 | Requests::flatten(): don't use reserved keywords as param names

This changes the parameter name for the `Requests::flatten()` function from `$array` to `$dictionary` and updates all uses of the parameter in the function to match.

### QA/PHP 8.0 | Cookie::domain_matches(): don't use reserved keywords as param names

This changes the parameter name for the `Cookie::domain_matches()` function from `$string` to `$domain` and updates all uses of the parameter in the function to match.

Includes changing the name of the function local `$domain_string` variable to `$cookie_domain` and updating the inline comments for comprehensibility as they had become unclear with the new names in play.

### QA/PHP 8.0 | Cookie::parse(): don't use reserved keywords as param names

This changes the parameter name for the `Cookie::parse()` function from `$string` to `$cookie_header` and updates all uses of the parameter in the function to match.

### QA/PHP 8.0 | IdnaEncoder::encode(): don't use reserved keywords as param names

This changes the parameter name for the `IdnaEncoder::encode()` function from `$string` to `$hostname` and updates all uses of the parameter in the function to match.

### QA/PHP 8.0 | IdnaEncoder::to_ascii(): don't use reserved keywords as param names

This changes the parameter name for the `IdnaEncoder::to_ascii()` function from `$string` to `$text` and updates all uses of the parameter in the function to match.

### QA/PHP 8.0 | IdnaEncoder::is_ascii(): don't use reserved keywords as param names

This changes the parameter name for the `IdnaEncoder::is_ascii()` function from `$string` to `$text` and updates all uses of the parameter in the function to match.

### QA/PHP 8.0 | IdnaEncoder::nameprep(): don't use reserved keywords as param names

This changes the parameter name for the `IdnaEncoder::nameprep()` function from `$string` to `$text` and updates all uses of the parameter in the function to match.

### QA/PHP 8.0 | Iri::replace_invalid_with_pct_encoding(): don't use reserved keywords as param names

This changes the parameter name for the `Iri::replace_invalid_with_pct_encoding()` function from `$string` to `$text` and updates all uses of the parameter in the function to match.

### QA/PHP 8.0 | Iri::remove_iunreserved_percent_encoded(): don't use reserved keywords as param names

This changes the parameter name for the `Iri::remove_iunreserved_percent_encoded()` function from `$match` to `$regex_match` and updates all uses of the parameter in the function to match.

### QA/PHP 8.0 | Iri::to_uri(): don't use reserved keywords as param names

This changes the parameter name for the `Iri::to_uri()` function from `$string` to `$iri` and updates all uses of the parameter in the function to match.

### QA/PHP 8.0 | Test bootstrap: don't use reserved keywords as param names

While this use in the test bootstrap is not problematic, for consistency, it is changed as well.



