### PR TITLE
Autoload: treat PSR-4 case-sensitively and PSR-0 case-insensitively

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -23,6 +23,11 @@ if (class_exists('WpOrg\Requests\Autoload') === false) {
 	/**
 	 * Autoloader for Requests for PHP.
 	 *
+	 * This autoloader supports the PSR-4 based Requests 2.0.0 classes in a case-sensitive manner
+	 * as the most common server OS-es are case-sensitive and the file names are in mixed case.
+	 *
+	 * For the PSR-0 Requests 1.x BC-layer, requested classes will be treated case-insensitively.
+	 *
 	 * @package Requests
 	 */
 	final class Autoload {
@@ -125,13 +130,15 @@ if (class_exists('WpOrg\Requests\Autoload') === false) {
 		 */
 		public static function load($class_name) {
 			// Check that the class starts with "Requests" (PSR-0) or "WpOrg\Requests" (PSR-4).
-			$psr_4_prefix_pos = stripos($class_name, 'WpOrg\\Requests\\');
+			$psr_4_prefix_pos = strpos($class_name, 'WpOrg\\Requests\\');
 
 			if (stripos($class_name, 'Requests') !== 0 && $psr_4_prefix_pos !== 0) {
 				return false;
 			}
 
-			if ($class_name === 'Requests') {
+			$class_lower = strtolower($class_name);
+
+			if ($class_lower === 'requests') {
 				// Reference to the original PSR-0 Requests class.
 				$file = dirname(__DIR__) . '/library/Requests.php';
 			} elseif ($psr_4_prefix_pos === 0) {
@@ -149,8 +156,6 @@ if (class_exists('WpOrg\Requests\Autoload') === false) {
 			 * If this is one of the deprecated/renamed PSR-0 classes being requested,
 			 * let's alias it to the new name and throw a deprecation notice.
 			 */
-			$class_lower = strtolower($class_name);
-
 			if (isset(self::$deprecated_classes[$class_lower])) {
 				/*
 				 * Integrators who cannot yet upgrade to the PSR-4 class names can silence deprecations

--- a/tests/AutoloadTest.php
+++ b/tests/AutoloadTest.php
@@ -34,13 +34,15 @@ final class AutoloadTest extends TestCase {
 	/**
 	 * Verify that the deprecation layer works without a fatal error for extending a final class.
 	 *
+	 * Note: this test also verifies that the PSR-0 names are handled case-insensitively by the autoloader.
+	 *
 	 * @preserveGlobalState disabled
 	 * @runInSeparateProcess
 	 */
 	public function testAutoloadOfOldRequestsClassDoesNotThrowAFatalForFinalClass() {
 		define('REQUESTS_SILENCE_PSR0_DEPRECATIONS', true);
 
-		$this->assertInstanceOf(FilteredIterator::class, new Requests_Utility_FilteredIterator(array(), function() {}));
+		$this->assertInstanceOf(FilteredIterator::class, new Requests_utility_filteredIterator(array(), function() {}));
 	}
 
 	/**


### PR DESCRIPTION
As the most common server OS-es have a case-sensitive file system and PSR-4 class loading does a direct translation from the class name to the file name, the PSR-4 based autoloading is now completely case-sensitive.

As for the BC-layer for PSR-0: this will now consistently be handled case-insensitively.
This was largely so, what with the case-insensitive classmap being used. It may also make the change over slightly easier as a number of class name have changes in the case being used.

Includes a minor adjustment to an existing test to safeguard the case-insensitive handling handling of the PSR-0 classes.