### PR TITLE
Class Ipv6: add input validation

### DIFF
--- a/src/Ipv6.php
+++ b/src/Ipv6.php
@@ -8,6 +8,9 @@
 
 namespace WpOrg\Requests;
 
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Utility\InputValidator;
+
 /**
  * Class to validate and to work with IPv6 addresses
  *
@@ -33,10 +36,19 @@ final class Ipv6 {
 	 * @author Josh Peck <jmp at joshpeck dot org>
 	 * @copyright 2003-2005 The PHP Group
 	 * @license https://opensource.org/licenses/bsd-license.php
+	 *
 	 * @param string $ip An IPv6 address
 	 * @return string The uncompressed IPv6 address
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string or a stringable object.
 	 */
 	public static function uncompress($ip) {
+		if (InputValidator::is_string_or_stringable($ip) === false) {
+			throw InvalidArgument::create(1, '$ip', 'string|Stringable', gettype($ip));
+		}
+
+		$ip = (string) $ip;
+
 		if (substr_count($ip, '::') !== 1) {
 			return $ip;
 		}
@@ -81,11 +93,13 @@ final class Ipv6 {
 	 *           0:0:0:0:0:0:0:1        ->  ::1
 	 *
 	 * @see \WpOrg\Requests\IPv6::uncompress()
+	 *
 	 * @param string $ip An IPv6 address
 	 * @return string The compressed IPv6 address
 	 */
 	public static function compress($ip) {
-		// Prepare the IP to be compressed
+		// Prepare the IP to be compressed.
+		// Note: Input validation is handled in the `uncompress()` method, which is the first call made in this method.
 		$ip       = self::uncompress($ip);
 		$ip_parts = self::split_v6_v4($ip);
 
@@ -147,6 +161,7 @@ final class Ipv6 {
 	 * @return bool true if $ip is a valid IPv6 address
 	 */
 	public static function check_ipv6($ip) {
+		// Note: Input validation is handled in the `uncompress()` method, which is the first call made in this method.
 		$ip                = self::uncompress($ip);
 		list($ipv6, $ipv4) = self::split_v6_v4($ip);
 		$ipv6              = explode(':', $ipv6);

--- a/tests/Ipv6Test.php
+++ b/tests/Ipv6Test.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace WpOrg\Requests\Tests;
+
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Ipv6;
+use WpOrg\Requests\Tests\Fixtures\StringableObject;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * Test for the Ipv6 class.
+ *
+ * Note: the "valid input type" tests can be removed once actual tests for the functionality
+ * of the methods have been added.
+ *
+ * @coversDefaultClass \WpOrg\Requests\Ipv6
+ */
+final class Ipv6Test extends TestCase {
+
+	/**
+	 * Tests that the Ipv6::uncompress() method accepts string/stringable as an $ip parameter.
+	 *
+	 * @covers       ::uncompress
+	 * @dataProvider dataValidInputType
+	 *
+	 * @param string $ip An IPv6 address.
+	 *
+	 * @return void
+	 */
+	public function testUncompressValidInputType($ip) {
+		$this->assertIsString(Ipv6::uncompress($ip));
+	}
+
+	/**
+	 * Tests that the Ipv6::compress() method accepts string/stringable as an $ip parameter.
+	 *
+	 * @covers       ::compress
+	 * @dataProvider dataValidInputType
+	 *
+	 * @param string $ip An IPv6 address.
+	 *
+	 * @return void
+	 */
+	public function testCompressValidInputType($ip) {
+		$this->assertIsString(Ipv6::compress($ip));
+	}
+
+	/**
+	 * Tests that the Ipv6::check_ipv6() method accepts string/stringable as an $ip parameter.
+	 *
+	 * @covers       ::check_ipv6
+	 * @dataProvider dataValidInputType
+	 *
+	 * @param string $ip An IPv6 address
+	 *
+	 * @return void
+	 */
+	public function testCheckIpv6ValidInputType($ip) {
+		$this->assertIsBool(Ipv6::check_ipv6($ip));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataValidInputType() {
+		return array(
+			'string'     => array('::1'),
+			'stringable' => array(new StringableObject('0:1234:dc0:41:216:3eff:fe67:3e01')),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed to the Ipv6::uncompress() method.
+	 *
+	 * @covers       ::uncompress
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $ip Parameter to test input validation with.
+	 *
+	 * @return void
+	 */
+	public function testUncompressInvalidInputType($ip) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($ip) must be of type string');
+
+		Ipv6::uncompress($ip);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed to the Ipv6::compress() method.
+	 *
+	 * @covers       ::compress
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $ip Parameter to test input validation with.
+	 *
+	 * @return void
+	 */
+	public function testCompressInvalidInputType($ip) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($ip) must be of type string');
+
+		Ipv6::compress($ip);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed to the Ipv6::check_ipv6() method.
+	 *
+	 * @covers       ::check_ipv6
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $ip Parameter to test input validation with.
+	 *
+	 * @return void
+	 */
+	public function testCheckIpv6InvalidInputType($ip) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($ip) must be of type string');
+
+		Ipv6::check_ipv6($ip);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputType() {
+		return array(
+			'null'          => array(null),
+			'boolean false' => array(false),
+			'integer'       => array(12345),
+			'array'         => array(array(1, 2, 3)),
+		);
+	}
+}


### PR DESCRIPTION
The documented accepted parameter type for all methods in the `Ipv6` class is `string`, but no input validation was done on the parameter, which could lead to various PHP errors, most notably a "passing null to non-nullable" deprecation notice on PHP 8.1.

~~This commit adds input validation to all public methods in the class, allowing only for strings and _stringable_ objects.~~ 
**This commit adds input validation to the `uncompress()` method, allowing only for strings and _stringable_ objects.**
**As the other `public` methods call `uncompress()` as the first point of action in their flow, this is sufficient to ensure input validation in all cases.**

As this class was until now only indirectly tested via the `IriTest` class, a new `Ipv6Test` class is being introduced containing - for now - only perfunctory tests for the input validation.
This test class should be expanded to cover the actual logic in the methods at a later date.

**Open questions:**
* It is up for discussion whether _stringable objects_ should even be allowed as input for these methods. Opinions welcome.
* ~~As both the `compress()` as well as the `check_ipv6()` method call the `uncompress()` method at the very start of the method logic, it could be argued that adding input validation to those methods is not needed as adding input validation to `uncompress()` is sufficient.~~
    ~~I've chosen to add the (duplicate) input validation anyway as it will make the error message more descriptive by pointing to the actual method which initially received the invalid input.~~
    ~~Again: opinions welcome.~~