### PR TITLE
CS/Docs: various minor fixes

### DIFF
--- a/build/ghpages/UpdateMarkdown.php
+++ b/build/ghpages/UpdateMarkdown.php
@@ -6,8 +6,7 @@
  *
  * @internal
  *
- * @package Requests
- * @subpackage GHPages
+ * @package Requests\GHPages
  *
  * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.stringFound
  * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.intFound

--- a/build/ghpages/UpdateMarkdown.php
+++ b/build/ghpages/UpdateMarkdown.php
@@ -193,6 +193,8 @@ title: %s
 	 * Transform all docs in the `docs` directory for use in GH Pages.
 	 *
 	 * @return void
+	 *
+	 * @throws \RuntimeException When no markdown files are found in the docs directory.
 	 */
 	private function update_docs(): void {
 		// Create the file list.
@@ -225,6 +227,8 @@ title: %s
 	 * @param string $target Path to the output file.
 	 *
 	 * @return void
+	 *
+	 * @throws \RuntimeException When the page title could not be found in the contents of a markdown file.
 	 */
 	private function update_doc(string $source, string $target): void {
 		// Read the file.
@@ -252,6 +256,8 @@ title: %s
 	 * @param string $source Path to the source file.
 	 *
 	 * @return void
+	 *
+	 * @throws \RuntimeException When index page could not be split correctly into index and navigation.
 	 */
 	private function update_docs_navigation(string $source): void {
 		// Read the file.
@@ -301,6 +307,8 @@ title: %s
 	 * @param string $source Path to the source file.
 	 *
 	 * @return string
+	 *
+	 * @throws \RuntimeException When the contents of the file could not be retrieved.
 	 */
 	private function get_contents(string $source): string {
 		$contents = file_get_contents($source);
@@ -319,6 +327,9 @@ title: %s
 	 * @param string $type     Type of file to use in error message.
 	 *
 	 * @return string
+	 *
+	 * @throws \RuntimeException When the target directory could not be created.
+	 * @throws \RuntimeException When the file could not be written to the target directory.
 	 */
 	private function put_contents(string $target, string $contents, string $type = 'doc file'): void {
 		// Check if the target directory exists and if not, create it.

--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -89,10 +89,10 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Set the given item
 	 *
-	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`)
-	 *
 	 * @param string $offset Item name
 	 * @param string $value Item value
+	 *
+	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`)
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetSet($offset, $value) {

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -73,13 +73,13 @@ class IdnaEncoder {
 	/**
 	 * Convert a UTF-8 text string to an ASCII string using Punycode
 	 *
+	 * @param string $text ASCII or UTF-8 string (max length 64 characters)
+	 * @return string ASCII string
+	 *
 	 * @throws \WpOrg\Requests\Exception Provided string longer than 64 ASCII characters (`idna.provided_too_long`)
 	 * @throws \WpOrg\Requests\Exception Prepared string longer than 64 ASCII characters (`idna.prepared_too_long`)
 	 * @throws \WpOrg\Requests\Exception Provided string already begins with xn-- (`idna.provided_is_prefixed`)
 	 * @throws \WpOrg\Requests\Exception Encoded string longer than 64 ASCII characters (`idna.encoded_too_long`)
-	 *
-	 * @param string $text ASCII or UTF-8 string (max length 64 characters)
-	 * @return string ASCII string
 	 */
 	public static function to_ascii($text) {
 		// Step 1: Check if the text is already ASCII
@@ -159,9 +159,10 @@ class IdnaEncoder {
 	 *
 	 * Based on \WpOrg\Requests\Iri::replace_invalid_with_pct_encoding()
 	 *
-	 * @throws \WpOrg\Requests\Exception Invalid UTF-8 codepoint (`idna.invalidcodepoint`)
 	 * @param string $input
 	 * @return array Unicode code points
+	 *
+	 * @throws \WpOrg\Requests\Exception Invalid UTF-8 codepoint (`idna.invalidcodepoint`)
 	 */
 	protected static function utf8_to_codepoints($input) {
 		$codepoints = array();
@@ -249,10 +250,11 @@ class IdnaEncoder {
 	 * RFC3492-compliant encoder
 	 *
 	 * @internal Pseudo-code from Section 6.3 is commented with "#" next to relevant code
-	 * @throws \WpOrg\Requests\Exception On character outside of the domain (never happens with Punycode) (`idna.character_outside_domain`)
 	 *
 	 * @param string $input UTF-8 encoded string to encode
 	 * @return string Punycode-encoded string
+	 *
+	 * @throws \WpOrg\Requests\Exception On character outside of the domain (never happens with Punycode) (`idna.character_outside_domain`)
 	 */
 	public static function punycode_encode($input) {
 		$output = '';
@@ -361,10 +363,11 @@ class IdnaEncoder {
 	 * Convert a digit to its respective character
 	 *
 	 * @link https://tools.ietf.org/html/rfc3492#section-5
-	 * @throws \WpOrg\Requests\Exception On invalid digit (`idna.invalid_digit`)
 	 *
 	 * @param int $digit Digit in the range 0-35
 	 * @return string Single character corresponding to digit
+	 *
+	 * @throws \WpOrg\Requests\Exception On invalid digit (`idna.invalid_digit`)
 	 */
 	protected static function digit_to_char($digit) {
 		// @codeCoverageIgnoreStart

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -623,6 +623,8 @@ class Requests {
 	 * @param string $type HTTP request type
 	 * @param array $options Options for the request
 	 * @return void $options is updated with the results
+	 *
+	 * @throws \WpOrg\Requests\Exception When the $url is not an http(s) URL.
 	 */
 	protected static function set_defaults(&$url, &$headers, &$data, &$type, &$options) {
 		if (!preg_match('/^http(s)?:\/\//i', $url, $matches)) {

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -45,10 +45,10 @@ class Headers extends CaseInsensitiveDictionary {
 	/**
 	 * Set the given item
 	 *
-	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`)
-	 *
 	 * @param string $offset Item name
 	 * @param string $value Item value
+	 *
+	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`)
 	 */
 	public function offsetSet($offset, $value) {
 		if ($offset === null) {

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -130,13 +130,14 @@ final class Curl implements Transport {
 	/**
 	 * Perform a request
 	 *
-	 * @throws \WpOrg\Requests\Exception On a cURL error (`curlerror`)
-	 *
 	 * @param string $url URL to request
 	 * @param array $headers Associative array of request headers
 	 * @param string|array $data Data to send either as the POST body, or as parameters in the URL for a GET/HEAD
 	 * @param array $options Request options, see {@see \WpOrg\Requests\Requests::response()} for documentation
 	 * @return string Raw HTTP result
+	 *
+	 * @throws \WpOrg\Requests\InvalidArgument When the $data parameter is not an array or string.
+	 * @throws \WpOrg\Requests\Exception       On a cURL error (`curlerror`)
 	 */
 	public function request($url, $headers = array(), $data = array(), $options = array()) {
 		if (!is_array($data) && !is_string($data)) {

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -55,14 +55,15 @@ final class Fsockopen implements Transport {
 	/**
 	 * Perform a request
 	 *
-	 * @throws \WpOrg\Requests\Exception On failure to connect to socket (`fsockopenerror`)
-	 * @throws \WpOrg\Requests\Exception On socket timeout (`timeout`)
-	 *
 	 * @param string $url URL to request
 	 * @param array $headers Associative array of request headers
 	 * @param string|array $data Data to send either as the POST body, or as parameters in the URL for a GET/HEAD
 	 * @param array $options Request options, see {@see \WpOrg\Requests\Requests::response()} for documentation
 	 * @return string Raw HTTP result
+	 *
+	 * @throws \WpOrg\Requests\InvalidArgument When the $data parameter is not an array or string.
+	 * @throws \WpOrg\Requests\Exception       On failure to connect to socket (`fsockopenerror`)
+	 * @throws \WpOrg\Requests\Exception       On socket timeout (`timeout`)
 	 */
 	public function request($url, $headers = array(), $data = array(), $options = array()) {
 		if (!is_array($data) && !is_string($data)) {

--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -74,10 +74,10 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Set the given item
 	 *
-	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`)
-	 *
 	 * @param string $offset Item name
 	 * @param string $value Item value
+	 *
+	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`)
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetSet($offset, $value) {

--- a/tests/AutoloadTest.php
+++ b/tests/AutoloadTest.php
@@ -28,7 +28,7 @@ final class AutoloadTest extends TestCase {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(self::MSG);
 
-		$var = Requests_Exception_Transport_cURL::EASY;
+		echo Requests_Exception_Transport_cURL::EASY;
 	}
 
 	/**

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -239,7 +239,7 @@ abstract class BaseTestCase extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #3 ($data) must be of type array|string');
 
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+		Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
 	}
 
 	/**


### PR DESCRIPTION
### CS: minor tweaks

* Don't declare variables which won't be used.

### Docs: @throws tags consistency

* Make sure the docblocks for all functions which throw exceptions contain a `@throws` tag.
* Consistently place the `@throws` tag _after_ the `@return` tag.

### Docs: minor tweaks

Fix up another `@package` tag for consistency (file will not be listed in the generated docs).