### PR TITLE
Cookie: add input validation

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -402,9 +402,22 @@ class Cookie {
 	 * specifies some of this handling, but not in a thorough manner.
 	 *
 	 * @param string $cookie_header Cookie header value (from a Set-Cookie header)
+	 * @param string $name
+	 * @param int|null $reference_time
 	 * @return \WpOrg\Requests\Cookie Parsed cookie object
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $cookie_header argument is not a string.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $name argument is not a string.
 	 */
 	public static function parse($cookie_header, $name = '', $reference_time = null) {
+		if (is_string($cookie_header) === false) {
+			throw InvalidArgument::create(1, '$cookie_header', 'string', gettype($cookie_header));
+		}
+
+		if (is_string($name) === false) {
+			throw InvalidArgument::create(2, '$name', 'string', gettype($name));
+		}
+
 		$parts   = explode(';', $cookie_header);
 		$kvparts = array_shift($parts);
 

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -242,6 +242,10 @@ class Cookie {
 			return true;
 		}
 
+		if (is_scalar($request_path) === false) {
+			return false;
+		}
+
 		$cookie_path = $this->attributes['path'];
 
 		if ($cookie_path === $request_path) {

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -7,9 +7,11 @@
 
 namespace WpOrg\Requests;
 
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Response\Headers;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
+use WpOrg\Requests\Utility\InputValidator;
 
 /**
  * Cookie storage object
@@ -67,8 +69,36 @@ class Cookie {
 	 * @param string $name
 	 * @param string $value
 	 * @param array|\WpOrg\Requests\Utility\CaseInsensitiveDictionary $attributes Associative array of attribute data
+	 * @param array $flags
+	 * @param int|null $reference_time
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $name argument is not a string.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $value argument is not a string.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $attributes argument is not an array or iterable object with array access.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $flags argument is not an array.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $reference_time argument is not an integer or null.
 	 */
 	public function __construct($name, $value, $attributes = array(), $flags = array(), $reference_time = null) {
+		if (is_string($name) === false) {
+			throw InvalidArgument::create(1, '$name', 'string', gettype($name));
+		}
+
+		if (is_string($value) === false) {
+			throw InvalidArgument::create(2, '$value', 'string', gettype($value));
+		}
+
+		if (InputValidator::has_array_access($attributes) === false || InputValidator::is_iterable($attributes) === false) {
+			throw InvalidArgument::create(3, '$attributes', 'array|ArrayAccess&Traversable', gettype($attributes));
+		}
+
+		if (is_array($flags) === false) {
+			throw InvalidArgument::create(4, '$flags', 'array', gettype($flags));
+		}
+
+		if ($reference_time !== null && is_int($reference_time) === false) {
+			throw InvalidArgument::create(5, '$reference_time', 'integer|null', gettype($reference_time));
+		}
+
 		$this->name       = $name;
 		$this->value      = $value;
 		$this->attributes = $attributes;

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -178,6 +178,10 @@ class Cookie {
 	 * @return boolean Whether the cookie is valid for the given domain
 	 */
 	public function domain_matches($domain) {
+		if (is_string($domain) === false) {
+			return false;
+		}
+
 		if (!isset($this->attributes['domain'])) {
 			// Cookies created manually; cookies created by Requests will set
 			// the domain to the requested domain

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -180,6 +180,10 @@ final class CookiesTest extends TestCase {
 
 	public function pathMatchProvider() {
 		return array(
+			'Invalid check path (type): null'    => array('/', null, true),
+			'Invalid check path (type): true'    => array('/', true, false),
+			'Invalid check path (type): integer' => array('/', 123, false),
+			'Invalid check path (type): array'   => array('/', array(1, 2), false),
 			array('/', '', true),
 			array('/', '/', true),
 

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -784,4 +784,22 @@ final class CookiesTest extends TestCase {
 
 		Cookie::parse('test', 'test', 'now');
 	}
+
+	/**
+	 * Tests receiving an exception when the parse_from_headers() method received an invalid input type as `$reference_time`.
+	 *
+	 * @covers \WpOrg\Requests\Cookie::parse_from_headers
+	 *
+	 * @return void
+	 */
+	public function testParseFromHeadersInvalidReferenceTime() {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #5 ($reference_time) must be of type integer|null');
+
+		$origin                = new Iri();
+		$headers               = new Headers();
+		$headers['Set-Cookie'] = 'name=value;';
+
+		Cookie::parse_from_headers($headers, $origin, 'now');
+	}
 }

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -422,7 +422,7 @@ final class CookiesTest extends TestCase {
 		// Set the reference time to 2014-01-01 00:00:00
 		$reference_time = gmmktime(0, 0, 0, 1, 1, 2014);
 
-		$cookie = Cookie::parse($header, null, $reference_time);
+		$cookie = Cookie::parse($header, '', $reference_time);
 		$this->check_parsed_cookie($cookie, $expected, $expected_attributes);
 	}
 
@@ -435,7 +435,7 @@ final class CookiesTest extends TestCase {
 		// Set the reference time to 2014-01-01 00:00:00
 		$reference_time = gmmktime(0, 0, 0, 1, 1, 2014);
 
-		$cookie = Cookie::parse($header, null, $reference_time);
+		$cookie = Cookie::parse($header, '', $reference_time);
 
 		// Normalize the value again
 		$cookie->normalize();
@@ -733,5 +733,55 @@ final class CookiesTest extends TestCase {
 			'string'          => array('now'),
 			'DateTime object' => array(new DateTime('now')),
 		);
+	}
+
+	/**
+	 * Tests receiving an exception when the parse() method received an invalid input type as `$cookie_header`.
+	 *
+	 * @dataProvider dataInvalidStringInput
+	 *
+	 * @covers \WpOrg\Requests\Cookie::parse
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testParseInvalidCookieHeader($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($cookie_header) must be of type string');
+
+		Cookie::parse($input);
+	}
+
+	/**
+	 * Tests receiving an exception when the parse() method received an invalid input type as `$name`.
+	 *
+	 * @dataProvider dataInvalidStringInput
+	 *
+	 * @covers \WpOrg\Requests\Cookie::parse
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testParseInvalidName($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #2 ($name) must be of type string');
+
+		Cookie::parse('test', $input);
+	}
+
+	/**
+	 * Tests receiving an exception when the parse() method received an invalid input type as `$reference_time`.
+	 *
+	 * @covers \WpOrg\Requests\Cookie::parse
+	 *
+	 * @return void
+	 */
+	public function testParseInvalidReferenceTime() {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #5 ($reference_time) must be of type integer|null');
+
+		Cookie::parse('test', 'test', 'now');
 	}
 }

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -130,6 +130,8 @@ final class CookiesTest extends TestCase {
 
 	public function domainMatchProvider() {
 		return array(
+			'Invalid check domain (type): null'         => array('example.com', null, false, false),
+			'Invalid check domain (type): boolean true' => array('example.com', true, false, false),
 			array('example.com', 'example.com', true, true),
 			array('example.com', 'www.example.com', false, true),
 			array('example.com', 'example.net', false, false),

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -2,10 +2,15 @@
 
 namespace WpOrg\Requests\Tests;
 
+use DateTime;
+use EmptyIterator;
 use WpOrg\Requests\Cookie;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response\Headers;
+use WpOrg\Requests\Tests\Fixtures\ArrayAccessibleObject;
+use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 
@@ -579,5 +584,148 @@ final class CookiesTest extends TestCase {
 
 		$cookie = reset($parsed);
 		$this->check_parsed_cookie($cookie, $expected, $expected_attributes, $expected_flags);
+	}
+
+	/**
+	 * Tests receiving an exception when the constructor received an invalid input type as `$name`.
+	 *
+	 * @dataProvider dataInvalidStringInput
+	 *
+	 * @covers \WpOrg\Requests\Cookie::__construct
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidName($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($name) must be of type string');
+
+		new Cookie($input, 'value');
+	}
+
+	/**
+	 * Tests receiving an exception when the constructor received an invalid input type as `$value`.
+	 *
+	 * @dataProvider dataInvalidStringInput
+	 *
+	 * @covers \WpOrg\Requests\Cookie::__construct
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidValue($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #2 ($value) must be of type string');
+
+		new Cookie('name', $input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidStringInput() {
+		return array(
+			'null'              => array(null),
+			'float'             => array(1.1),
+			'stringable object' => array(new StringableObject('name')),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when the constructor received an invalid input type as `$name`.
+	 *
+	 * @dataProvider dataConstructorInvalidAttributes
+	 *
+	 * @covers \WpOrg\Requests\Cookie::__construct
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidAttributes($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #3 ($attributes) must be of type array|ArrayAccess&Traversable');
+
+		new Cookie('name', 'value', $input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataConstructorInvalidAttributes() {
+		return array(
+			'null'                                 => array(null),
+			'text string'                          => array('array'),
+			'iterator object without array access' => array(new EmptyIterator()),
+			'array accessible object not iterable' => array(new ArrayAccessibleObject(array(1, 2, 3))),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when the constructor received an invalid input type as `$flags`.
+	 *
+	 * @dataProvider dataConstructorInvalidFlags
+	 *
+	 * @covers \WpOrg\Requests\Cookie::__construct
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidFlags($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #4 ($flags) must be of type array');
+
+		new Cookie('name', 'value', array(), $input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataConstructorInvalidFlags() {
+		return array(
+			'null'                    => array(null),
+			'integer'                 => array(101),
+			'array accessible object' => array(new ArrayAccessibleObject(array())),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when the constructor received an invalid input type as `$reference_time`.
+	 *
+	 * @dataProvider dataConstructorInvalidReferenceTime
+	 *
+	 * @covers \WpOrg\Requests\Cookie::__construct
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidReferenceTime($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #5 ($reference_time) must be of type integer|null');
+
+		new Cookie('name', 'value', array(), array(), $input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataConstructorInvalidReferenceTime() {
+		return array(
+			'float'           => array(1.1),
+			'string'          => array('now'),
+			'DateTime object' => array(new DateTime('now')),
+		);
 	}
 }


### PR DESCRIPTION
### Cookie::__construct(): add input validation

This commit adds input validation for all parameters of the `Cookie::__construct()` method:
* For `$name` and `$value`, I've chosen to only accept plain strings and not `Stringable` objects.
* The `$attributes` parameter accepts an array or an instance of `CaseInsensitiveDictionary` according to the docs, but the important thing about the `CaseInsensitiveDictionary` part is that if the parameter is passed as an object, it needs to have both `ArrayAccess`, as well as be `Traversable`, so the input validation checks for those characteristics rather than hard-requiring an instance of `CaseInsensitiveDictionary`.
* As the `$flags` parameter is used with `array_merge()`, we cannot accept objects, so an array is the only valid input type.
* As for `$reference_time`: as the default value is set using `time()`, which returns an integer time stamp, I've implemented the input validation to expect an integer.

Includes tests for these new exceptions.

### Cookie::domain_matches(): add input validation

As this method only returns `boolean`, we may as well return boolean `false` instead of throwing an exception.

Includes tests.

### Cookie::path_matches(): add input validation

As this method only returns `boolean`, we may as well return boolean `false` instead of throwing an exception.

The input validation in this case is not done at the very start of the function to prevent changing the behaviour of the function for those cases which were already being handled by the method. This is also the reason for using `is_scalar()` instead of `is_string()`.

Includes tests.

### Cookie::parse(): add input validation

This adds input validation to the `Cookie::parse()` method for the `$cookie_header` and `$name` parameters.

As the `$reference_time` parameter is not directly used in this method, but only passed through to the `Cookie::__construct()` method, no input validation has been added, as it will be validated by the `Cookie::__construct()` method.

Includes tests for the new exceptions + a test to safeguard that the "fall through validation for the `$reference_time`" actually happens.

Includes fixing up two tests which were passing the wrong value type for an optional parameter.

### Cookie::parse_from_headers(): add test safeguarding input validation

The first and second argument for the `Cookie::parse_from_headers()` method already have (class-based) type declarations.
The third argument - `$time` - is only used to pass it through to the `parse()` method, which will subsequently pass it through to the class constructor which contains input validation for the parameter.

This just adds a test to safeguard that the "fall through" validation for the `$time` parameter actually happens.



---

### Regarding the other `public` methods:

* The `uri_matches()` method already has a class based type declaration.
* The other `public` methods do not take parameters.