### PR TITLE
Iri::__construct(): allow `$iri` to be stringable

### DIFF
--- a/src/Iri.php
+++ b/src/Iri.php
@@ -11,6 +11,7 @@ use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Ipv6;
 use WpOrg\Requests\Port;
+use WpOrg\Requests\Utility\InputValidator;
 
 /**
  * IRI parser/serialiser/normaliser
@@ -245,13 +246,13 @@ class Iri {
 	/**
 	 * Create a new IRI object, from a specified string
 	 *
-	 * @param string|null $iri
+	 * @param string|Stringable|null $iri
 	 *
-	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $iri argument is not a string nor null.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $iri argument is not a string, Stringable or null.
 	 */
 	public function __construct($iri = null) {
-		if ($iri !== null && is_string($iri) === false) {
-			throw InvalidArgument::create(1, '$iri', 'string|null', gettype($iri));
+		if ($iri !== null && InputValidator::is_string_or_stringable($iri) === false) {
+			throw InvalidArgument::create(1, '$iri', 'string|Stringable|null', gettype($iri));
 		}
 
 		$this->set_iri($iri);
@@ -732,6 +733,9 @@ class Iri {
 		if ($iri === null) {
 			return true;
 		}
+
+		$iri = (string) $iri;
+
 		if (isset($cache[$iri])) {
 			list($this->scheme,
 				 $this->iuserinfo,
@@ -744,7 +748,7 @@ class Iri {
 			return $return;
 		}
 
-		$parsed = $this->parse_iri((string) $iri);
+		$parsed = $this->parse_iri($iri);
 
 		$return = $this->set_scheme($parsed['scheme'])
 			&& $this->set_authority($parsed['authority'])

--- a/tests/IriTest.php
+++ b/tests/IriTest.php
@@ -42,6 +42,7 @@
 
 namespace WpOrg\Requests\Tests;
 
+use stdClass;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Tests\Fixtures\StringableObject;
@@ -417,6 +418,17 @@ final class IriTest extends TestCase
 	}
 
 	/**
+	 * Safeguard that the constructor can accept Stringable objects as $iri.
+	 *
+	 * @covers \WpOrg\Requests\Iri::__construct
+	 *
+	 * @return void
+	 */
+	public function testConstructorAcceptsStringableIri() {
+		$this->assertInstanceOf(Iri::class, new Iri(new StringableObject('https://example.com/')));
+	}
+
+	/**
 	 * Tests receiving an exception when an invalid input type is passed to the constructor.
 	 *
 	 * @dataProvider dataConstructorInvalidInput
@@ -429,7 +441,7 @@ final class IriTest extends TestCase
 	 */
 	public function testConstructorInvalidInput($iri) {
 		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($iri) must be of type string|null');
+		$this->expectExceptionMessage('Argument #1 ($iri) must be of type string|Stringable|null');
 
 		new Iri($iri);
 	}
@@ -441,9 +453,9 @@ final class IriTest extends TestCase
 	 */
 	public function dataConstructorInvalidInput() {
 		return array(
-			'boolean false'     => array(false),
-			'float'             => array(1.1),
-			'stringable object' => array(new StringableObject('value')),
+			'boolean false'         => array(false),
+			'float'                 => array(1.1),
+			'non-stringable object' => array(new stdClass('value')),
 		);
 	}
 }


### PR DESCRIPTION
Follow up on #602

As the `Iri::set_iri()` method does a string cast before parsing the URL, the constructor should also allow for Stringable objects. The only change needed is for the string cast to be moved up to before the cache check is done.

Includes additional test.