### PR TITLE
Auth\Basic: add input validation to constructor

### DIFF
--- a/src/Auth/Basic.php
+++ b/src/Auth/Basic.php
@@ -10,6 +10,7 @@ namespace WpOrg\Requests\Auth;
 
 use WpOrg\Requests\Auth;
 use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Hooks;
 
 /**
@@ -39,8 +40,10 @@ class Basic implements Auth {
 	/**
 	 * Constructor
 	 *
-	 * @throws \WpOrg\Requests\Exception On incorrect number of arguments (`authbasicbadargs`)
 	 * @param array|null $args Array of user and password. Must have exactly two elements
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not an array or null.
+	 * @throws \WpOrg\Requests\Exception                 On incorrect number of arguments (`authbasicbadargs`).
 	 */
 	public function __construct($args = null) {
 		if (is_array($args)) {
@@ -49,6 +52,11 @@ class Basic implements Auth {
 			}
 
 			list($this->user, $this->pass) = $args;
+			return;
+		}
+
+		if ($args !== null) {
+			throw InvalidArgument::create(1, '$args', 'array|null', gettype($args));
 		}
 	}
 

--- a/src/Auth/Basic.php
+++ b/src/Auth/Basic.php
@@ -9,7 +9,7 @@
 namespace WpOrg\Requests\Auth;
 
 use WpOrg\Requests\Auth;
-use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\ArgumentCount;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Hooks;
 
