### PR TITLE
Fix the DocBlock for `offsetGet()`.

### DIFF
--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -62,15 +62,7 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetGet($offset) {
-		if (is_string($offset)) {
-			$offset = strtolower($offset);
-		}
-
-		if (!isset($this->data[$offset])) {
-			return null;
-		}
-
-		return $this->data[$offset];
+		return $this->offsetExists($offset) ? $this->data[$offset] : null;
 	}
 
 	/**

--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -58,11 +58,19 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	 * Get the value for the item
 	 *
 	 * @param string $offset Item key
-	 * @return string|null Item value (null if offsetExists is false)
+	 * @return string|null Item value (null if the item key doesn't exist)
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetGet($offset) {
-		return $this->offsetExists($offset) ? $this->data[$offset] : null;
+		if (is_string($offset)) {
+			$offset = strtolower($offset);
+		}
+
+		if (!isset($this->data[$offset])) {
+			return null;
+		}
+
+		return $this->data[$offset];
 	}
 
 	/**


### PR DESCRIPTION
## Pull Request Type

- [x]  I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [ ] New feature
- [x] Code quality improvement

## Context

**What do you want to achieve with this PR?**
Fix the documentation.

**Why did you write this code? What problem does this PR solve?**
The `offsetGet()` method doesn't call `offsetExists()` as its DocBlock states.

**What should be mentioned about this PR in the changelog?**
That the DocBlock is now accurate.

## Detailed Description

The docs for `CaseInsensitiveDictionary::offsetGet()` state:

`@return string|null Item value (null if offsetExists is false)`

However, this method doesn't call `offsetExists()`.

With this change, the DocBlock no longer references `offsetExists()` and now states:

`@return string|null Item value (null if the item key doesn't exist)`

## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.
