### PR TITLE
PHP 8.0 | Hooks::dispatch(): prevent potential fatal error

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -88,7 +88,7 @@ class Hooks implements HookManager {
 
 		foreach ($this->hooks[$hook] as $priority => $hooked) {
 			foreach ($hooked as $callback) {
-				call_user_func_array($callback, $parameters);
+				$callback(...$parameters);
 			}
 		}
 

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -81,6 +81,11 @@ class Hooks implements HookManager {
 			return false;
 		}
 
+		if (!empty($parameters)) {
+			// Strip potential keys from the array to prevent them being interpreted as parameter names in PHP 8.0.
+			$parameters = array_values($parameters);
+		}
+
 		foreach ($this->hooks[$hook] as $priority => $hooked) {
 			foreach ($hooked as $callback) {
 				call_user_func_array($callback, $parameters);

--- a/tests/HooksTest.php
+++ b/tests/HooksTest.php
@@ -203,6 +203,32 @@ class HooksTest extends TestCase {
 	}
 
 	/**
+	 * Technical test to verify that the dispatch method handles parameters passed by reference correctly.
+	 *
+	 * @covers ::dispatch
+	 *
+	 * @return void
+	 */
+	public function testDispatchHandlesParametersPassedByReference() {
+		$this->hooks->register('hookname', array($this, 'dummyCallbackExpectingReferences'));
+		$url             = 'original';
+		$headers         = array('original');
+		$unchanged       = 'original';
+		$not_a_reference = 'original';
+
+		$this->assertTrue(
+			$this->hooks->dispatch('hookname', array(&$url, &$headers, &$unchanged, $not_a_reference)),
+			'Hook dispatch did not return true'
+		);
+
+		// Verify that the variables were updated by reference (when passed as reference).
+		$this->assertSame('changed', $url, 'Value of $url was not changed by reference');
+		$this->assertSame(array('changed'), $headers, 'Value of $headers was not changed by reference');
+		$this->assertSame('original', $unchanged, 'Value of unchanged parameter passed by reference, did not match original value');
+		$this->assertSame('original', $not_a_reference, 'Value of parameter not passed by reference, did not match original value');
+	}
+
+	/**
 	 * Technical test to verify that the dispatch method doesn't break on PHP 8.0 when passed an associative array.
 	 *
 	 * @covers ::dispatch
@@ -374,4 +400,15 @@ class HooksTest extends TestCase {
 	 * @return void
 	 */
 	public function dummyCallback2() {}
+
+	/**
+	 * Dummy callback method.
+	 *
+	 * @return void
+	 */
+	public function dummyCallbackExpectingReferences(&$url, &$headers, &$unchanged, $not_a_reference) {
+		$url             = 'changed';
+		$headers         = array('changed');
+		$not_a_reference = 'changed';
+	}
 }

--- a/tests/HooksTest.php
+++ b/tests/HooksTest.php
@@ -203,6 +203,19 @@ class HooksTest extends TestCase {
 	}
 
 	/**
+	 * Technical test to verify that the dispatch method doesn't break on PHP 8.0 when passed an associative array.
+	 *
+	 * @covers ::dispatch
+	 *
+	 * @return void
+	 */
+	public function testDispatchDoesntBreakWithKeyedParametersArray() {
+		$this->hooks->register('hookname', array($this, 'dummyCallback1'));
+
+		$this->assertTrue($this->hooks->dispatch('hookname', array('paramA' => 10, 'paramB' => 'text')));
+	}
+
+	/**
 	 * Tests receiving an exception when an invalid input type is passed to `register()` as `$hook`.
 	 *
 	 * @dataProvider dataInvalidHookname


### PR DESCRIPTION
### PHP 8.0 | Hooks::dispatch(): prevent potential fatal error

This commit adds a safeguard on the off-chance that the `Hooks::dispatch()` method would ever be called with an associative array for the parameters.

This prevents a potential fatal `Unknown named parameter ...` error in PHP 8.x.

Includes unit test.

Related to #533

### 🆕  Hooks::dispatch(): modernize dynamic function call

... by replacing the `call_user_func_array()` with a variable function call in combination with the spread operator.

Includes adding a dedicated test to safeguard that this change does not break the handling of references when passed as part of the `$parameters` to dispatch.