@@ -40,15 +40,18 @@ class Basic implements Auth {
 	/**
 	 * Constructor
 	 *
+	 * @since 2.0 Throws an `InvalidArgument` exception.
+	 * @since 2.0 Throws an `ArgumentCount` exception instead of the Requests base `Exception.
+	 *
 	 * @param array|null $args Array of user and password. Must have exactly two elements
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not an array or null.
-	 * @throws \WpOrg\Requests\Exception                 On incorrect number of arguments (`authbasicbadargs`).
+	 * @throws \WpOrg\Requests\Exception\ArgumentCount   On incorrect number of array elements (`authbasicbadargs`).
 	 */
 	public function __construct($args = null) {
 		if (is_array($args)) {
 			if (count($args) !== 2) {
-				throw new Exception('Invalid number of arguments', 'authbasicbadargs');
+				throw ArgumentCount::create('an array with exactly two elements', count($args), 'authbasicbadargs');
 			}
 
 			list($this->user, $this->pass) = $args;

--- a/src/Exception/ArgumentCount.php
+++ b/src/Exception/ArgumentCount.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WpOrg\Requests\Exception;
+
+use WpOrg\Requests\Exception;
+
+/**
+ * Exception for when an incorrect number of arguments are passed to a method.
+ *
+ * Typically, this exception is used when all arguments for a method are optional,
+ * but certain arguments need to be passed together, i.e. a method which can be called
+ * with no arguments or with two arguments, but not with one argument.
+ *
+ * Along the same lines, this exception is also used if a method expects an array
+ * with a certain number of elements and the provided number of elements does not comply.
+ *
+ * @package Requests
+ * @since   2.0.0
+ */
+final class ArgumentCount extends Exception {
+
+	/**
+	 * Create a new argument count exception with a standardized text.
+	 *
+	 * @param string $expected The argument count expected as a phrase.
+	 *                         For example: `at least 2 arguments` or `exactly 1 argument`.
+	 * @param int    $received The actual argument count received.
+	 * @param string $type     Exception type.
+	 *
+	 * @return \WpOrg\Requests\Exception\ArgumentCount
+	 */
+	public static function create($expected, $received, $type) {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+		return new self(
+			sprintf(
+				'%s::%s() expects %s, %d given',
+				$stack[1]['class'],
+				$stack[1]['function'],
+				$expected,
+				$received
+			),
+			$type
+		);
+	}
+}

--- a/src/Proxy/Http.php
+++ b/src/Proxy/Http.php
@@ -9,7 +9,7 @@
 
 namespace WpOrg\Requests\Proxy;
 
-use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\ArgumentCount;
 use WpOrg\Requests\Hooks;
 use WpOrg\Requests\Proxy;
 
@@ -57,8 +57,12 @@ final class Http implements Proxy {
 	 * Constructor
 	 *
 	 * @since 1.6
-	 * @throws \WpOrg\Requests\Exception On incorrect number of arguments (`authbasicbadargs`)
-	 * @param array|null $args Array of user and password. Must have exactly two elements
+	 * @since 2.0 Throws an `ArgumentCount` exception instead of the Requests base `Exception.
+	 *
+	 * @param array|null $args Array of proxy, user and password.
+	 *                         Must have exactly one (proxy) or three elements (proxy, user, password).
+	 *
+	 * @throws \WpOrg\Requests\Exception\ArgumentCount On incorrect number of arguments (`proxyhttpbadargs`)
 	 */
 	public function __construct($args = null) {
 		if (is_string($args)) {
@@ -73,7 +77,11 @@ final class Http implements Proxy {
 				$this->use_authentication                    = true;
 			}
 			else {
-				throw new Exception('Invalid number of arguments', 'proxyhttpbadargs');
+				throw ArgumentCount::create(
+					'an array with exactly one element or exactly three elements',
+					count($args),
+					'proxyhttpbadargs'
+				);
 			}
 		}
 	}

--- a/tests/Auth/BasicTest.php
+++ b/tests/Auth/BasicTest.php
@@ -4,6 +4,7 @@ namespace WpOrg\Requests\Tests\Auth;
 
 use WpOrg\Requests\Auth\Basic;
 use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\TestCase;
@@ -114,6 +115,56 @@ final class BasicTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	public function testUsingInstantiationWithDelayedSettingOfCredentials($transport) {
+		$this->skipWhenTransportNotAvailable($transport);
+
+		$options = array(
+			'auth'      => new Basic(),
+			'transport' => $transport,
+		);
+
+		$options['auth']->user = 'user';
+		$options['auth']->pass = 'passwd';
+		$request               = Requests::get(httpbin('/basic-auth/user/passwd'), array(), $options);
+
+		// Verify the request succeeded.
+		$this->assertInstanceOf(
+			Response::class,
+			$request,
+			'GET request did not return an instance of `Requests\Response`'
+		);
+		$this->assertSame(
+			200,
+			$request->status_code,
+			'GET request failed. Expected status: 200. Received status: ' . $request->status_code
+		);
+
+		// Verify the response confirms that the request was authenticated.
+		$result = json_decode($request->body);
+		$this->assertIsObject($result, 'Decoded response body is not an object');
+
+		$this->assertObjectHasAttribute(
+			'authenticated',
+			$result,
+			'Property "authenticated" not available in decoded response'
+		);
+		$this->assertTrue($result->authenticated, 'Authentication failed');
+
+		$this->assertObjectHasAttribute(
+			'user',
+			$result,
+			'Property "user" not available in decoded response'
+		);
+		$this->assertSame('user', $result->user, 'Unexpected value encountered for "user"');
+	}
+
+	/**
+	 * @dataProvider transportProvider
+	 *
+	 * @param string $transport Transport to use.
+	 *
+	 * @return void
+	 */
 	public function testPOSTUsingInstantiation($transport) {
 		$this->skipWhenTransportNotAvailable($transport);
 
@@ -162,6 +213,34 @@ final class BasicTest extends TestCase {
 			'Property "data" not available in decoded response'
 		);
 		$this->assertSame('test', $result->data, 'Unexpected data value encountered');
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed.
+	 *
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $input Input data.
+	 *
+	 * @return void
+	 */
+	public function testInvalidInputType($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($args) must be of type array|null');
+
+		new Basic($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputType() {
+		return array(
+			'boolean false'         => array(false),
+			'authentication string' => array('user:psw'),
+		);
 	}
 
 	/**

--- a/tests/Auth/BasicTest.php
+++ b/tests/Auth/BasicTest.php
@@ -3,7 +3,7 @@
 namespace WpOrg\Requests\Tests\Auth;
 
 use WpOrg\Requests\Auth\Basic;
-use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\ArgumentCount;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
@@ -253,8 +253,8 @@ final class BasicTest extends TestCase {
 	 * @return void
 	 */
 	public function testInvalidArgumentCount($input) {
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Invalid number of arguments');
+		$this->expectException(ArgumentCount::class);
+		$this->expectExceptionMessage('WpOrg\Requests\Auth\Basic::__construct() expects an array with exactly two elements');
 
 		new Basic($input);
 	}

--- a/tests/Exception/ArgumentCountTest.php
+++ b/tests/Exception/ArgumentCountTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Exception;
+
+use WpOrg\Requests\Exception\ArgumentCount;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Exception\ArgumentCount
+ */
+final class ArgumentCountTest extends TestCase {
+
+	/**
+	 * Test that the text of the exception is as expected.
+	 *
+	 * @return void
+	 */
+	public function testCreate() {
+		$this->expectException(ArgumentCount::class);
+		$this->expectExceptionMessage('ArgumentCountTest::testCreate() expects exactly 1 argument, 0 given');
+
+		throw ArgumentCount::create('exactly 1 argument', 0, 'code');
+	}
+}

--- a/tests/Proxy/HttpTest.php
+++ b/tests/Proxy/HttpTest.php
@@ -3,6 +3,7 @@
 namespace WpOrg\Requests\Tests\Proxy;
 
 use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\ArgumentCount;
 use WpOrg\Requests\Proxy\Http;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
@@ -69,8 +70,8 @@ final class HttpTest extends TestCase {
 			'proxy'     => array(REQUESTS_HTTP_PROXY, 'testuser', 'password', 'something'),
 			'transport' => $transport,
 		);
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Invalid number of arguments');
+		$this->expectException(ArgumentCount::class);
+		$this->expectExceptionMessage('WpOrg\Requests\Proxy\Http::__construct() expects an array with exactly one element or exactly three elements');
 		Requests::get(httpbin('/get'), array(), $options);
 	}
 


### PR DESCRIPTION
The `Basic::__construct()` method expects to receive an array of exactly two element and did validate the input received, but only threw an exception when the passed parameter did not match the expected element count, not when the passed parameter wasn't an array.

At the same time, the default value of `$args` is `null`, not an empty array and the `$user` and `$pass` properties are both public.

The only reason I can think of to have these properties `public` and the default value set to `null`, is to allow for delayed setting of the `$user` and `$pass`, after the class has already been instantiated.

To maintain the existing behaviour, but still add input validation, an exception is now thrown when the `$args` parameter is neither an array, nor `null`.

Includes;
* A dedicated test for the input validation.
* An additional test with Basic authentication with an instantiated class, but with delayed setting of the `$user` and `$pass` directly on the instantiated object. This test is solely added to document that this is a supported feature (and to safeguard against regressions in that respect).