### PR TITLE
Proxy\Http::__construct(): add input validation

### DIFF
--- a/src/Proxy/Http.php
+++ b/src/Proxy/Http.php
@@ -9,6 +9,7 @@
 namespace WpOrg\Requests\Proxy;
 
 use WpOrg\Requests\Exception\ArgumentCount;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Hooks;
 use WpOrg\Requests\Proxy;
 
@@ -55,11 +56,12 @@ final class Http implements Proxy {
 	 * Constructor
 	 *
 	 * @since 1.6
-	 * @since 2.0 Throws an `ArgumentCount` exception instead of the Requests base `Exception.
 	 *
-	 * @param array|null $args Array of proxy, user and password.
-	 *                         Must have exactly one (proxy) or three elements (proxy, user, password).
+	 * @param array|string|null $args Proxy as a string or an array of proxy, user and password.
+	 *                                When passed as an array, must have exactly one (proxy)
+	 *                                or three elements (proxy, user, password).
 	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not an array, a string or null.
 	 * @throws \WpOrg\Requests\Exception\ArgumentCount On incorrect number of arguments (`proxyhttpbadargs`)
 	 */
 	public function __construct($args = null) {
@@ -81,6 +83,8 @@ final class Http implements Proxy {
 					'proxyhttpbadargs'
 				);
 			}
+		} elseif ($args !== null) {
+			throw InvalidArgument::create(1, '$args', 'array|string|null', gettype($args));
 		}
 	}
 

--- a/tests/Proxy/HttpTest.php
+++ b/tests/Proxy/HttpTest.php
@@ -4,6 +4,7 @@ namespace WpOrg\Requests\Tests\Proxy;
 
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\ArgumentCount;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Proxy\Http;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
@@ -139,5 +140,17 @@ final class HttpTest extends TestCase {
 
 		$response = Requests::get(httpbin('/get'), array(), $options);
 		$this->assertSame(407, $response->status_code);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed to the Proxy\Http constructor.
+	 *
+	 * @covers \WpOrg\Requests\Proxy\Http::__construct
+	 */
+	public function testConstructorInvalidParameterType() {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($args) must be of type array|string|null');
+
+		new Http(false);
 	}
 }


### PR DESCRIPTION
The method already contains input validation, but would not notify the dev-user if no usable input was received.

This commit adds an `InvalidArgument` exception for that situation.

Includes test.

Includes improving the documentation for the `$args` parameter.


---

### Regarding the other `public` methods:

* The `register()` method already have a class based type declaration.
* The `curl_before_send()`, `fsockopen_remote_socket()`, `fsockopen_remote_host_path()` and `fsockopen_header()` methods are intended to be only called as a Hook callback.
* The other `public` methods do not take parameters.