### PR TITLE
Requests: remove duplicate `match_domain()` method

### DIFF
--- a/src/Requests.php
+++ b/src/Requests.php
@@ -1036,25 +1036,4 @@ class Requests {
 
 		return false;
 	}
-
-	public static function match_domain($host, $reference) {
-		// Check for a direct match
-		if ($host === $reference) {
-			return true;
-		}
-
-		// Calculate the valid wildcard match if the host is not an IP address
-		// Also validates that the host has 3 parts or more, as per Firefox's
-		// ruleset.
-		$parts = explode('.', $host);
-		if (ip2long($host) === false && count($parts) >= 3) {
-			$parts[0] = '*';
-			$wildcard = implode('.', $parts);
-			if ($wildcard === $reference) {
-				return true;
-			}
-		}
-
-		return false;
-	}
 }


### PR DESCRIPTION
This method was "moved" to the `SSL` class in 2013 via 0c2fe6e24e7ec34117b3bbd3d227046920c92c86 and is publicly accessible in that class. The method within the `Requests` class is never called from within the Requests code base and shouldn't exist.