### PR TITLE
IdnaEncoder + Ipv6: minor tweaks for Stringable support

### DIFF
--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -54,7 +54,7 @@ class IdnaEncoder {
 	/**
 	 * Encode a hostname using Punycode
 	 *
-	 * @param string $hostname Hostname
+	 * @param string|Stringable $hostname Hostname
 	 * @return string Punycode-encoded hostname
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string or a stringable object.
 	 */

--- a/src/Ipv6.php
+++ b/src/Ipv6.php
@@ -35,7 +35,7 @@ final class Ipv6 {
 	 * @copyright 2003-2005 The PHP Group
 	 * @license https://opensource.org/licenses/bsd-license.php
 	 *
-	 * @param string $ip An IPv6 address
+	 * @param string|Stringable $ip An IPv6 address
 	 * @return string The uncompressed IPv6 address
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string or a stringable object.

--- a/tests/IdnaEncoderTest.php
+++ b/tests/IdnaEncoderTest.php
@@ -194,7 +194,7 @@ final class IdnaEncoderTest extends TestCase {
 	 */
 	public function testInvalidInputType($data) {
 		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($hostname) must be of type string');
+		$this->expectExceptionMessage('Argument #1 ($hostname) must be of type string|Stringable');
 
 		IdnaEncoder::encode($data);
 	}

--- a/tests/Ipv6Test.php
+++ b/tests/Ipv6Test.php
@@ -83,7 +83,7 @@ final class Ipv6Test extends TestCase {
 	 */
 	public function testUncompressInvalidInputType($ip) {
 		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($ip) must be of type string');
+		$this->expectExceptionMessage('Argument #1 ($ip) must be of type string|Stringable');
 
 		Ipv6::uncompress($ip);
 	}
@@ -100,7 +100,7 @@ final class Ipv6Test extends TestCase {
 	 */
 	public function testCompressInvalidInputType($ip) {
 		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($ip) must be of type string');
+		$this->expectExceptionMessage('Argument #1 ($ip) must be of type string|Stringable');
 
 		Ipv6::compress($ip);
 	}
@@ -117,7 +117,7 @@ final class Ipv6Test extends TestCase {
 	 */
 	public function testCheckIpv6InvalidInputType($ip) {
 		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($ip) must be of type string');
+		$this->expectExceptionMessage('Argument #1 ($ip) must be of type string|Stringable');
 
 		Ipv6::check_ipv6($ip);
 	}


### PR DESCRIPTION
Follow up on #592 and #601

Minor tweaks to make sure the docblocks and tests also mention the option to pass a Stringable object.

Both these classes already contain tests safeguarding that Stringable objects are handled correctly.