### PR TITLE
DecompressionTest: improve tests

### DIFF
--- a/src/Requests.php
+++ b/src/Requests.php
@@ -894,7 +894,7 @@ class Requests {
 	 * takes place. For a simple progmatic way to determine the magic offset in use, see:
 	 * https://core.trac.wordpress.org/ticket/18273
 	 *
-	 * @since 2.8.1
+	 * @since 1.6.0
 	 * @link https://core.trac.wordpress.org/ticket/18273
 	 * @link https://www.php.net/gzinflate#70875
 	 * @link https://www.php.net/gzinflate#77336

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -842,6 +842,11 @@ class Requests {
 	 * @return string Decompressed string
 	 */
 	public static function decompress($data) {
+		if (trim($data) === '') {
+			// Empty body does not need further processing.
+			return $data;
+		}
+
 		$marker = substr($data, 0, 2);
 		if (!isset(self::$magic_compression_headers[$marker])) {
 			// Not actually compressed. Probably cURL ruining this for us.
@@ -898,6 +903,10 @@ class Requests {
 	 * @return string|bool False on failure.
 	 */
 	public static function compatible_gzinflate($gz_data) {
+		if (trim($gz_data) === '') {
+			return false;
+		}
+
 		// Compressed data might contain a full zlib header, if so strip it for
 		// gzinflate()
 		if (substr($gz_data, 0, 3) === "\x1f\x8b\x08") {

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -8,6 +8,7 @@ use WpOrg\Requests\Tests\TestCase;
 final class DecompressionTest extends TestCase {
 
 	/**
+	 * @dataProvider dataDecompressNotCompressed
 	 * @dataProvider dataGzip
 	 * @dataProvider dataDeflate
 	 * @dataProvider dataDeflateWithoutHeaders
@@ -18,6 +19,7 @@ final class DecompressionTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider dataCompatibleInflateNotCompressed
 	 * @dataProvider dataGzip
 	 * @dataProvider dataDeflate
 	 * @dataProvider dataDeflateWithoutHeaders
@@ -25,6 +27,38 @@ final class DecompressionTest extends TestCase {
 	public function testCompatibleInflate($expected, $compressed) {
 		$decompressed = Requests::compatible_gzinflate($compressed);
 		$this->assertSame($expected, $decompressed);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataDecompressNotCompressed() {
+		return array(
+			'not compressed: empty string' => array(
+				'expected'   => '',
+				'compressed' => '',
+			),
+			'not compressed: Requests for PHP' => array(
+				'expected'   => 'Requests for PHP',
+				'compressed' => 'Requests for PHP',
+			),
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataCompatibleInflateNotCompressed() {
+		$data = $this->dataDecompressNotCompressed();
+		foreach ($data as $key => $value) {
+			$data[$key]['expected'] = false;
+		}
+
+		return $data;
 	}
 
 	public function dataGzip() {

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -40,6 +40,10 @@ final class DecompressionTest extends TestCase {
 				'expected'   => '',
 				'compressed' => '',
 			),
+			'not compressed: whitespace only string' => array(
+				'expected'   => "  \n\r  ",
+				'compressed' => "  \n\r  ",
+			),
 			'not compressed: Requests for PHP' => array(
 				'expected'   => 'Requests for PHP',
 				'compressed' => 'Requests for PHP',

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -8,10 +8,19 @@ use WpOrg\Requests\Tests\TestCase;
 final class DecompressionTest extends TestCase {
 
 	/**
+	 * Test decompressing an encoded response body.
+	 *
+	 * @covers \WpOrg\Requests\Requests::decompress
+	 *
 	 * @dataProvider dataDecompressNotCompressed
 	 * @dataProvider dataGzip
 	 * @dataProvider dataDeflate
 	 * @dataProvider dataDeflateWithoutHeaders
+	 *
+	 * @param string $expected   Expected text string after decompression.
+	 * @param string $compressed Compressed data string.
+	 *
+	 * @return void
 	 */
 	public function testDecompress($expected, $compressed) {
 		$decompressed = Requests::decompress($compressed);
@@ -19,10 +28,19 @@ final class DecompressionTest extends TestCase {
 	}
 
 	/**
+	 * Test decompression of deflated strings.
+	 *
+	 * @covers \WpOrg\Requests\Requests::compatible_gzinflate
+	 *
 	 * @dataProvider dataCompatibleInflateNotCompressed
 	 * @dataProvider dataGzip
 	 * @dataProvider dataDeflate
 	 * @dataProvider dataDeflateWithoutHeaders
+	 *
+	 * @param string $expected   Expected text string after decompression.
+	 * @param string $compressed Compressed data string.
+	 *
+	 * @return void
 	 */
 	public function testCompatibleInflate($expected, $compressed) {
 		$decompressed = Requests::compatible_gzinflate($compressed);
@@ -65,6 +83,11 @@ final class DecompressionTest extends TestCase {
 		return $data;
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
 	public function dataGzip() {
 		return array(
 			'gzip: foobar' => array(
@@ -81,6 +104,11 @@ final class DecompressionTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
 	public function dataDeflate() {
 		return array(
 			'deflate: foobar' => array(
@@ -97,6 +125,11 @@ final class DecompressionTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
 	public function dataDeflateWithoutHeaders() {
 		return array(
 			'deflate without zlib headers: foobar' => array(

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -90,11 +90,19 @@ final class DecompressionTest extends TestCase {
 	 */
 	public function dataGzip() {
 		return array(
+			/*
+			 * Test data generated using CLI command:
+			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzencode("foobar")),2,"\\x"), 0, -2) . "\n";'
+			 */
 			'gzip: foobar' => array(
 				'expected'   => 'foobar',
 				'compressed' => "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x4b\xcb\xcf\x4f\x4a"
 							. "\x2c\x02\x00\x95\x1f\xf6\x9e\x06\x00\x00\x00",
 			),
+			/*
+			 * Test data generated using CLI command:
+			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzencode("Requests for PHP")),2,"\\x"), 0, -2) . "\n";'
+			 */
 			'gzip: Requests for PHP' => array(
 				'expected'   => 'Requests for PHP',
 				'compressed' => "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x0b\x4a\x2d\x2c\x4d"
@@ -111,11 +119,13 @@ final class DecompressionTest extends TestCase {
 	 */
 	public function dataDeflate() {
 		return array(
+			// TODO: What is this byte stream representing? Looks like GZIP header with ZLIB compressed data...
 			'deflate: foobar' => array(
 				'expected'   => 'foobar',
 				'compressed' => "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x78\x9c\x4b\xcb\xcf"
-					. "\x4f\x4a\x2c\x02\x00\x08\xab\x02\x7a",
+							. "\x4f\x4a\x2c\x02\x00\x08\xab\x02\x7a",
 			),
+			// TODO: What is this byte stream representing? Looks like GZIP header with ZLIB compressed data...
 			'deflate: Requests for PHP' => array(
 				'expected'   => 'Requests for PHP',
 				'compressed' => "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x78\x9c\x0b\x4a\x2d"
@@ -132,25 +142,45 @@ final class DecompressionTest extends TestCase {
 	 */
 	public function dataDeflateWithoutHeaders() {
 		return array(
+			/*
+			 * Test data generated using CLI command:
+			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzcompress("foobar")),2,"\\x"), 0, -2) . "\n";'
+			 */
 			'deflate without zlib headers: foobar' => array(
 				'expected'   => 'foobar',
 				'compressed' => "\x78\x9c\x4b\xcb\xcf\x4f\x4a\x2c\x02\x00\x08\xab\x02\x7a",
 			),
+			/*
+			 * Test data generated using CLI command:
+			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzcompress("Requests for PHP")),2,"\\x"), 0, -2) . "\n";'
+			 */
 			'deflate without zlib headers: Requests for PHP' => array(
 				'expected'   => 'Requests for PHP',
 				'compressed' => "\x78\x9c\x0b\x4a\x2d\x2c\x4d\x2d\x2e\x29\x56\x48\xcb\x2f\x52"
 							. "\x08\xf0\x08\x00\x00\x34\x68\x05\xcc",
 			),
+			/*
+			 * Test data generated using CLI command:
+			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzcompress("compression level 1", 1)),2,"\\x"), 0, -2) . "\n";'
+			 */
 			'deflate without zlib headers: compression level 1' => array(
 				'expected'   => 'compression level 1',
 				'compressed' => "\x78\x01\x4b\xce\xcf\x2d\x28\x4a\x2d\x2e\xce\xcc\xcf\x53\xc8\x49"
 							. "\x2d\x4b\xcd\x51\x30\x04\x00\x4d\x86\x07\x3c",
 			),
+			/*
+			 * Test data generated using CLI command:
+			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzcompress("compression level 3", 3)),2,"\\x"), 0, -2) . "\n";'
+			 */
 			'deflate without zlib headers: compression level 3' => array(
 				'expected'   => 'compression level 3',
 				'compressed' => "\x78\x5e\x4b\xce\xcf\x2d\x28\x4a\x2d\x2e\xce\xcc\xcf\x53\xc8\x49"
 							. "\x2d\x4b\xcd\x51\x30\x06\x00\x4d\x88\x07\x3e",
 			),
+			/*
+			 * Test data generated using CLI command:
+			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzcompress("compression level 9", 9)),2,"\\x"), 0, -2) . "\n";'
+			 */
 			'deflate without zlib headers: compression level 9' => array(
 				'expected'   => 'compression level 9',
 				'compressed' => "\x78\xda\x4b\xce\xcf\x2d\x28\x4a\x2d\x2e\xce\xcc\xcf\x53\xc8\x49"

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -10,17 +10,17 @@ final class DecompressionTest extends TestCase {
 	/**
 	 * @dataProvider encodedData
 	 */
-	public function testDecompress($original, $encoded) {
-		$decoded = Requests::decompress($encoded);
-		$this->assertSame($original, $decoded);
+	public function testDecompress($expected, $compressed) {
+		$decompressed = Requests::decompress($compressed);
+		$this->assertSame($expected, $decompressed);
 	}
 
 	/**
 	 * @dataProvider encodedData
 	 */
-	public function testCompatibleInflate($original, $encoded) {
-		$decoded = Requests::compatible_gzinflate($encoded);
-		$this->assertSame($original, $decoded);
+	public function testCompatibleInflate($expected, $compressed) {
+		$decompressed = Requests::compatible_gzinflate($compressed);
+		$this->assertSame($expected, $decompressed);
 	}
 
 	public static function gzipData() {

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -6,13 +6,21 @@ use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
 
 final class DecompressionTest extends TestCase {
-	private static function mapData($type, $data) {
-		$real_data = array();
-		foreach ($data as $value) {
-			$key             = $type . ': ' . $value[0];
-			$real_data[$key] = $value;
-		}
-		return $real_data;
+
+	/**
+	 * @dataProvider encodedData
+	 */
+	public function testDecompress($original, $encoded) {
+		$decoded = Requests::decompress($encoded);
+		$this->assertSame($original, $decoded);
+	}
+
+	/**
+	 * @dataProvider encodedData
+	 */
+	public function testCompatibleInflate($original, $encoded) {
+		$decoded = Requests::compatible_gzinflate($encoded);
+		$this->assertSame($original, $decoded);
 	}
 
 	public static function gzipData() {
@@ -89,19 +97,12 @@ final class DecompressionTest extends TestCase {
 		return $data;
 	}
 
-	/**
-	 * @dataProvider encodedData
-	 */
-	public function testDecompress($original, $encoded) {
-		$decoded = Requests::decompress($encoded);
-		$this->assertSame($original, $decoded);
-	}
-
-	/**
-	 * @dataProvider encodedData
-	 */
-	public function testCompatibleInflate($original, $encoded) {
-		$decoded = Requests::compatible_gzinflate($encoded);
-		$this->assertSame($original, $decoded);
+	private static function mapData($type, $data) {
+		$real_data = array();
+		foreach ($data as $value) {
+			$key             = $type . ': ' . $value[0];
+			$real_data[$key] = $value;
+		}
+		return $real_data;
 	}
 }

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WpOrg\Requests\Tests;
+namespace WpOrg\Requests\Tests\Requests;
 
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
 
-final class EncodingTest extends TestCase {
+final class DecompressionTest extends TestCase {
 	private static function mapData($type, $data) {
 		$real_data = array();
 		foreach ($data as $value) {


### PR DESCRIPTION
👉🏻 Note: the methods covered via this test class need a **lot** more tests, in particular the `Requests::compatible_gzinflate()` method, which includes code paths currently completely untested and handling of ZIP file format, which when called from `Requests::decompress()` (which is the only way it is called from within the Requests library itself), can never be reached as the "magic markers" used by ZIP are not included in the `Requests::$magic_compression_headers` property.

A future iteration should do a more in-depth review of these two method to determine what should be handled by each method and add additional tests. Still, this first iteration is already an improvement.


### EncodingTest: move to subdirectory and rename

There are a number of test classes which all directly relate to the `WpOrg\Requests\Requests` class.

Having those test files/classes all in the `tests` root directory does not make it any clearer what these tests are actually testing. So, I'm proposing that if a class warrants multiple test classes, we create a directory named after the class and place the files in that directory.

Also, the tests in this file are not about _encoded_ data, but about _compressed_ data, so renaming the test class to be more descriptive.

### DecompressionTest: reorder methods

Move the data providers (and associated helper methods) down to below the tests they apply to.

### DecompressionTest: rename test method parameters

... to better reflect the data which is expected to be passed to the tests.

### DecompressionTest: refactor data providers

* Rename the methods to use `data` as the prefix.
* Remove the `static` keyword as data providers do not need to be `static` (and haven't needed to be for a long time).
* Add keys to the data arrays to turn the data sets into named data providers.
* Add keys to the information in each data set to make the data providers easier to understand.
* Remove the "helper" methods to "create" the data providers. They are unnecessary and obfuscate what data was provided to the tests.
* Use all three data providers for each test instead of the helper method.

### DecompressionTest: add extra test cases

... to ensure that non-compressed data is returned unchanged.

### Requests: improve handling of non-compressed semi-empty strings

... in `Requests::decompress()` and `Requests::compatible_gzinflate()`.

Bow out earlier for non-compressed strings containing only whitespace.

Includes extra test case and fixes the failing test for `Requests::compatible_gzinflate()` as introduced in the previous commit.

### DecompressionTest: improve documentation

Includes adding `@covers` tags.

### Requests::compatible_gzinflate: fix `@since` tag

The `@since` tag should reference the version in which the method was introduced in Requests, not in WordPress.

Related to #497