### PR TITLE
IdnaEncoder::encode(): add input validation

### DIFF
--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -3,6 +3,8 @@
 namespace WpOrg\Requests;
 
 use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Utility\InputValidator;
 
 /**
  * IDNA URL encoder
@@ -54,8 +56,13 @@ class IdnaEncoder {
 	 *
 	 * @param string $hostname Hostname
 	 * @return string Punycode-encoded hostname
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string or a stringable object.
 	 */
 	public static function encode($hostname) {
+		if (InputValidator::is_string_or_stringable($hostname) === false) {
+			throw InvalidArgument::create(1, '$hostname', 'string|Stringable', gettype($hostname));
+		}
+
 		$parts = explode('.', $hostname);
 		foreach ($parts as &$part) {
 			$part = self::to_ascii($part);

--- a/tests/IdnaEncoderTest.php
+++ b/tests/IdnaEncoderTest.php
@@ -3,6 +3,7 @@
 namespace WpOrg\Requests\Tests;
 
 use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\IdnaEncoder;
 use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
@@ -179,6 +180,36 @@ final class IdnaEncoderTest extends TestCase {
 			'Invalid ASCII character with multibyte' => array("\0\xc2\xb6"),
 			'Unfinished multibyte'                   => array("\xc2"),
 			'Partial multibyte'                      => array("\xc2\xc2\xb6"),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed.
+	 *
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $data Data to encode.
+	 *
+	 * @return void
+	 */
+	public function testInvalidInputType($data) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($hostname) must be of type string');
+
+		IdnaEncoder::encode($data);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputType() {
+		return array(
+			'null'          => array(null),
+			'boolean false' => array(false),
+			'integer'       => array(12345),
+			'array'         => array(array(1, 2, 3)),
 		);
 	}
 


### PR DESCRIPTION
The `IdnaEncoder::encode()` is the official entry point for this class, even though there are more public methods (of which it is questionable whether they should be public, but changing that now would be a BC-break).

The documented accepted parameter type is `string`, but no input validation was done on the parameter, which could lead to various PHP errors, most notably a "passing null to non-nullable" deprecation notice on PHP 8.1.

This commit adds input validation to the `IdnaEncoder::encode()` method, allowing only for strings and _stringable_ objects.

While this is stricter than previously, only a string could result in a valid return value, so in my opinion, being strict is warranted.

Includes adding perfunctory tests for the new exception.