### PR TITLE
Class FilteredIterator: add input validation

### DIFF
--- a/src/Utility/FilteredIterator.php
+++ b/src/Utility/FilteredIterator.php
@@ -10,6 +10,8 @@ namespace WpOrg\Requests\Utility;
 
 use ArrayIterator;
 use ReturnTypeWillChange;
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Utility\InputValidator;
 
 /**
  * Iterator for arrays requiring filtered values
@@ -30,11 +32,19 @@ final class FilteredIterator extends ArrayIterator {
 	 *
 	 * @param array $data
 	 * @param callable $callback Callback to be called on each value
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $data argument is not iterable.
 	 */
 	public function __construct($data, $callback) {
+		if (InputValidator::is_iterable($data) === false) {
+			throw InvalidArgument::create(1, '$data', 'iterable', gettype($data));
+		}
+
 		parent::__construct($data);
 
-		$this->callback = $callback;
+		if (is_callable($callback)) {
+			$this->callback = $callback;
+		}
 	}
 
 	/**


### PR DESCRIPTION
This commit adds input validation to the class constructor.
* The `$data` parameter is documented to expect an `array`, but as the class uses `ArrayIterator`, any iterable should be accepted as valid.
    For non-iterable data an exception will now be thrown.
* The `$callback` parameter has to be a valid callback. In contrast to most input validation, for invalid callbacks passed, this parameter will just be ignored (property not set).
    This is in line with the handling of the property in the rest of the class, where the `$callback` property may be unset after unserialization anyway.

As for the other methods:
* The `public` magic/ArrayIterator methods should not need input validation as they should not be called directly, but only indirectly and when called that way, will receive the correct input type.
* The other `public` methods do not take parameters.

Includes adding perfunctory tests for the added input validation.

**Open question:**
* Should the input check for the `$callback` parameter even be added ? After all, a type check is already done before using it in the `current()` method anyway.