### PR TITLE
Requests: Add "requests.failed" hook

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -63,6 +63,13 @@ Available Hooks
     To use this hook, pass a callback via `$options['complete']` when calling
     `WpOrg\Requests\Requests\request_multiple()`.
 
+* **`requests.failed`**
+
+    Alter/Inspect transport or response parsing exception before it is returned to the user.
+
+    Parameters: `WpOrg\Requests\Exception|WpOrg\Requests\Exception\InvalidArgument &$exception`, `string $url`, `array $headers`, `array|string $data`,
+    `string $type`, `array $options`
+
 * **`curl.before_request`**
 
     Set cURL options before the transport sets any (note that Requests may

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -36,7 +36,7 @@ class Exception extends PHPException {
 	 *
 	 * @var boolean
 	 */
-	public $failed_hook_handled = FALSE;
+	public $failed_hook_handled = false;
 
 	/**
 	 * Create a new exception

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -32,6 +32,13 @@ class Exception extends PHPException {
 	protected $data;
 
 	/**
+	 * Whether the exception was already passed to the requests.failed hook or not
+	 *
+	 * @var boolean
+	 */
+	public $failed_hook_handled = FALSE;
+
+	/**
 	 * Create a new exception
 	 *
 	 * @param string $message Exception message

--- a/src/Exception/InvalidArgument.php
+++ b/src/Exception/InvalidArgument.php
@@ -20,6 +20,13 @@ use InvalidArgumentException;
 final class InvalidArgument extends InvalidArgumentException {
 
 	/**
+	 * Whether the exception was already passed to the requests.failed hook or not
+	 *
+	 * @var boolean
+	 */
+	public $failed_hook_handled = FALSE;
+
+	/**
 	 * Create a new invalid argument exception with a standardized text.
 	 *
 	 * @param int    $position The argument position in the function signature. 1-based.

--- a/src/Exception/InvalidArgument.php
+++ b/src/Exception/InvalidArgument.php
@@ -24,7 +24,7 @@ final class InvalidArgument extends InvalidArgumentException {
 	 *
 	 * @var boolean
 	 */
-	public $failed_hook_handled = FALSE;
+	public $failed_hook_handled = false;
 
 	/**
 	 * Create a new invalid argument exception with a standardized text.

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -471,12 +471,10 @@ class Requests {
 			$options['hooks']->dispatch('requests.before_parse', [&$response, $url, $headers, $data, $type, $options]);
 
 			$parsed_response = self::parse_response($response, $url, $headers, $data, $options);
-		}
-		catch (Exception $e) {
+		} catch (Exception $e) {
 			$options['hooks']->dispatch('requests.failed', [$e, $url, $headers, $data, $type, $options]);
 			throw $e;
-		}
-		catch (InvalidArgument $e) {
+		} catch (InvalidArgument $e) {
 			$options['hooks']->dispatch('requests.failed', [$e, $url, $headers, $data, $type, $options]);
 			throw $e;
 		}

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -471,11 +471,8 @@ class Requests {
 			$options['hooks']->dispatch('requests.before_parse', [&$response, $url, $headers, $data, $type, $options]);
 
 			$parsed_response = self::parse_response($response, $url, $headers, $data, $options);
-		} catch (Exception $e) {
-			$options['hooks']->dispatch('requests.failed', [$e, $url, $headers, $data, $type, $options]);
-			throw $e;
-		} catch (InvalidArgument $e) {
-			$options['hooks']->dispatch('requests.failed', [$e, $url, $headers, $data, $type, $options]);
+		} catch (Exception|InvalidArgument $e) {
+			$options['hooks']->dispatch('requests.failed', [&$e, $url, $headers, $data, $type, $options]);
 			throw $e;
 		}
 

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -465,11 +465,23 @@ class Requests {
 			$transport    = self::get_transport($capabilities);
 		}
 
-		$response = $transport->request($url, $headers, $data, $options);
+		try {
+			$response = $transport->request($url, $headers, $data, $options);
 
-		$options['hooks']->dispatch('requests.before_parse', [&$response, $url, $headers, $data, $type, $options]);
+			$options['hooks']->dispatch('requests.before_parse', [&$response, $url, $headers, $data, $type, $options]);
 
-		return self::parse_response($response, $url, $headers, $data, $options);
+			$parsed_response = self::parse_response($response, $url, $headers, $data, $options);
+		}
+		catch (Exception $e) {
+			$options['hooks']->dispatch('requests.failed', [$e, $url, $headers, $data, $type, $options]);
+			throw $e;
+		}
+		catch (InvalidArgument $e) {
+			$options['hooks']->dispatch('requests.failed', [$e, $url, $headers, $data, $type, $options]);
+			throw $e;
+		}
+
+		return $parsed_response;
 	}
 
 	/**

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -471,11 +471,19 @@ class Requests {
 			$options['hooks']->dispatch('requests.before_parse', [&$response, $url, $headers, $data, $type, $options]);
 
 			$parsed_response = self::parse_response($response, $url, $headers, $data, $options);
-		} catch (Exception|InvalidArgument $e) {
+		} catch (Exception $e) {
 			if ($e->failed_hook_handled === FALSE) {
 				$options['hooks']->dispatch('requests.failed', [&$e, $url, $headers, $data, $type, $options]);
 				$e->failed_hook_handled = TRUE;
 			}
+
+			throw $e;
+		} catch (InvalidArgument $e) {
+			if ($e->failed_hook_handled === FALSE) {
+				$options['hooks']->dispatch('requests.failed', [&$e, $url, $headers, $data, $type, $options]);
+				$e->failed_hook_handled = TRUE;
+			}
+
 			throw $e;
 		}
 

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -472,16 +472,16 @@ class Requests {
 
 			$parsed_response = self::parse_response($response, $url, $headers, $data, $options);
 		} catch (Exception $e) {
-			if ($e->failed_hook_handled === FALSE) {
+			if ($e->failed_hook_handled === false) {
 				$options['hooks']->dispatch('requests.failed', [&$e, $url, $headers, $data, $type, $options]);
-				$e->failed_hook_handled = TRUE;
+				$e->failed_hook_handled = true;
 			}
 
 			throw $e;
 		} catch (InvalidArgument $e) {
-			if ($e->failed_hook_handled === FALSE) {
+			if ($e->failed_hook_handled === false) {
 				$options['hooks']->dispatch('requests.failed', [&$e, $url, $headers, $data, $type, $options]);
-				$e->failed_hook_handled = TRUE;
+				$e->failed_hook_handled = true;
 			}
 
 			throw $e;

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -472,7 +472,10 @@ class Requests {
 
 			$parsed_response = self::parse_response($response, $url, $headers, $data, $options);
 		} catch (Exception|InvalidArgument $e) {
-			$options['hooks']->dispatch('requests.failed', [&$e, $url, $headers, $data, $type, $options]);
+			if ($e->failed_hook_handled === FALSE) {
+				$options['hooks']->dispatch('requests.failed', [&$e, $url, $headers, $data, $type, $options]);
+				$e->failed_hook_handled = TRUE;
+			}
 			throw $e;
 		}
 

--- a/tests/Fixtures/TransportFailedMock.php
+++ b/tests/Fixtures/TransportFailedMock.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Fixtures;
+
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Transport;
+
+final class TransportFailedMock implements Transport {
+	public function request($url, $headers = [], $data = [], $options = []) {
+		throw new Exception('Transport failed!', 'transporterror');
+	}
+	public function request_multiple($requests, $options) {
+		throw new Exception('Transport failed!', 'transporterror');
+	}
+	public static function test($capabilities = []) {
+		return true;
+	}
+}

--- a/tests/Fixtures/TransportInvalidArgumentMock.php
+++ b/tests/Fixtures/TransportInvalidArgumentMock.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Fixtures;
+
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Transport;
+
+final class TransportInvalidArgumentMock implements Transport {
+	public function request($url, $headers = [], $data = [], $options = []) {
+		throw InvalidArgument::create(1, '$url', 'string|Stringable', gettype($url));
+	}
+	public function request_multiple($requests, $options) {
+		throw InvalidArgument::create(1, '$requests', 'array|ArrayAccess&Traversable', gettype($requests));
+	}
+	public static function test($capabilities = []) {
+		return true;
+	}
+}

--- a/tests/Fixtures/TransportRedirectMock.php
+++ b/tests/Fixtures/TransportRedirectMock.php
@@ -3,6 +3,7 @@
 namespace WpOrg\Requests\Tests\Fixtures;
 
 use WpOrg\Requests\Transport;
+use WpOrg\Requests\Utility\HttpStatus;
 
 final class TransportRedirectMock implements Transport {
 	public $code        = 302;
@@ -14,55 +15,6 @@ final class TransportRedirectMock implements Transport {
 
 	public $redirected_transport = null;
 
-	private static $messages = [
-		100 => '100 Continue',
-		101 => '101 Switching Protocols',
-		200 => '200 OK',
-		201 => '201 Created',
-		202 => '202 Accepted',
-		203 => '203 Non-Authoritative Information',
-		204 => '204 No Content',
-		205 => '205 Reset Content',
-		206 => '206 Partial Content',
-		300 => '300 Multiple Choices',
-		301 => '301 Moved Permanently',
-		302 => '302 Found',
-		303 => '303 See Other',
-		304 => '304 Not Modified',
-		305 => '305 Use Proxy',
-		306 => '306 (Unused)',
-		307 => '307 Temporary Redirect',
-		400 => '400 Bad Request',
-		401 => '401 Unauthorized',
-		402 => '402 Payment Required',
-		403 => '403 Forbidden',
-		404 => '404 Not Found',
-		405 => '405 Method Not Allowed',
-		406 => '406 Not Acceptable',
-		407 => '407 Proxy Authentication Required',
-		408 => '408 Request Timeout',
-		409 => '409 Conflict',
-		410 => '410 Gone',
-		411 => '411 Length Required',
-		412 => '412 Precondition Failed',
-		413 => '413 Request Entity Too Large',
-		414 => '414 Request-URI Too Long',
-		415 => '415 Unsupported Media Type',
-		416 => '416 Requested Range Not Satisfiable',
-		417 => '417 Expectation Failed',
-		418 => '418 I\'m a teapot',
-		428 => '428 Precondition Required',
-		429 => '429 Too Many Requests',
-		431 => '431 Request Header Fields Too Large',
-		500 => '500 Internal Server Error',
-		501 => '501 Not Implemented',
-		502 => '502 Bad Gateway',
-		503 => '503 Service Unavailable',
-		504 => '504 Gateway Timeout',
-		505 => '505 HTTP Version Not Supported',
-		511 => '511 Network Authentication Required',
-	];
-
 	public function request($url, $headers = [], $data = [], $options = []) {
 		if (array_key_exists($url, $this->redirected)) {
 			return $this->redirected_transport->request($url, $headers, $data, $options);
@@ -70,8 +22,8 @@ final class TransportRedirectMock implements Transport {
 
 		$redirect_url = 'https://example.com/redirected?url=' . urlencode($url);
 
-		$status    = isset(self::$messages[$this->code]) ? self::$messages[$this->code] : $this->code . ' unknown';
-		$response  = "HTTP/1.0 $status\r\n";
+		$text      = HttpStatus::is_valid_code($this->code) ? HttpStatus::get_text($this->code) : 'unknown';
+		$response  = "HTTP/1.0 {$this->code} $text\r\n";
 		$response .= "Content-Type: text/plain\r\n";
 		if ($this->chunked) {
 			$response .= "Transfer-Encoding: chunked\r\n";

--- a/tests/Fixtures/TransportRedirectMock.php
+++ b/tests/Fixtures/TransportRedirectMock.php
@@ -12,7 +12,7 @@ final class TransportRedirectMock implements Transport {
 
 	private $redirected = [];
 
-	public $redirected_transport = NULL;
+	public $redirected_transport = null;
 
 	private static $messages = [
 		100 => '100 Continue',
@@ -64,12 +64,11 @@ final class TransportRedirectMock implements Transport {
 	];
 
 	public function request($url, $headers = [], $data = [], $options = []) {
-		if (array_key_exists($url, $this->redirected))
-		{
+		if (array_key_exists($url, $this->redirected)) {
 			return $this->redirected_transport->request($url, $headers, $data, $options);
 		}
 
-		$redirect_url = "https://example.com/redirected?url=" . urlencode($url);
+		$redirect_url = 'https://example.com/redirected?url=' . urlencode($url);
 
 		$status    = isset(self::$messages[$this->code]) ? self::$messages[$this->code] : $this->code . ' unknown';
 		$response  = "HTTP/1.0 $status\r\n";
@@ -77,13 +76,14 @@ final class TransportRedirectMock implements Transport {
 		if ($this->chunked) {
 			$response .= "Transfer-Encoding: chunked\r\n";
 		}
+
 		$response .= "Location: $redirect_url\r\n";
 		$response .= $this->raw_headers;
 		$response .= "Connection: close\r\n\r\n";
 		$response .= $this->body;
 
-		$this->redirected[$url] = TRUE;
-		$this->redirected[$redirect_url] = TRUE;
+		$this->redirected[$url]          = true;
+		$this->redirected[$redirect_url] = true;
 
 		return $response;
 	}

--- a/tests/Fixtures/TransportRedirectMock.php
+++ b/tests/Fixtures/TransportRedirectMock.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Fixtures;
+
+use WpOrg\Requests\Transport;
+
+final class TransportRedirectMock implements Transport {
+	public $code        = 302;
+	public $chunked     = false;
+	public $body        = '';
+	public $raw_headers = '';
+
+	private $redirected = [];
+
+	public $redirected_transport = NULL;
+
+	private static $messages = [
+		100 => '100 Continue',
+		101 => '101 Switching Protocols',
+		200 => '200 OK',
+		201 => '201 Created',
+		202 => '202 Accepted',
+		203 => '203 Non-Authoritative Information',
+		204 => '204 No Content',
+		205 => '205 Reset Content',
+		206 => '206 Partial Content',
+		300 => '300 Multiple Choices',
+		301 => '301 Moved Permanently',
+		302 => '302 Found',
+		303 => '303 See Other',
+		304 => '304 Not Modified',
+		305 => '305 Use Proxy',
+		306 => '306 (Unused)',
+		307 => '307 Temporary Redirect',
+		400 => '400 Bad Request',
+		401 => '401 Unauthorized',
+		402 => '402 Payment Required',
+		403 => '403 Forbidden',
+		404 => '404 Not Found',
+		405 => '405 Method Not Allowed',
+		406 => '406 Not Acceptable',
+		407 => '407 Proxy Authentication Required',
+		408 => '408 Request Timeout',
+		409 => '409 Conflict',
+		410 => '410 Gone',
+		411 => '411 Length Required',
+		412 => '412 Precondition Failed',
+		413 => '413 Request Entity Too Large',
+		414 => '414 Request-URI Too Long',
+		415 => '415 Unsupported Media Type',
+		416 => '416 Requested Range Not Satisfiable',
+		417 => '417 Expectation Failed',
+		418 => '418 I\'m a teapot',
+		428 => '428 Precondition Required',
+		429 => '429 Too Many Requests',
+		431 => '431 Request Header Fields Too Large',
+		500 => '500 Internal Server Error',
+		501 => '501 Not Implemented',
+		502 => '502 Bad Gateway',
+		503 => '503 Service Unavailable',
+		504 => '504 Gateway Timeout',
+		505 => '505 HTTP Version Not Supported',
+		511 => '511 Network Authentication Required',
+	];
+
+	public function request($url, $headers = [], $data = [], $options = []) {
+		if (array_key_exists($url, $this->redirected))
+		{
+			return $this->redirected_transport->request($url, $headers, $data, $options);
+		}
+
+		$redirect_url = "https://example.com/redirected?url=" . urlencode($url);
+
+		$status    = isset(self::$messages[$this->code]) ? self::$messages[$this->code] : $this->code . ' unknown';
+		$response  = "HTTP/1.0 $status\r\n";
+		$response .= "Content-Type: text/plain\r\n";
+		if ($this->chunked) {
+			$response .= "Transfer-Encoding: chunked\r\n";
+		}
+		$response .= "Location: $redirect_url\r\n";
+		$response .= $this->raw_headers;
+		$response .= "Connection: close\r\n\r\n";
+		$response .= $this->body;
+
+		$this->redirected[$url] = TRUE;
+		$this->redirected[$redirect_url] = TRUE;
+
+		return $response;
+	}
+
+	public function request_multiple($requests, $options) {
+		$responses = [];
+		foreach ($requests as $id => $request) {
+			$handler              = new self();
+			$handler->code        = $request['options']['mock.code'];
+			$handler->chunked     = $request['options']['mock.chunked'];
+			$handler->body        = $request['options']['mock.body'];
+			$handler->raw_headers = $request['options']['mock.raw_headers'];
+			$responses[$id]       = $handler->request($request['url'], $request['headers'], $request['data'], $request['options']);
+
+			if (!empty($options['mock.parse'])) {
+				$request['options']['hooks']->dispatch('transport.internal.parse_response', [&$responses[$id], $request]);
+				$request['options']['hooks']->dispatch('multiple.request.complete', [&$responses[$id], $id]);
+			}
+		}
+
+		return $responses;
+	}
+
+	public static function test($capabilities = []) {
+		return true;
+	}
+}

--- a/tests/Requests/RequestsTest.php
+++ b/tests/Requests/RequestsTest.php
@@ -4,10 +4,13 @@ namespace WpOrg\Requests\Tests\Requests;
 
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Hooks;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response\Headers;
 use WpOrg\Requests\Tests\Fixtures\RawTransportMock;
+use WpOrg\Requests\Tests\Fixtures\TransportFailedMock;
+use WpOrg\Requests\Tests\Fixtures\TransportInvalidArgumentMock;
 use WpOrg\Requests\Tests\Fixtures\TransportMock;
 use WpOrg\Requests\Tests\TestCase;
 use WpOrg\Requests\Tests\TypeProviderHelper;
@@ -152,6 +155,42 @@ final class RequestsTest extends TestCase {
 		$this->assertSame(200, $request->status_code);
 	}
 
+	public function testTransportFailedTriggersRequestsFailedCallback() {
+		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock->expects($this->atLeastOnce())->method('failed');
+		$hooks = new Hooks();
+		$hooks->register('requests.failed', [$mock, 'failed']);
+
+		$transport = new TransportFailedMock();
+
+		$options = [
+			'hooks'     => $hooks,
+			'transport' => $transport,
+		];
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Transport failed!');
+		Requests::get('http://example.com/', [], $options);
+	}
+
+	public function testTransportInvalidArgumentTriggersRequestsFailedCallback() {
+		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock->expects($this->atLeastOnce())->method('failed');
+		$hooks = new Hooks();
+		$hooks->register('requests.failed', [$mock, 'failed']);
+
+		$transport = new TransportInvalidArgumentMock();
+
+		$options = [
+			'hooks'     => $hooks,
+			'transport' => $transport,
+		];
+
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($url) must be of type string|Stringable');
+		Requests::get('http://example.com/', [], $options);
+	}
+
 	/**
 	 * Standard response header parsing
 	 */
@@ -253,6 +292,31 @@ final class RequestsTest extends TestCase {
 	}
 
 	/**
+	 * Check that invalid protocols are not accepted
+	 *
+	 * We do not support HTTP/0.9. If this is really an issue for you, file a
+	 * new issue, and update your server/proxy to support a proper protocol.
+	 */
+	public function testInvalidProtocolVersionTriggersRequestsFailedCallback() {
+		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock->expects($this->atLeastOnce())->method('failed');
+		$hooks = new Hooks();
+		$hooks->register('requests.failed', [$mock, 'failed']);
+
+		$transport       = new RawTransportMock();
+		$transport->data = "HTTP/0.9 200 OK\r\n\r\n<p>Test";
+
+		$options = [
+			'hooks'     => $hooks,
+			'transport' => $transport,
+		];
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Response could not be parsed');
+		Requests::get('http://example.com/', [], $options);
+	}
+
+	/**
 	 * HTTP/0.9 also appears to use a single CRLF instead of two.
 	 */
 	public function testSingleCRLFSeparator() {
@@ -268,11 +332,52 @@ final class RequestsTest extends TestCase {
 		Requests::get('http://example.com/', [], $options);
 	}
 
+	/**
+	 * HTTP/0.9 also appears to use a single CRLF instead of two.
+	 */
+	public function testSingleCRLFSeparatorTriggersRequestsFailedCallback() {
+		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock->expects($this->atLeastOnce())->method('failed');
+		$hooks = new Hooks();
+		$hooks->register('requests.failed', [$mock, 'failed']);
+
+		$transport       = new RawTransportMock();
+		$transport->data = "HTTP/0.9 200 OK\r\n<p>Test";
+
+		$options = [
+			'hooks'     => $hooks,
+			'transport' => $transport,
+		];
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Missing header/body separator');
+		Requests::get('http://example.com/', [], $options);
+	}
+
 	public function testInvalidStatus() {
 		$transport       = new RawTransportMock();
 		$transport->data = "HTTP/1.1 OK\r\nTest: value\nAnother-Test: value\r\n\r\nTest";
 
 		$options = [
+			'transport' => $transport,
+		];
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Response could not be parsed');
+		Requests::get('http://example.com/', [], $options);
+	}
+
+	public function testInvalidStatusTriggersRequestsFailedCallback() {
+		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock->expects($this->atLeastOnce())->method('failed');
+		$hooks = new Hooks();
+		$hooks->register('requests.failed', [$mock, 'failed']);
+
+		$transport       = new RawTransportMock();
+		$transport->data = "HTTP/1.1 OK\r\nTest: value\nAnother-Test: value\r\n\r\nTest";
+
+		$options = [
+			'hooks'     => $hooks,
 			'transport' => $transport,
 		];
 

--- a/tests/Requests/RequestsTest.php
+++ b/tests/Requests/RequestsTest.php
@@ -157,7 +157,7 @@ final class RequestsTest extends TestCase {
 	}
 
 	public function testTransportFailedTriggersRequestsFailedCallback() {
-		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['failed']);
 		$mock->expects($this->once())->method('failed');
 		$hooks = new Hooks();
 		$hooks->register('requests.failed', [$mock, 'failed']);
@@ -175,7 +175,7 @@ final class RequestsTest extends TestCase {
 	}
 
 	public function testTransportInvalidArgumentTriggersRequestsFailedCallback() {
-		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['failed']);
 		$mock->expects($this->once())->method('failed');
 		$hooks = new Hooks();
 		$hooks->register('requests.failed', [$mock, 'failed']);
@@ -299,7 +299,7 @@ final class RequestsTest extends TestCase {
 	 * new issue, and update your server/proxy to support a proper protocol.
 	 */
 	public function testInvalidProtocolVersionTriggersRequestsFailedCallback() {
-		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['failed']);
 		$mock->expects($this->once())->method('failed');
 		$hooks = new Hooks();
 		$hooks->register('requests.failed', [$mock, 'failed']);
@@ -337,7 +337,7 @@ final class RequestsTest extends TestCase {
 	 * HTTP/0.9 also appears to use a single CRLF instead of two.
 	 */
 	public function testSingleCRLFSeparatorTriggersRequestsFailedCallback() {
-		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['failed']);
 		$mock->expects($this->once())->method('failed');
 		$hooks = new Hooks();
 		$hooks->register('requests.failed', [$mock, 'failed']);
@@ -369,7 +369,7 @@ final class RequestsTest extends TestCase {
 	}
 
 	public function testInvalidStatusTriggersRequestsFailedCallback() {
-		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['failed']);
 		$mock->expects($this->once())->method('failed');
 		$hooks = new Hooks();
 		$hooks->register('requests.failed', [$mock, 'failed']);
@@ -400,7 +400,7 @@ final class RequestsTest extends TestCase {
 	}
 
 	public function testRedirectToExceptionTriggersRequestsFailedCallbackOnce() {
-		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['failed']);
 		$mock->expects($this->once())->method('failed');
 		$hooks = new Hooks();
 		$hooks->register('requests.failed', [$mock, 'failed']);
@@ -423,7 +423,7 @@ final class RequestsTest extends TestCase {
 	}
 
 	public function testRedirectToInvalidArgumentTriggersRequestsFailedCallbackOnce() {
-		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['failed'])->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['failed']);
 		$mock->expects($this->once())->method('failed');
 		$hooks = new Hooks();
 		$hooks->register('requests.failed', [$mock, 'failed']);

--- a/tests/Requests/RequestsTest.php
+++ b/tests/Requests/RequestsTest.php
@@ -408,7 +408,7 @@ final class RequestsTest extends TestCase {
 		$transport                       = new TransportRedirectMock();
 		$transport->redirected_transport = new TransportFailedMock();
 
-		$options  = [
+		$options = [
 			'hooks'     => $hooks,
 			'transport' => $transport,
 		];
@@ -431,7 +431,7 @@ final class RequestsTest extends TestCase {
 		$transport                       = new TransportRedirectMock();
 		$transport->redirected_transport = new TransportInvalidArgumentMock();
 
-		$options  = [
+		$options = [
 			'hooks'     => $hooks,
 			'transport' => $transport,
 		];


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement

## Context
This allows to inspect or alter the exception that is thrown to
the user in case of transport errors, or in case of response
parsing problems.


## Detailed Description
We use the hooks to gather analytics about the remote requests we make in out platform, but failed requests slipped through the cracks since there is currently no way to track those. You can get *some* analytics from when you make the request, but you won't know from just that whether it failed. We'd also like to know why it failed, the error message that was returned, etc.

We've been using the hook in our platform for a couple weeks now and it worked fine for us :)
(Although we've applied this change to 1.8.x)


## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added unit tests to accompany this PR.
- [x] The (new/existing) tests cover this PR 100%.
- [x] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [x] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.
