### PR TITLE
Session: add input validation

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -8,8 +8,10 @@
 namespace WpOrg\Requests;
 
 use WpOrg\Requests\Cookie\Jar;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Requests;
+use WpOrg\Requests\Utility\InputValidator;
 
 /**
  * Session handler for persistent requests and default parameters
@@ -64,12 +66,33 @@ class Session {
 	/**
 	 * Create a new session
 	 *
-	 * @param string|null $url Base URL for requests
+	 * @param string|Stringable|null $url Base URL for requests
 	 * @param array $headers Default headers for requests
 	 * @param array $data Default data for requests
 	 * @param array $options Default options for requests
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $url argument is not a string, Stringable or null.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $headers argument is not an array.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $data argument is not an array.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 */
 	public function __construct($url = null, $headers = array(), $data = array(), $options = array()) {
+		if ($url !== null && InputValidator::is_string_or_stringable($url) === false) {
+			throw InvalidArgument::create(1, '$url', 'string|Stringable|null', gettype($url));
+		}
+
+		if (is_array($headers) === false) {
+			throw InvalidArgument::create(2, '$headers', 'array', gettype($headers));
+		}
+
+		if (is_array($data) === false) {
+			throw InvalidArgument::create(3, '$data', 'array', gettype($data));
+		}
+
+		if (is_array($options) === false) {
+			throw InvalidArgument::create(4, '$options', 'array', gettype($options));
+		}
+
 		$this->url     = $url;
 		$this->headers = $headers;
 		$this->data    = $data;

--- a/src/Session.php
+++ b/src/Session.php
@@ -292,7 +292,7 @@ class Session {
 			$request['data'] = array_merge($this->data, $request['data']);
 		}
 
-		if ($merge_options !== false) {
+		if ($merge_options === true) {
 			$request['options'] = array_merge($this->options, $request['options']);
 
 			// Disallow forcing the type, as that's a per request setting

--- a/src/Session.php
+++ b/src/Session.php
@@ -240,8 +240,19 @@ class Session {
 	 * @param array $requests Requests data (see {@see \WpOrg\Requests\Requests::request_multiple()})
 	 * @param array $options Global and default options (see {@see \WpOrg\Requests\Requests::request()})
 	 * @return array Responses (either \WpOrg\Requests\Response or a \WpOrg\Requests\Exception object)
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $requests argument is not an array or iterable object with array access.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 */
 	public function request_multiple($requests, $options = array()) {
+		if (InputValidator::has_array_access($requests) === false || InputValidator::is_iterable($requests) === false) {
+			throw InvalidArgument::create(1, '$requests', 'array|ArrayAccess&Traversable', gettype($requests));
+		}
+
+		if (is_array($options) === false) {
+			throw InvalidArgument::create(2, '$options', 'array', gettype($options));
+		}
+
 		foreach ($requests as $key => $request) {
 			$requests[$key] = $this->merge_request($request, false);
 		}

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -2,6 +2,7 @@
 
 namespace WpOrg\Requests\Tests;
 
+use EmptyIterator;
 use stdClass;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
@@ -340,6 +341,58 @@ final class SessionTest extends TestCase {
 		$this->expectExceptionMessage('Argument #4 ($options) must be of type array');
 
 		new Session('/', array(), array(), $input);
+	}
+
+	/**
+	 * Tests receiving an exception when the request_multiple() method received an invalid input type as `$requests`.
+	 *
+	 * @dataProvider dataRequestMultipleInvalidRequests
+	 *
+	 * @covers \WpOrg\Requests\Session::request_multiple
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testRequestMultipleInvalidRequests($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($requests) must be of type array|ArrayAccess&Traversable');
+
+		$session = new Session();
+		$session->request_multiple($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataRequestMultipleInvalidRequests() {
+		return array(
+			'null'                                 => array(null),
+			'text string'                          => array('array'),
+			'iterator object without array access' => array(new EmptyIterator()),
+			'array accessible object not iterable' => array(new ArrayAccessibleObject(array(1, 2, 3))),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when the request_multiple() method received an invalid input type as `$option`.
+	 *
+	 * @dataProvider dataInvalidTypeNotArray
+	 *
+	 * @covers \WpOrg\Requests\Session::request_multiple
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testRequestMultipleInvalidOptions($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #2 ($options) must be of type array');
+
+		$session = new Session();
+		$session->request_multiple(array(), $input);
 	}
 
 	/**

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -2,8 +2,12 @@
 
 namespace WpOrg\Requests\Tests;
 
+use stdClass;
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Iri;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Session;
+use WpOrg\Requests\Tests\Fixtures\ArrayAccessibleObject;
 use WpOrg\Requests\Tests\TestCase;
 
 final class SessionTest extends TestCase {
@@ -223,5 +227,131 @@ final class SessionTest extends TestCase {
 			'requests-testcookie' => 'testvalue',
 		);
 		$this->assertSame($cookies, $data['cookies']);
+	}
+
+	/**
+	 * Tests that valid input for the $url parameter for a new Session object is handled correctly.
+	 *
+	 * @dataProvider dataConstructorValidUrl
+	 *
+	 * @covers \WpOrg\Requests\Session::__construct
+	 *
+	 * @param mixed $input Valid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorValidUrl($input) {
+		$this->assertInstanceOf(Session::class, new Session($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataConstructorValidUrl() {
+		return array(
+			'null'              => array(null),
+			'string'            => array(httpbin('/')),
+			'stringable object' => array(new Iri(httpbin('/'))),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when the constructor received an invalid input type as `$url`.
+	 *
+	 * @dataProvider dataConstructorInvalidUrl
+	 *
+	 * @covers \WpOrg\Requests\Session::__construct
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidUrl($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($url) must be of type string|Stringable|null');
+
+		new Session($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataConstructorInvalidUrl() {
+		return array(
+			'boolean false'         => array(false),
+			'array'                 => array(array(httpbin('/'))),
+			'non-stringable object' => array(new stdClass('name')),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when the constructor received an invalid input type as `$headers`.
+	 *
+	 * @dataProvider dataInvalidTypeNotArray
+	 *
+	 * @covers \WpOrg\Requests\Session::__construct
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidHeaders($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #2 ($headers) must be of type array');
+
+		new Session(null, $input);
+	}
+
+	/**
+	 * Tests receiving an exception when the constructor received an invalid input type as `$data`.
+	 *
+	 * @dataProvider dataInvalidTypeNotArray
+	 *
+	 * @covers \WpOrg\Requests\Session::__construct
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidData($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #3 ($data) must be of type array');
+
+		new Session('/', array(), $input);
+	}
+
+	/**
+	 * Tests receiving an exception when the constructor received an invalid input type as `$options`.
+	 *
+	 * @dataProvider dataInvalidTypeNotArray
+	 *
+	 * @covers \WpOrg\Requests\Session::__construct
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testConstructorInvalidOptions($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #4 ($options) must be of type array');
+
+		new Session('/', array(), array(), $input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidTypeNotArray() {
+		return array(
+			'null'                    => array(null),
+			'boolean false'           => array(false),
+			'array accessible object' => array(new ArrayAccessibleObject(array())),
+		);
 	}
 }


### PR DESCRIPTION
### Session::__construct(): add input validation

This commit adds input validation for all parameters of the `Session::__construct()` method:
* For `$url`, `null`, strings and Stringable (`Iri`) objects should be accepted as the `Iri::absolutize()` method also allows for .
* For the `$headers`, $data` and `$options` parameters, only plain arrays can be accepted due to the use of `array_merge()` in the `Session::merge_request()` method.

Includes tests for these new exceptions.

### Session::request_multiple(): add input validation

This commit adds input validation for all parameters of the `Session::request_multiple()` method:
* For `$requests`, arrays and iterable objects with array access should be accepted based on how the parameter is used within this class.
* For the `$options` parameter, only plain arrays can be accepted due to the use of `array_merge()` in the method.

Includes tests for these new exceptions.

### Session::merge_request(): improve a condition

The default value for the `$merge_options` parameter is `true`, but the condition in which the parameter is used was doing a strict comparison against `false`, which could lead to undesirable effects if `$merge_options` was passed incorrectly.

By changing the condition to do a strict comparison against the `true` default value, this issue is fixed and no additional input validation needs to be added for the `$merge_options` parameter.

Notes:
As for the `$request` parameter, I'd recommend that - at a later point in time -, stricter checks will be put in place in the `merge_requests()` method to validate that the sub-keys which are expected are of a usable type (and value) as this method is basically used as a form of input validation for the input received in the `Session::request()` and `Session::request_multiple()` methods.


---

### Regarding the other `public` methods:

* The `public` magic methods should not need input validation as they should not be called directly, but only indirectly and when called that way, will receive the correct input type.
* The `get()`, `head()` etc methods don't need input validation as they will fall through to the `Session::request()` method.
* The `request()` method itself will do some cursory input validation via the `Session::merge_request()` method, but other than that will just pass the parameter through to the `Requests::request()` method. The input validation for that method should suffice. (to be added)
* Regarding the `merge_request()` method: this is "sort of" an input validation method, but can use improvement in a future iteration. See my remarks above.