### PR TITLE
Class Response: improve input handling

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -118,7 +118,7 @@ class Response {
 	 */
 	public function throw_for_status($allow_redirects = true) {
 		if ($this->is_redirect()) {
-			if (!$allow_redirects) {
+			if ($allow_redirects !== true) {
 				throw new Exception('Redirection not allowed', 'response.no_redirects', $this);
 			}
 		}


### PR DESCRIPTION
The `Response` class contains two `public` methods which take parameters:
* `throw_for_status()` which takes a boolean parameter.
* `decode_body()` which takes three parameters mirroring the PHP native `json_decode()` function.

The `$allow_redirects` parameter for `throw_for_status()` is only used in a condition. Instead of adding pure type validation, making that condition type safe based on the default parameter is effective enough.

As for the `decode_body()` method: as the input parameters are passed straight on to the PHP native `json_decode()` function, we may as well let the PHP native input validation handle those parameters.