### PR TITLE
Cookie\Jar: add input validation

### DIFF
--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -52,7 +52,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string|\WpOrg\Requests\Cookie $cookie
 	 * @return \WpOrg\Requests\Cookie
 	 */
-	public function normalize_cookie($cookie, $key = null) {
+	public function normalize_cookie($cookie, $key = '') {
 		if ($cookie instanceof Cookie) {
 			return $cookie;
 		}

--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -13,6 +13,7 @@ use IteratorAggregate;
 use ReturnTypeWillChange;
 use WpOrg\Requests\Cookie;
 use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\HookManager;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Response;
@@ -34,8 +35,14 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	 * Create a new jar
 	 *
 	 * @param array $cookies Existing cookie values
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not an array.
 	 */
 	public function __construct($cookies = array()) {
+		if (is_array($cookies) === false) {
+			throw InvalidArgument::create(1, '$cookies', 'array', gettype($cookies));
+		}
+
 		$this->cookies = $cookies;
 	}
 

--- a/tests/Cookie/JarTest.php
+++ b/tests/Cookie/JarTest.php
@@ -5,6 +5,7 @@ namespace WpOrg\Requests\Tests\Cookie;
 use WpOrg\Requests\Cookie;
 use WpOrg\Requests\Cookie\Jar;
 use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
 
@@ -105,5 +106,17 @@ final class JarTest extends TestCase {
 		$this->assertIsArray($data);
 		$this->assertArrayHasKey('cookies', $data);
 		return $data['cookies'];
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed to the class constructor.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidInputType() {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($cookies) must be of type array');
+
+		new Jar('string');
 	}
 }

--- a/tests/Cookie/JarTest.php
+++ b/tests/Cookie/JarTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Cookie;
+
+use WpOrg\Requests\Cookie;
+use WpOrg\Requests\Cookie\Jar;
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Requests;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Cookie\Jar
+ */
+final class JarTest extends TestCase {
+
+	public function testCookieJarSetter() {
+		$jar1                        = new Jar();
+		$jar1['requests-testcookie'] = 'testvalue';
+
+		$jar2 = new Jar(
+			array(
+				'requests-testcookie' => 'testvalue',
+			)
+		);
+		$this->assertEquals($jar1, $jar2);
+	}
+
+	public function testCookieJarUnsetter() {
+		$jar                        = new Jar();
+		$jar['requests-testcookie'] = 'testvalue';
+
+		$this->assertSame('testvalue', $jar['requests-testcookie']);
+
+		unset($jar['requests-testcookie']);
+		$this->assertEmpty($jar['requests-testcookie']);
+		$this->assertFalse(isset($jar['requests-testcookie']));
+	}
+
+	public function testCookieJarAsList() {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Object is a dictionary, not a list');
+		$cookies   = new Jar();
+		$cookies[] = 'requests-testcookie1=testvalue1';
+	}
+
+	public function testCookieJarIterator() {
+		$cookies = array(
+			'requests-testcookie1' => 'testvalue1',
+			'requests-testcookie2' => 'testvalue2',
+		);
+		$jar     = new Jar($cookies);
+
+		foreach ($jar as $key => $value) {
+			$this->assertSame($cookies[$key], $value);
+		}
+	}
+
+	public function testSendingCookieWithJar() {
+		$cookies = new Jar(
+			array(
+				'requests-testcookie1' => 'testvalue1',
+			)
+		);
+		$data    = $this->setCookieRequest($cookies);
+
+		$this->assertArrayHasKey('requests-testcookie1', $data);
+		$this->assertSame('testvalue1', $data['requests-testcookie1']);
+	}
+
+	public function testSendingMultipleCookiesWithJar() {
+		$cookies = new Jar(
+			array(
+				'requests-testcookie1' => 'testvalue1',
+				'requests-testcookie2' => 'testvalue2',
+			)
+		);
+		$data    = $this->setCookieRequest($cookies);
+
+		$this->assertArrayHasKey('requests-testcookie1', $data);
+		$this->assertSame('testvalue1', $data['requests-testcookie1']);
+
+		$this->assertArrayHasKey('requests-testcookie2', $data);
+		$this->assertSame('testvalue2', $data['requests-testcookie2']);
+	}
+
+	public function testSendingPrebakedCookie() {
+		$cookies = new Jar(
+			array(
+				new Cookie('requests-testcookie', 'testvalue'),
+			)
+		);
+		$data    = $this->setCookieRequest($cookies);
+
+		$this->assertArrayHasKey('requests-testcookie', $data);
+		$this->assertSame('testvalue', $data['requests-testcookie']);
+	}
+
+	private function setCookieRequest($cookies) {
+		$options  = array(
+			'cookies' => $cookies,
+		);
+		$response = Requests::get(httpbin('/cookies/set'), array(), $options);
+
+		$data = json_decode($response->body, true);
+		$this->assertIsArray($data);
+		$this->assertArrayHasKey('cookies', $data);
+		return $data['cookies'];
+	}
+}

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -3,8 +3,6 @@
 namespace WpOrg\Requests\Tests;
 
 use WpOrg\Requests\Cookie;
-use WpOrg\Requests\Cookie\Jar;
-use WpOrg\Requests\Exception;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response\Headers;
@@ -43,48 +41,6 @@ final class CookiesTest extends TestCase {
 	public function testEmptyAttributes() {
 		$cookie = Cookie::parse('foo=bar; HttpOnly');
 		$this->assertTrue($cookie->attributes['httponly']);
-	}
-
-	public function testCookieJarSetter() {
-		$jar1                        = new Jar();
-		$jar1['requests-testcookie'] = 'testvalue';
-
-		$jar2 = new Jar(
-			array(
-				'requests-testcookie' => 'testvalue',
-			)
-		);
-		$this->assertEquals($jar1, $jar2);
-	}
-
-	public function testCookieJarUnsetter() {
-		$jar                        = new Jar();
-		$jar['requests-testcookie'] = 'testvalue';
-
-		$this->assertSame('testvalue', $jar['requests-testcookie']);
-
-		unset($jar['requests-testcookie']);
-		$this->assertEmpty($jar['requests-testcookie']);
-		$this->assertFalse(isset($jar['requests-testcookie']));
-	}
-
-	public function testCookieJarAsList() {
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Object is a dictionary, not a list');
-		$cookies   = new Jar();
-		$cookies[] = 'requests-testcookie1=testvalue1';
-	}
-
-	public function testCookieJarIterator() {
-		$cookies = array(
-			'requests-testcookie1' => 'testvalue1',
-			'requests-testcookie2' => 'testvalue2',
-		);
-		$jar     = new Jar($cookies);
-
-		foreach ($jar as $key => $value) {
-			$this->assertSame($cookies[$key], $value);
-		}
 	}
 
 	public function testReceivingCookies() {
@@ -153,18 +109,6 @@ final class CookiesTest extends TestCase {
 		$this->assertEmpty($data['cookies']);
 	}
 
-	public function testSendingCookieWithJar() {
-		$cookies = new Jar(
-			array(
-				'requests-testcookie1' => 'testvalue1',
-			)
-		);
-		$data    = $this->setCookieRequest($cookies);
-
-		$this->assertArrayHasKey('requests-testcookie1', $data);
-		$this->assertSame('testvalue1', $data['requests-testcookie1']);
-	}
-
 	public function testSendingMultipleCookies() {
 		$cookies = array(
 			'requests-testcookie1' => 'testvalue1',
@@ -177,34 +121,6 @@ final class CookiesTest extends TestCase {
 
 		$this->assertArrayHasKey('requests-testcookie2', $data);
 		$this->assertSame('testvalue2', $data['requests-testcookie2']);
-	}
-
-	public function testSendingMultipleCookiesWithJar() {
-		$cookies = new Jar(
-			array(
-				'requests-testcookie1' => 'testvalue1',
-				'requests-testcookie2' => 'testvalue2',
-			)
-		);
-		$data    = $this->setCookieRequest($cookies);
-
-		$this->assertArrayHasKey('requests-testcookie1', $data);
-		$this->assertSame('testvalue1', $data['requests-testcookie1']);
-
-		$this->assertArrayHasKey('requests-testcookie2', $data);
-		$this->assertSame('testvalue2', $data['requests-testcookie2']);
-	}
-
-	public function testSendingPrebakedCookie() {
-		$cookies = new Jar(
-			array(
-				new Cookie('requests-testcookie', 'testvalue'),
-			)
-		);
-		$data    = $this->setCookieRequest($cookies);
-
-		$this->assertArrayHasKey('requests-testcookie', $data);
-		$this->assertSame('testvalue', $data['requests-testcookie']);
 	}
 
 	public function domainMatchProvider() {


### PR DESCRIPTION
### Cookie\Jar: move tests to dedicated file

The tests for the `Cookie\Jar` class were up to now mixed in with the tests for the `Cookie` class.

This moves the `Jar` tests to a dedicated test file.

The actual test code has not been touched.

This includes duplicating a helper method. At a later point in time when these tests are reviewed, it can be decided whether this helper should move to the `TestCase`.

### Cookie\Jar::__construct(): add input validation

As `array_merge()` is used on the `$cookies` property in the `before_redirect_check()` method, only arrays can be accepted.

Includes test.

### Cookie\Jar::normalize_cookie(): fix default value of $key

The `$key` parameter corresponds to the `$name` parameter in the `Cookie::parse()` method, which expects a string and has a default value of `''`.

This fixes the default value of the `$key` parameter to be the same, i.e. an empty string.

---

### Regarding the other `public` methods:

* The `public` magic/ArrayIterator methods should not need input validation as they should not be called directly, but only indirectly and when called that way, will receive the correct input type.
* The `normalize_cookie()` method checks for an instance of Cookie already and if not passes off to `Cookie::parse()` for which input validation is being added in PR #609
* The `register()` and `before_redirect_check()` methods already have a class based type declaration.
* The `before_request()` method is intended to be only called as a Hook callback.
* The other `public` methods do not take parameters.