### PR TITLE
Class Iri: add input validation

### DIFF
--- a/src/Iri.php
+++ b/src/Iri.php
@@ -9,6 +9,7 @@
 namespace WpOrg\Requests;
 
 use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Ipv6;
 use WpOrg\Requests\Port;
 
@@ -247,8 +248,14 @@ class Iri {
 	 * Create a new IRI object, from a specified string
 	 *
 	 * @param string|null $iri
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $iri argument is not a string nor null.
 	 */
 	public function __construct($iri = null) {
+		if ($iri !== null && is_string($iri) === false) {
+			throw InvalidArgument::create(1, '$iri', 'string|null', gettype($iri));
+		}
+
 		$this->set_iri($iri);
 	}
 

--- a/tests/IriTest.php
+++ b/tests/IriTest.php
@@ -42,7 +42,9 @@
 
 namespace WpOrg\Requests\Tests;
 
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
+use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
 
 final class IriTest extends TestCase
@@ -412,5 +414,36 @@ final class IriTest extends TestCase
 		$iri->port = 'example';
 
 		$this->assertNull($iri->port);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed to the constructor.
+	 *
+	 * @dataProvider dataConstructorInvalidInput
+	 *
+	 * @covers \WpOrg\Requests\Iri::__construct
+	 *
+	 * @param mixed $iri Invalid input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidInput($iri) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($iri) must be of type string|null');
+
+		new Iri($iri);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataConstructorInvalidInput() {
+		return array(
+			'boolean false'     => array(false),
+			'float'             => array(1.1),
+			'stringable object' => array(new StringableObject('value')),
+		);
 	}
 }


### PR DESCRIPTION
The documented accepted parameter type for the constructor of the `Iri` class is `string|null`, but no input validation was done on the parameter, which could lead to various PHP errors.

This commit adds input validation to the class constructor, allowing only for strings or null.

As for the other methods:
* The `public` magic methods should not need input validation as they should not be called directly, but only indirectly and when called that way, will receive the correct input type.
* The `public static` `Iri::absolutize()` method takes two parameters, both of type `\WpOrg\Requests\Iri|string` and already validates these parameters to be an instance of `Iri` and if not, invokes the class constructor, which will now automatically validate the input as `string|null`.
* The other `public` non-static methods do not take parameters.

Includes adding perfunctory tests for the new exception.