### PR TITLE
ChunkedEncodingTest: improve tests

### DIFF
--- a/tests/Requests/ChunkedEncodingTest.php
+++ b/tests/Requests/ChunkedEncodingTest.php
@@ -27,28 +27,28 @@ final class ChunkedDecodingTest extends TestCase {
 	public function dataChunked() {
 		return array(
 			array(
-				"25\r\nThis is the data in the first chunk\r\n\r\n1A\r\nand this is the second one\r\n0\r\n",
-				"This is the data in the first chunk\r\nand this is the second one",
+				'body'     => "25\r\nThis is the data in the first chunk\r\n\r\n1A\r\nand this is the second one\r\n0\r\n",
+				'expected' => "This is the data in the first chunk\r\nand this is the second one",
 			),
 			array(
-				"02\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0\r\nnothing\n",
-				"abra\ncadabra",
+				'body'     => "02\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0\r\nnothing\n",
+				'expected' => "abra\ncadabra",
 			),
 			array(
-				"02\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
-				"abra\ncadabra\nall we got\n",
+				'body'     => "02\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
+				'expected' => "abra\ncadabra\nall we got\n",
 			),
 			array(
-				"02;foo=bar;hello=world\r\nab\r\n04;foo=baz\r\nra\nc\r\n06;justfoo\r\nadabra\r\n0c\r\n\nall we got\n",
-				"abra\ncadabra\nall we got\n",
+				'body'     => "02;foo=bar;hello=world\r\nab\r\n04;foo=baz\r\nra\nc\r\n06;justfoo\r\nadabra\r\n0c\r\n\nall we got\n",
+				'expected' => "abra\ncadabra\nall we got\n",
 			),
 			array(
-				"02;foo=\"quoted value\"\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
-				"abra\ncadabra\nall we got\n",
+				'body'     => "02;foo=\"quoted value\"\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
+				'expected' => "abra\ncadabra\nall we got\n",
 			),
 			array(
-				"02;foo-bar=baz\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
-				"abra\ncadabra\nall we got\n",
+				'body'     => "02;foo-bar=baz\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
+				'expected' => "abra\ncadabra\nall we got\n",
 			),
 		);
 	}

--- a/tests/Requests/ChunkedEncodingTest.php
+++ b/tests/Requests/ChunkedEncodingTest.php
@@ -7,10 +7,19 @@ use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\Fixtures\TransportMock;
 use WpOrg\Requests\Tests\TestCase;
 
+/**
+ * @covers \WpOrg\Requests\Requests::decode_chunked
+ */
 final class ChunkedDecodingTest extends TestCase {
 
 	/**
+	 * Test decoding chunked responses.
+	 *
 	 * @dataProvider dataChunked
+	 *
+	 * @param string $body Not really chunked response body.
+	 *
+	 * @return void
 	 */
 	public function testChunked($body, $expected) {
 		$transport          = new TransportMock();
@@ -26,6 +35,11 @@ final class ChunkedDecodingTest extends TestCase {
 		$this->assertSame($expected, $response->body, 'Response body does not match expected dechunked body');
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
 	public function dataChunked() {
 		return array(
 			array(
@@ -56,8 +70,13 @@ final class ChunkedDecodingTest extends TestCase {
 	}
 
 	/**
-	 * Response says it's chunked, but actually isn't
+	 * Response says it's chunked, but actually isn't.
+	 *
 	 * @dataProvider dataNotActuallyChunked
+	 *
+	 * @param string $body Not really chunked response body.
+	 *
+	 * @return void
 	 */
 	public function testNotActuallyChunked($body) {
 		$transport          = new TransportMock();
@@ -73,6 +92,11 @@ final class ChunkedDecodingTest extends TestCase {
 		$this->assertSame($transport->body, $response->body, 'Response body does not match original body');
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
 	public function dataNotActuallyChunked() {
 		return array(
 			'empty string'                         => array(''),
@@ -87,7 +111,9 @@ final class ChunkedDecodingTest extends TestCase {
 
 	/**
 	 * Response says it's chunked and starts looking like it is, but turns out
-	 * that they're lying to us
+	 * that they're lying to us.
+	 *
+	 * @return void
 	 */
 	public function testMixedChunkiness() {
 		$transport          = new TransportMock();

--- a/tests/Requests/ChunkedEncodingTest.php
+++ b/tests/Requests/ChunkedEncodingTest.php
@@ -9,7 +9,7 @@ use WpOrg\Requests\Tests\TestCase;
 final class ChunkedDecodingTest extends TestCase {
 
 	/**
-	 * @dataProvider chunkedProvider
+	 * @dataProvider dataChunked
 	 */
 	public function testChunked($body, $expected) {
 		$transport          = new TransportMock();
@@ -24,7 +24,7 @@ final class ChunkedDecodingTest extends TestCase {
 		$this->assertSame($expected, $response->body);
 	}
 
-	public static function chunkedProvider() {
+	public function dataChunked() {
 		return array(
 			array(
 				"25\r\nThis is the data in the first chunk\r\n\r\n1A\r\nand this is the second one\r\n0\r\n",
@@ -55,7 +55,7 @@ final class ChunkedDecodingTest extends TestCase {
 
 	/**
 	 * Response says it's chunked, but actually isn't
-	 * @dataProvider notChunkedProvider
+	 * @dataProvider dataNotActuallyChunked
 	 */
 	public function testNotActuallyChunked($body) {
 		$transport          = new TransportMock();
@@ -70,7 +70,7 @@ final class ChunkedDecodingTest extends TestCase {
 		$this->assertSame($transport->body, $response->body);
 	}
 
-	public static function notChunkedProvider() {
+	public function dataNotActuallyChunked() {
 		return array(
 			'invalid chunk size'                   => array('Hello! This is a non-chunked response!'),
 			'invalid chunk extension'              => array('1BNot chunked\r\nLooks chunked but it is not\r\n'),

--- a/tests/Requests/ChunkedEncodingTest.php
+++ b/tests/Requests/ChunkedEncodingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\Requests\Tests;
+namespace WpOrg\Requests\Tests\Requests;
 
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\Fixtures\TransportMock;

--- a/tests/Requests/ChunkedEncodingTest.php
+++ b/tests/Requests/ChunkedEncodingTest.php
@@ -72,6 +72,7 @@ final class ChunkedDecodingTest extends TestCase {
 
 	public function dataNotActuallyChunked() {
 		return array(
+			'empty string'                         => array(''),
 			'invalid chunk size'                   => array('Hello! This is a non-chunked response!'),
 			'invalid chunk extension'              => array('1BNot chunked\r\nLooks chunked but it is not\r\n'),
 			'unquoted chunk-ext-val with space'    => array("02;foo=unquoted with space\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n"),

--- a/tests/Requests/ChunkedEncodingTest.php
+++ b/tests/Requests/ChunkedEncodingTest.php
@@ -3,6 +3,7 @@
 namespace WpOrg\Requests\Tests\Requests;
 
 use WpOrg\Requests\Requests;
+use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\Fixtures\TransportMock;
 use WpOrg\Requests\Tests\TestCase;
 
@@ -21,7 +22,8 @@ final class ChunkedDecodingTest extends TestCase {
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
 
-		$this->assertSame($expected, $response->body);
+		$this->assertInstanceOf(Response::class, $response, 'Response is not an instance of the Response class.');
+		$this->assertSame($expected, $response->body, 'Response body does not match expected dechunked body');
 	}
 
 	public function dataChunked() {
@@ -67,7 +69,8 @@ final class ChunkedDecodingTest extends TestCase {
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
 
-		$this->assertSame($transport->body, $response->body);
+		$this->assertInstanceOf(Response::class, $response, 'Response is not an instance of the Response class.');
+		$this->assertSame($transport->body, $response->body, 'Response body does not match original body');
 	}
 
 	public function dataNotActuallyChunked() {
@@ -95,6 +98,8 @@ final class ChunkedDecodingTest extends TestCase {
 			'transport' => $transport,
 		);
 		$response = Requests::get('http://example.com/', array(), $options);
-		$this->assertSame($transport->body, $response->body);
+
+		$this->assertInstanceOf(Response::class, $response, 'Response is not an instance of the Response class.');
+		$this->assertSame($transport->body, $response->body, 'Response body does not match original body');
 	}
 }


### PR DESCRIPTION
### ChunkedEncodingTest: move to subdirectory

There are a number of test classes which all directly relate to the `WpOrg\Requests\Requests` class.

Having those test files/classes all in the `tests` root directory does not make it any clearer what these tests are actually testing. So, I'm proposing that if a class warrants multiple test classes, we create a directory named after the class and place the files in that directory.

### ChunkedEncodingTest: reorder methods

Move the data providers down to just below the test they apply to.

### ChunkedEncodingTest: rename dataprovider methods

... to mirror the name of the test the data provider belongs with.

### ChunkedEncodingTest: improve data provider

* Add keys to the entries in each data set.

### ChunkedEncodingTest: add one extra test

Just adding one extra test to document the behaviour when an empty string is passed.

As this is a protected method, I deem stringent input validation unnecessary.

### ChunkedEncodingTest: stabilize the tests

* Verify that `$response` is an instance of the `Response` class before approaching it as such.
* Add the `$message` parameter to all assertions.

### ChunkedEncodingTest: improve documentation

Includes adding `@covers` tag.

Related to #497