### PR TITLE
Ssl: safeguard support for Stringable objects

### DIFF
--- a/src/Ssl.php
+++ b/src/Ssl.php
@@ -26,7 +26,7 @@ final class Ssl {
 	 *
 	 * @link https://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
 	 *
-	 * @param string $host Host name to verify against
+	 * @param string|Stringable $host Host name to verify against
 	 * @param array $cert Certificate data from openssl_x509_parse()
 	 * @return bool
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $host argument is not a string or a stringable object.
@@ -91,7 +91,7 @@ final class Ssl {
 	 * character to be the full first component; that is, with the exclusion of
 	 * the third rule.
 	 *
-	 * @param string $reference Reference dNSName
+	 * @param string|Stringable $reference Reference dNSName
 	 * @return boolean Is the name valid?
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string or a stringable object.
 	 */
@@ -144,8 +144,8 @@ final class Ssl {
 	/**
 	 * Match a hostname against a dNSName reference
 	 *
-	 * @param string $host Requested host
-	 * @param string $reference dNSName to match against
+	 * @param string|Stringable $host Requested host
+	 * @param string|Stringable $reference dNSName to match against
 	 * @return boolean Does the domain match?
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When either of the passed arguments is not a string or a stringable object.
 	 */
@@ -160,7 +160,7 @@ final class Ssl {
 		}
 
 		// Check for a direct match
-		if ($host === $reference) {
+		if ((string) $host === (string) $reference) {
 			return true;
 		}
 
@@ -172,7 +172,7 @@ final class Ssl {
 			$parts    = explode('.', $host);
 			$parts[0] = '*';
 			$wildcard = implode('.', $parts);
-			if ($wildcard === $reference) {
+			if ($wildcard === (string) $reference) {
 				return true;
 			}
 		}

--- a/tests/SslTest.php
+++ b/tests/SslTest.php
@@ -5,6 +5,7 @@ namespace WpOrg\Requests\Tests;
 use stdClass;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Ssl;
+use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
 
 /**
@@ -57,9 +58,9 @@ final class SslTest extends TestCase {
 	 */
 	public function dataMatch() {
 		return array(
-			'top-level domain' => array(
-				'host'      => 'example.com',
-				'reference' => 'example.com',
+			'top-level domain (stringable object)' => array(
+				'host'      => new StringableObject('example.com'),
+				'reference' => new StringableObject('example.com'),
 			),
 			'subdomain' => array(
 				'host'      => 'test.example.com',
@@ -447,7 +448,7 @@ final class SslTest extends TestCase {
 				'expected'  => false,
 			),
 			'three parts, no wildcard' => array(
-				'reference' => 'www.example.com',
+				'reference' => new StringableObject('www.example.com'),
 				'expected'  => true,
 			),
 			'three parts, no wildcard, has spaces' => array(


### PR DESCRIPTION
Follow up on #572

Minor tweaks to make sure the docblocks also mention the option to pass a Stringable object and that the `Ssl::match()` method actually supports Stringable objects.

Includes adjusting a few existing tests to pass the input as Stringable objects instead of as plain strings to safeguard full Stringable support.