### PR TITLE
Docblocks: update all `@package` tags

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -2,8 +2,7 @@
 /**
  * Authentication provider interface
  *
- * @package Requests
- * @subpackage Authentication
+ * @package Requests\Authentication
  */
 
 namespace WpOrg\Requests;
@@ -19,8 +18,8 @@ use WpOrg\Requests\Hooks;
  * makes it much easier for users to use your provider.
  *
  * @see \WpOrg\Requests\Hooks
- * @package Requests
- * @subpackage Authentication
+ *
+ * @package Requests\Authentication
  */
 interface Auth {
 	/**

--- a/src/Auth/Basic.php
+++ b/src/Auth/Basic.php
@@ -2,8 +2,7 @@
 /**
  * Basic Authentication provider
  *
- * @package Requests
- * @subpackage Authentication
+ * @package Requests\Authentication
  */
 
 namespace WpOrg\Requests\Auth;
@@ -19,8 +18,7 @@ use WpOrg\Requests\Hooks;
  * Provides a handler for Basic HTTP authentication via the Authorization
  * header.
  *
- * @package Requests
- * @subpackage Authentication
+ * @package Requests\Authentication
  */
 class Basic implements Auth {
 	/**

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -2,8 +2,7 @@
 /**
  * Cookie storage object
  *
- * @package Requests
- * @subpackage Cookies
+ * @package Requests\Cookies
  */
 
 namespace WpOrg\Requests;
@@ -15,8 +14,7 @@ use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 /**
  * Cookie storage object
  *
- * @package Requests
- * @subpackage Cookies
+ * @package Requests\Cookies
  */
 class Cookie {
 	/**

--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -2,8 +2,7 @@
 /**
  * Cookie holder object
  *
- * @package Requests
- * @subpackage Cookies
+ * @package Requests\Cookies
  */
 
 namespace WpOrg\Requests\Cookie;
@@ -21,8 +20,7 @@ use WpOrg\Requests\Response;
 /**
  * Cookie holder object
  *
- * @package Requests
- * @subpackage Cookies
+ * @package Requests\Cookies
  */
 class Jar implements ArrayAccess, IteratorAggregate {
 	/**

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -2,7 +2,7 @@
 /**
  * Exception for HTTP requests
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests;
@@ -12,7 +12,7 @@ use Exception as PHPException;
 /**
  * Exception for HTTP requests
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 class Exception extends PHPException {
 	/**

--- a/src/Exception/ArgumentCount.php
+++ b/src/Exception/ArgumentCount.php
@@ -14,7 +14,7 @@ use WpOrg\Requests\Exception;
  * Along the same lines, this exception is also used if a method expects an array
  * with a certain number of elements and the provided number of elements does not comply.
  *
- * @package Requests
+ * @package Requests\Exceptions
  * @since   2.0.0
  */
 final class ArgumentCount extends Exception {

--- a/src/Exception/Http.php
+++ b/src/Exception/Http.php
@@ -2,7 +2,7 @@
 /**
  * Exception based on HTTP response
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception;
@@ -13,7 +13,7 @@ use WpOrg\Requests\Exception\Http\StatusUnknown;
 /**
  * Exception based on HTTP response
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 class Http extends Exception {
 	/**

--- a/src/Exception/Http/Status304.php
+++ b/src/Exception/Http/Status304.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 304 Not Modified responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 304 Not Modified responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status304 extends Http {
 	/**

--- a/src/Exception/Http/Status305.php
+++ b/src/Exception/Http/Status305.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 305 Use Proxy responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 305 Use Proxy responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status305 extends Http {
 	/**

--- a/src/Exception/Http/Status306.php
+++ b/src/Exception/Http/Status306.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 306 Switch Proxy responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 306 Switch Proxy responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status306 extends Http {
 	/**

--- a/src/Exception/Http/Status400.php
+++ b/src/Exception/Http/Status400.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 400 Bad Request responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 400 Bad Request responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status400 extends Http {
 	/**

--- a/src/Exception/Http/Status401.php
+++ b/src/Exception/Http/Status401.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 401 Unauthorized responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 401 Unauthorized responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status401 extends Http {
 	/**

--- a/src/Exception/Http/Status402.php
+++ b/src/Exception/Http/Status402.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 402 Payment Required responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 402 Payment Required responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status402 extends Http {
 	/**

--- a/src/Exception/Http/Status403.php
+++ b/src/Exception/Http/Status403.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 403 Forbidden responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 403 Forbidden responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status403 extends Http {
 	/**

--- a/src/Exception/Http/Status404.php
+++ b/src/Exception/Http/Status404.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 404 Not Found responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 404 Not Found responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status404 extends Http {
 	/**

--- a/src/Exception/Http/Status405.php
+++ b/src/Exception/Http/Status405.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 405 Method Not Allowed responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 405 Method Not Allowed responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status405 extends Http {
 	/**

--- a/src/Exception/Http/Status406.php
+++ b/src/Exception/Http/Status406.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 406 Not Acceptable responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 406 Not Acceptable responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status406 extends Http {
 	/**

--- a/src/Exception/Http/Status407.php
+++ b/src/Exception/Http/Status407.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 407 Proxy Authentication Required responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 407 Proxy Authentication Required responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status407 extends Http {
 	/**

--- a/src/Exception/Http/Status408.php
+++ b/src/Exception/Http/Status408.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 408 Request Timeout responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 408 Request Timeout responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status408 extends Http {
 	/**

--- a/src/Exception/Http/Status409.php
+++ b/src/Exception/Http/Status409.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 409 Conflict responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 409 Conflict responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status409 extends Http {
 	/**

--- a/src/Exception/Http/Status410.php
+++ b/src/Exception/Http/Status410.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 410 Gone responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 410 Gone responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status410 extends Http {
 	/**

--- a/src/Exception/Http/Status411.php
+++ b/src/Exception/Http/Status411.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 411 Length Required responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 411 Length Required responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status411 extends Http {
 	/**

--- a/src/Exception/Http/Status412.php
+++ b/src/Exception/Http/Status412.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 412 Precondition Failed responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 412 Precondition Failed responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status412 extends Http {
 	/**

--- a/src/Exception/Http/Status413.php
+++ b/src/Exception/Http/Status413.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 413 Request Entity Too Large responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 413 Request Entity Too Large responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status413 extends Http {
 	/**

--- a/src/Exception/Http/Status414.php
+++ b/src/Exception/Http/Status414.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 414 Request-URI Too Large responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 414 Request-URI Too Large responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status414 extends Http {
 	/**

--- a/src/Exception/Http/Status415.php
+++ b/src/Exception/Http/Status415.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 415 Unsupported Media Type responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 415 Unsupported Media Type responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status415 extends Http {
 	/**

--- a/src/Exception/Http/Status416.php
+++ b/src/Exception/Http/Status416.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 416 Requested Range Not Satisfiable responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 416 Requested Range Not Satisfiable responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status416 extends Http {
 	/**

--- a/src/Exception/Http/Status417.php
+++ b/src/Exception/Http/Status417.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 417 Expectation Failed responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 417 Expectation Failed responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status417 extends Http {
 	/**

--- a/src/Exception/Http/Status418.php
+++ b/src/Exception/Http/Status418.php
@@ -3,7 +3,8 @@
  * Exception for 418 I'm A Teapot responses
  *
  * @link https://tools.ietf.org/html/rfc2324
- * @package Requests
+ *
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -14,7 +15,8 @@ use WpOrg\Requests\Exception\Http;
  * Exception for 418 I'm A Teapot responses
  *
  * @link https://tools.ietf.org/html/rfc2324
- * @package Requests
+ *
+ * @package Requests\Exceptions
  */
 final class Status418 extends Http {
 	/**

--- a/src/Exception/Http/Status428.php
+++ b/src/Exception/Http/Status428.php
@@ -3,7 +3,8 @@
  * Exception for 428 Precondition Required responses
  *
  * @link https://tools.ietf.org/html/rfc6585
- * @package Requests
+ *
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -14,7 +15,8 @@ use WpOrg\Requests\Exception\Http;
  * Exception for 428 Precondition Required responses
  *
  * @link https://tools.ietf.org/html/rfc6585
- * @package Requests
+ *
+ * @package Requests\Exceptions
  */
 final class Status428 extends Http {
 	/**

--- a/src/Exception/Http/Status429.php
+++ b/src/Exception/Http/Status429.php
@@ -3,7 +3,8 @@
  * Exception for 429 Too Many Requests responses
  *
  * @link https://tools.ietf.org/html/draft-nottingham-http-new-status-04
- * @package Requests
+ *
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -14,7 +15,8 @@ use WpOrg\Requests\Exception\Http;
  * Exception for 429 Too Many Requests responses
  *
  * @link https://tools.ietf.org/html/draft-nottingham-http-new-status-04
- * @package Requests
+ *
+ * @package Requests\Exceptions
  */
 final class Status429 extends Http {
 	/**

--- a/src/Exception/Http/Status431.php
+++ b/src/Exception/Http/Status431.php
@@ -3,7 +3,8 @@
  * Exception for 431 Request Header Fields Too Large responses
  *
  * @link https://tools.ietf.org/html/rfc6585
- * @package Requests
+ *
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -14,7 +15,8 @@ use WpOrg\Requests\Exception\Http;
  * Exception for 431 Request Header Fields Too Large responses
  *
  * @link https://tools.ietf.org/html/rfc6585
- * @package Requests
+ *
+ * @package Requests\Exceptions
  */
 final class Status431 extends Http {
 	/**

--- a/src/Exception/Http/Status500.php
+++ b/src/Exception/Http/Status500.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 500 Internal Server Error responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 500 Internal Server Error responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status500 extends Http {
 	/**

--- a/src/Exception/Http/Status501.php
+++ b/src/Exception/Http/Status501.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 501 Not Implemented responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 501 Not Implemented responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status501 extends Http {
 	/**

--- a/src/Exception/Http/Status502.php
+++ b/src/Exception/Http/Status502.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 502 Bad Gateway responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 502 Bad Gateway responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status502 extends Http {
 	/**

--- a/src/Exception/Http/Status503.php
+++ b/src/Exception/Http/Status503.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 503 Service Unavailable responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 503 Service Unavailable responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status503 extends Http {
 	/**

--- a/src/Exception/Http/Status504.php
+++ b/src/Exception/Http/Status504.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 504 Gateway Timeout responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 504 Gateway Timeout responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status504 extends Http {
 	/**

--- a/src/Exception/Http/Status505.php
+++ b/src/Exception/Http/Status505.php
@@ -2,7 +2,7 @@
 /**
  * Exception for 505 HTTP Version Not Supported responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -12,7 +12,7 @@ use WpOrg\Requests\Exception\Http;
 /**
  * Exception for 505 HTTP Version Not Supported responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class Status505 extends Http {
 	/**

--- a/src/Exception/Http/Status511.php
+++ b/src/Exception/Http/Status511.php
@@ -3,7 +3,8 @@
  * Exception for 511 Network Authentication Required responses
  *
  * @link https://tools.ietf.org/html/rfc6585
- * @package Requests
+ *
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -14,7 +15,8 @@ use WpOrg\Requests\Exception\Http;
  * Exception for 511 Network Authentication Required responses
  *
  * @link https://tools.ietf.org/html/rfc6585
- * @package Requests
+ *
+ * @package Requests\Exceptions
  */
 final class Status511 extends Http {
 	/**

--- a/src/Exception/Http/StatusUnknown.php
+++ b/src/Exception/Http/StatusUnknown.php
@@ -2,7 +2,7 @@
 /**
  * Exception for unknown status responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 
 namespace WpOrg\Requests\Exception\Http;
@@ -13,7 +13,7 @@ use WpOrg\Requests\Response;
 /**
  * Exception for unknown status responses
  *
- * @package Requests
+ * @package Requests\Exceptions
  */
 final class StatusUnknown extends Http {
 	/**

--- a/src/Exception/InvalidArgument.php
+++ b/src/Exception/InvalidArgument.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 /**
  * Exception for an invalid argument passed.
  *
- * @package Requests
+ * @package Requests\Exceptions
  * @since   2.0.0
  */
 final class InvalidArgument extends InvalidArgumentException {

--- a/src/Exception/Transport.php
+++ b/src/Exception/Transport.php
@@ -1,7 +1,17 @@
 <?php
+/**
+ * Transport Exception
+ *
+ * @package Requests\Exceptions
+ */
 
 namespace WpOrg\Requests\Exception;
 
 use WpOrg\Requests\Exception;
 
+/**
+ * Transport Exception
+ *
+ * @package Requests\Exceptions
+ */
 class Transport extends Exception {}

--- a/src/Exception/Transport/Curl.php
+++ b/src/Exception/Transport/Curl.php
@@ -1,9 +1,19 @@
 <?php
+/**
+ * CURL Transport Exception.
+ *
+ * @package Requests\Exceptions
+ */
 
 namespace WpOrg\Requests\Exception\Transport;
 
 use WpOrg\Requests\Exception\Transport;
 
+/**
+ * CURL Transport Exception.
+ *
+ * @package Requests\Exceptions
+ */
 final class Curl extends Transport {
 
 	const EASY  = 'cURLEasy';

--- a/src/HookManager.php
+++ b/src/HookManager.php
@@ -2,8 +2,7 @@
 /**
  * Event dispatcher
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\EventDispatcher
  */
 
 namespace WpOrg\Requests;
@@ -11,8 +10,7 @@ namespace WpOrg\Requests;
 /**
  * Event dispatcher
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\EventDispatcher
  */
 interface HookManager {
 	/**

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -2,8 +2,7 @@
 /**
  * Handles adding and dispatching events
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\EventDispatcher
  */
 
 namespace WpOrg\Requests;
@@ -15,8 +14,7 @@ use WpOrg\Requests\Utility\InputValidator;
 /**
  * Handles adding and dispatching events
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\EventDispatcher
  */
 class Hooks implements HookManager {
 	/**

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -11,8 +11,8 @@ use WpOrg\Requests\Utility\InputValidator;
  *
  * Note: Not fully compliant, as nameprep does nothing yet.
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
+ *
  * @link https://tools.ietf.org/html/rfc3490 IDNA specification
  * @link https://tools.ietf.org/html/rfc3492 Punycode/Bootstrap specification
  */

--- a/src/Ipv6.php
+++ b/src/Ipv6.php
@@ -2,8 +2,7 @@
 /**
  * Class to validate and to work with IPv6 addresses
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 
 namespace WpOrg\Requests;
@@ -14,8 +13,7 @@ namespace WpOrg\Requests;
  * This was originally based on the PEAR class of the same name, but has been
  * entirely rewritten.
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 final class Ipv6 {
 	/**

--- a/src/Iri.php
+++ b/src/Iri.php
@@ -2,8 +2,7 @@
 /**
  * IRI parser/serialiser/normaliser
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 
 namespace WpOrg\Requests;
@@ -45,8 +44,7 @@ use WpOrg\Requests\Port;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  * @author Geoffrey Sneddon
  * @author Steve Minutillo
  * @copyright 2007-2009 Geoffrey Sneddon and Steve Minutillo

--- a/src/Port.php
+++ b/src/Port.php
@@ -2,10 +2,8 @@
 /**
  * Port utilities for Requests
  *
- * @package Requests
- * @subpackage Utilities
- *
- * @since 2.0.0
+ * @package Requests\Utilities
+ * @since   2.0.0
  */
 
 namespace WpOrg\Requests;
@@ -16,10 +14,8 @@ use WpOrg\Requests\Exception\InvalidArgument;
 /**
  * Find the correct port depending on the Request type.
  *
- * @package Requests
- * @subpackage Utilities
- *
- * @since 2.0.0
+ * @package Requests\Utilities
+ * @since   2.0.0
  */
 final class Port {
 

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -2,9 +2,8 @@
 /**
  * Proxy connection interface
  *
- * @package Requests
- * @subpackage Proxy
- * @since 1.6
+ * @package Requests\Proxy
+ * @since   1.6
  */
 
 namespace WpOrg\Requests;
@@ -20,9 +19,9 @@ use WpOrg\Requests\Hooks;
  * makes it much easier for users to use your provider.
  *
  * @see \WpOrg\Requests\Hooks
- * @package Requests
- * @subpackage Proxy
- * @since 1.6
+ *
+ * @package Requests\Proxy
+ * @since   1.6
  */
 interface Proxy {
 	/**

--- a/src/Proxy/Http.php
+++ b/src/Proxy/Http.php
@@ -2,9 +2,8 @@
 /**
  * HTTP Proxy connection interface
  *
- * @package Requests
- * @subpackage Proxy
- * @since 1.6
+ * @package Requests\Proxy
+ * @since   1.6
  */
 
 namespace WpOrg\Requests\Proxy;
@@ -18,9 +17,8 @@ use WpOrg\Requests\Proxy;
  *
  * Provides a handler for connection via an HTTP proxy
  *
- * @package Requests
- * @subpackage Proxy
- * @since 1.6
+ * @package Requests\Proxy
+ * @since   1.6
  */
 final class Http implements Proxy {
 	/**

--- a/src/Response.php
+++ b/src/Response.php
@@ -3,6 +3,7 @@
  * HTTP response class
  *
  * Contains a response from \WpOrg\Requests\Requests::request()
+ *
  * @package Requests
  */
 
@@ -17,6 +18,7 @@ use WpOrg\Requests\Response\Headers;
  * HTTP response class
  *
  * Contains a response from \WpOrg\Requests\Requests::request()
+ *
  * @package Requests
  */
 class Response {

--- a/src/Session.php
+++ b/src/Session.php
@@ -2,8 +2,7 @@
 /**
  * Session handler for persistent requests and default parameters
  *
- * @package Requests
- * @subpackage Session Handler
+ * @package Requests\SessionHandler
  */
 
 namespace WpOrg\Requests;
@@ -20,8 +19,7 @@ use WpOrg\Requests\Requests;
  * with all subrequests resolved from this. Base options can be set (including
  * a shared cookie jar), then overridden for individual requests.
  *
- * @package Requests
- * @subpackage Session Handler
+ * @package Requests\SessionHandler
  */
 class Session {
 	/**

--- a/src/Ssl.php
+++ b/src/Ssl.php
@@ -2,8 +2,7 @@
 /**
  * SSL utilities for Requests
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 
 namespace WpOrg\Requests;
@@ -16,8 +15,7 @@ use WpOrg\Requests\Utility\InputValidator;
  *
  * Collection of utilities for working with and verifying SSL certificates.
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 final class Ssl {
 	/**

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -2,8 +2,7 @@
 /**
  * Base HTTP transport
  *
- * @package Requests
- * @subpackage Transport
+ * @package Requests\Transport
  */
 
 namespace WpOrg\Requests;
@@ -11,8 +10,7 @@ namespace WpOrg\Requests;
 /**
  * Base HTTP transport
  *
- * @package Requests
- * @subpackage Transport
+ * @package Requests\Transport
  */
 interface Transport {
 	/**

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -2,8 +2,7 @@
 /**
  * cURL HTTP transport
  *
- * @package Requests
- * @subpackage Transport
+ * @package Requests\Transport
  */
 
 namespace WpOrg\Requests\Transport;
@@ -19,8 +18,7 @@ use WpOrg\Requests\Transport;
 /**
  * cURL HTTP transport
  *
- * @package Requests
- * @subpackage Transport
+ * @package Requests\Transport
  */
 final class Curl implements Transport {
 	const CURL_7_10_5 = 0x070A05;

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -2,8 +2,7 @@
 /**
  * fsockopen HTTP transport
  *
- * @package Requests
- * @subpackage Transport
+ * @package Requests\Transport
  */
 
 namespace WpOrg\Requests\Transport;
@@ -19,8 +18,7 @@ use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 /**
  * fsockopen HTTP transport
  *
- * @package Requests
- * @subpackage Transport
+ * @package Requests\Transport
  */
 final class Fsockopen implements Transport {
 	/**

--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -2,8 +2,7 @@
 /**
  * Case-insensitive dictionary, suitable for HTTP headers
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 
 namespace WpOrg\Requests\Utility;
@@ -17,8 +16,7 @@ use WpOrg\Requests\Exception;
 /**
  * Case-insensitive dictionary, suitable for HTTP headers
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	/**

--- a/src/Utility/FilteredIterator.php
+++ b/src/Utility/FilteredIterator.php
@@ -2,8 +2,7 @@
 /**
  * Iterator for arrays requiring filtered values
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 
 namespace WpOrg\Requests\Utility;
@@ -16,8 +15,7 @@ use WpOrg\Requests\Utility\InputValidator;
 /**
  * Iterator for arrays requiring filtered values
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 final class FilteredIterator extends ArrayIterator {
 	/**

--- a/src/Utility/InputValidator.php
+++ b/src/Utility/InputValidator.php
@@ -2,8 +2,7 @@
 /**
  * Input validation utilities.
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 
 namespace WpOrg\Requests\Utility;
@@ -15,8 +14,7 @@ use Traversable;
 /**
  * Input validation utilities.
  *
- * @package Requests
- * @subpackage Utilities
+ * @package Requests\Utilities
  */
 final class InputValidator {
 


### PR DESCRIPTION
This commit:
* Removes all `@subpackage` tags in favour of hierarchical `@package` tags.
* Adds the missing docblocks to the Transport exception classes.
* Changes the tags for the `HookManager` interface and the `Hooks` class from `Requests\Utilities` to `Requests\EventDispatcher`.
* Changes the package for all exception classes to `Requests\Exceptions`.

Includes minor tag grouping and alignment tweaks.

Fixes #590