### PR TITLE
GH Actions: minor simplification to website gen workflow

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -45,18 +45,13 @@ jobs:
           php-version: '7.4'
           ini-values: display_errors=On
           coverage: none
-
-      # This will install the phpDocumentor PHAR, not the "normal" dependencies.
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
-        with:
-          composer-options: "--working-dir=build/ghpages/"
+          tools: phpdoc
 
       - name: Update the phpDoc configuration
         run: php build/ghpages/update-docgen-config.php
 
       - name: Generate the phpDoc documentation
-        run: php build/ghpages/vendor/bin/phpdoc
+        run: phpDocumentor
 
       - name: Transform the markdown docs for use in GH Pages
         run: php build/ghpages/update-markdown-docs.php


### PR DESCRIPTION
As of `setup-php` `2.15.0`, phpDocumentor is available via the `tools` in SetupPHP, so we may as well use that.

The `build/ghpages/composer.json` file remains in place as an aid for people running/testing the website regeneration locally, but is no longer used in the GH Actions workflow.

Ref: https://github.com/shivammathur/setup-php/releases/tag/2.15.0