### PR TITLE
Release checklist: minor tweaks

### DIFF
--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -10,11 +10,11 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
 - [ ] Add changelog for the release - PR #xxx
 - [ ] Merge this PR.
 - [ ] Make sure all CI builds are green.
-- [ ] Tag the release (careful, GH defaults to `develop`!).
+- [ ] Tag the release against `stable` and push the tag.
+- [ ] Review the automatically created PR with the GH Pages docs update & merge.
+- [ ] Verify that the website regenerated correctly and is in working order.
 - [ ] Create a release from the tag (careful, GH defaults to `develop`!) & copy & paste the changelog to it.
     Make sure to copy the links to the issues and the links to the GH usernames from the bottom of the changelog!
-- [ ] Update GH Pages website / merge GH Pages update PR.
-- [ ] Verify that the website regenerated correctly.
 - [ ] Close the milestone.
 - [ ] Open a new milestone for the next release.
 - [ ] If any open PRs/issues which were milestoned for the release did not make it into the release, update their milestone.


### PR DESCRIPTION
Minor re-ordering of the release checklist to better reflect the current workflow which automatically creates the GH Pages update PR.