### PR TITLE
Requests: add input validation

### DIFF
--- a/src/Requests.php
+++ b/src/Requests.php
@@ -900,8 +900,14 @@ class Requests {
 	 *
 	 * @param string $data Compressed data in one of the above formats
 	 * @return string Decompressed string
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string.
 	 */
 	public static function decompress($data) {
+		if (is_string($data) === false) {
+			throw InvalidArgument::create(1, '$data', 'string', gettype($data));
+		}
+
 		if (trim($data) === '') {
 			// Empty body does not need further processing.
 			return $data;
@@ -961,8 +967,14 @@ class Requests {
 	 *
 	 * @param string $gz_data String to decompress.
 	 * @return string|bool False on failure.
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string.
 	 */
 	public static function compatible_gzinflate($gz_data) {
+		if (is_string($gz_data) === false) {
+			throw InvalidArgument::create(1, '$gz_data', 'string', gettype($gz_data));
+		}
+
 		if (trim($gz_data) === '') {
 			return false;
 		}

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -15,6 +15,7 @@ use WpOrg\Requests\Auth\Basic;
 use WpOrg\Requests\Capability;
 use WpOrg\Requests\Cookie\Jar;
 use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Hooks;
 use WpOrg\Requests\IdnaEncoder;
 use WpOrg\Requests\Iri;
@@ -22,6 +23,7 @@ use WpOrg\Requests\Proxy\Http;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Transport\Curl;
 use WpOrg\Requests\Transport\Fsockopen;
+use WpOrg\Requests\Utility\InputValidator;
 
 /**
  * Requests for PHP
@@ -428,16 +430,31 @@ class Requests {
 	 *    (string, one of 'query' or 'body', default: 'query' for
 	 *    HEAD/GET/DELETE, 'body' for POST/PUT/OPTIONS/PATCH)
 	 *
-	 * @throws \WpOrg\Requests\Exception On invalid URLs (`nonhttp`)
-	 *
-	 * @param string $url URL to request
+	 * @param string|Stringable $url URL to request
 	 * @param array $headers Extra headers to send with the request
 	 * @param array|null $data Data to send either as a query string for GET/HEAD requests, or in the body for POST requests
 	 * @param string $type HTTP request type (use Requests constants)
 	 * @param array $options Options for the request (see description for more information)
 	 * @return \WpOrg\Requests\Response
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $url argument is not a string or Stringable.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $type argument is not a string.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
+	 * @throws \WpOrg\Requests\Exception On invalid URLs (`nonhttp`)
 	 */
 	public static function request($url, $headers = array(), $data = array(), $type = self::GET, $options = array()) {
+		if (InputValidator::is_string_or_stringable($url) === false) {
+			throw InvalidArgument::create(1, '$url', 'string|Stringable', gettype($url));
+		}
+
+		if (is_string($type) === false) {
+			throw InvalidArgument::create(4, '$type', 'string', gettype($type));
+		}
+
+		if (is_array($options) === false) {
+			throw InvalidArgument::create(5, '$options', 'array', gettype($options));
+		}
+
 		if (empty($options['type'])) {
 			$options['type'] = $type;
 		}

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -231,7 +231,7 @@ class Requests {
 	 * @return string FQCN of the transport to use, or an empty string if no transport was
 	 *                found which provided the requested capabilities.
 	 */
-	protected static function get_transport_class($capabilities = array()) {
+	protected static function get_transport_class(array $capabilities = array()) {
 		// Caching code, don't bother testing coverage.
 		// @codeCoverageIgnoreStart
 		// Array of capabilities as a string to be used as an array key.
@@ -274,7 +274,7 @@ class Requests {
 	 * @return \WpOrg\Requests\Transport
 	 * @throws \WpOrg\Requests\Exception If no valid transport is found (`notransport`).
 	 */
-	protected static function get_transport($capabilities = array()) {
+	protected static function get_transport(array $capabilities = array()) {
 		$class = self::get_transport_class($capabilities);
 
 		if ($class === '') {
@@ -296,7 +296,7 @@ class Requests {
 	 * @param array<string, bool> $capabilities Optional. Associative array of capabilities to test against, i.e. `['<capability>' => true]`.
 	 * @return bool Whether the transport has the requested capabilities.
 	 */
-	public static function has_capabilities($capabilities = array()) {
+	public static function has_capabilities(array $capabilities = array()) {
 		return self::get_transport_class($capabilities) !== '';
 	}
 

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -875,10 +875,16 @@ class Requests {
 	/**
 	 * Convert a key => value array to a 'key: value' array for headers
 	 *
-	 * @param array $dictionary Dictionary of header values
+	 * @param iterable $dictionary Dictionary of header values
 	 * @return array List of headers
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not iterable.
 	 */
 	public static function flatten($dictionary) {
+		if (InputValidator::is_iterable($dictionary) === false) {
+			throw InvalidArgument::create(1, '$dictionary', 'iterable', gettype($dictionary));
+		}
+
 		$return = array();
 		foreach ($dictionary as $key => $value) {
 			$return[] = sprintf('%s: %s', $key, $value);

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -100,17 +100,6 @@ class Requests {
 	const BUFFER_SIZE = 1160;
 
 	/**
-	 * Default certificate path.
-	 *
-	 * @see \WpOrg\Requests\Requests::get_certificate_path()
-	 *
-	 * @since 2.0.0
-	 *
-	 * @var string
-	 */
-	const DEFAULT_CERT_PATH = __DIR__ . '/../certificates/cacert.pem';
-
-	/**
 	 * Option defaults.
 	 *
 	 * @see \WpOrg\Requests\Requests::get_default_options()
@@ -185,7 +174,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-	protected static $certificate_path;
+	protected static $certificate_path = __DIR__ . '/../certificates/cacert.pem';
 
 	/**
 	 * All (known) valid deflate, gzip header magic markers.
@@ -612,7 +601,7 @@ class Requests {
 	 */
 	protected static function get_default_options($multirequest = false) {
 		$defaults           = static::OPTION_DEFAULTS;
-		$defaults['verify'] = self::get_certificate_path();
+		$defaults['verify'] = self::$certificate_path;
 
 		if ($multirequest !== false) {
 			$defaults['complete'] = null;
@@ -626,19 +615,21 @@ class Requests {
 	 * @return string Default certificate path.
 	 */
 	public static function get_certificate_path() {
-		if (!empty(self::$certificate_path)) {
-			return self::$certificate_path;
-		}
-
-		return self::DEFAULT_CERT_PATH;
+		return self::$certificate_path;
 	}
 
 	/**
 	 * Set default certificate path.
 	 *
-	 * @param string $path Certificate path, pointing to a PEM file.
+	 * @param string|Stringable|bool $path Certificate path, pointing to a PEM file.
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $url argument is not a string, Stringable or boolean.
 	 */
 	public static function set_certificate_path($path) {
+		if (InputValidator::is_string_or_stringable($path) === false && is_bool($path) === false) {
+			throw InvalidArgument::create(1, '$path', 'string|Stringable|bool', gettype($path));
+		}
+
 		self::$certificate_path = $path;
 	}
 

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -523,8 +523,19 @@ class Requests {
 	 * @param array $requests Requests data (see description for more information)
 	 * @param array $options Global and default options (see {@see \WpOrg\Requests\Requests::request()})
 	 * @return array Responses (either \WpOrg\Requests\Response or a \WpOrg\Requests\Exception object)
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $requests argument is not an array or iterable object with array access.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 */
 	public static function request_multiple($requests, $options = array()) {
+		if (InputValidator::has_array_access($requests) === false || InputValidator::is_iterable($requests) === false) {
+			throw InvalidArgument::create(1, '$requests', 'array|ArrayAccess&Traversable', gettype($requests));
+		}
+
+		if (is_array($options) === false) {
+			throw InvalidArgument::create(2, '$options', 'array', gettype($options));
+		}
+
 		$options = array_merge(self::get_default_options(true), $options);
 
 		if (!empty($options['hooks'])) {

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -2,7 +2,9 @@
 
 namespace WpOrg\Requests\Tests\Requests;
 
+use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Requests;
+use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
 
 final class DecompressionTest extends TestCase {
@@ -186,6 +188,54 @@ final class DecompressionTest extends TestCase {
 				'compressed' => "\x78\xda\x4b\xce\xcf\x2d\x28\x4a\x2d\x2e\xce\xcc\xcf\x53\xc8\x49"
 							. "\x2d\x4b\xcd\x51\xb0\x04\x00\x4d\x8e\x07\x44",
 			),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed.
+	 *
+	 * @covers \WpOrg\Requests\Requests::decompress
+	 *
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $input Input data.
+	 *
+	 * @return void
+	 */
+	public function testDecompressInvalidInputType($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($data) must be of type string');
+
+		Requests::decompress($input);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed.
+	 *
+	 * @covers \WpOrg\Requests\Requests::compatible_gzinflate
+	 *
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $input Input data.
+	 *
+	 * @return void
+	 */
+	public function testCompatibleGzinflateInvalidInputType($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($gz_data) must be of type string');
+
+		Requests::compatible_gzinflate($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputType() {
+		return array(
+			'null'              => array(null),
+			'stringable object' => array(new StringableObject('value')),
 		);
 	}
 }

--- a/tests/RequestsTest.php
+++ b/tests/RequestsTest.php
@@ -2,6 +2,7 @@
 
 namespace WpOrg\Requests\Tests;
 
+use ArrayIterator;
 use EmptyIterator;
 use ReflectionProperty;
 use stdClass;
@@ -403,6 +404,70 @@ final class RequestsTest extends TestCase {
 		return array(
 			'null'                  => array(null),
 			'non-stringable object' => array(new stdClass('value')),
+		);
+	}
+
+	/**
+	 * Tests flattening of data arrays.
+	 *
+	 * @dataProvider dataFlattenValidData
+	 *
+	 * @covers \WpOrg\Requests\Requests::flatten
+	 *
+	 * @param mixed $input Valid input.
+	 *
+	 * @return void
+	 */
+	public function testFlattenValidData($input) {
+		$expected = array(
+			0 => 'key1: value1',
+			1 => 'key2: value2',
+		);
+
+		$this->assertSame($expected, Requests::flatten($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataFlattenValidData() {
+		$to_flatten = array('key1' => 'value1', 'key2' => 'value2');
+
+		return array(
+			'array'           => array($to_flatten),
+			'iterable object' => array(new ArrayIterator($to_flatten)),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed as `$dictionary` to the flatten() method.
+	 *
+	 * @dataProvider dataFlattenInvalidData
+	 *
+	 * @covers \WpOrg\Requests\Requests::flatten
+	 *
+	 * @param mixed $input Invalid input.
+	 *
+	 * @return void
+	 */
+	public function testFlattenInvalidData($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($dictionary) must be of type iterable');
+
+		Requests::flatten($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataFlattenInvalidData() {
+		return array(
+			'null'                                 => array(null),
+			'array accessible object not iterable' => array(new ArrayAccessibleObject(array(1, 2, 3))),
 		);
 	}
 }

--- a/tests/RequestsTest.php
+++ b/tests/RequestsTest.php
@@ -344,4 +344,65 @@ final class RequestsTest extends TestCase {
 
 		$this->assertFalse($result);
 	}
+
+	/**
+	 * Tests setting a custom certificate path with valid data types (though potentially not a valid path).
+	 *
+	 * @dataProvider dataSetCertificatePathValidData
+	 *
+	 * @covers \WpOrg\Requests\Requests::set_certificate_path
+	 *
+	 * @param mixed $input Valid input.
+	 *
+	 * @return void
+	 */
+	public function testSetCertificatePathValidData($input) {
+		Requests::set_certificate_path($input);
+
+		$this->assertSame($input, Requests::get_certificate_path());
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataSetCertificatePathValidData() {
+		return array(
+			'boolean false'     => array(false),
+			'boolean true'      => array(true),
+			'string'            => array('path/to/file.pem'),
+			'stringable object' => array(new StringableObject('path/to/file.pem')),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed as `$path` to the set_certificate_path() method.
+	 *
+	 * @dataProvider dataSetCertificatePathInvalidData
+	 *
+	 * @covers \WpOrg\Requests\Requests::set_certificate_path
+	 *
+	 * @param mixed $input Invalid input.
+	 *
+	 * @return void
+	 */
+	public function testSetCertificatePathInvalidData($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($path) must be of type string|Stringable|bool');
+
+		Requests::set_certificate_path($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataSetCertificatePathInvalidData() {
+		return array(
+			'null'                  => array(null),
+			'non-stringable object' => array(new stdClass('value')),
+		);
+	}
 }

--- a/tests/RequestsTest.php
+++ b/tests/RequestsTest.php
@@ -2,6 +2,7 @@
 
 namespace WpOrg\Requests\Tests;
 
+use EmptyIterator;
 use ReflectionProperty;
 use stdClass;
 use WpOrg\Requests\Capability;
@@ -95,6 +96,56 @@ final class RequestsTest extends TestCase {
 		$this->expectExceptionMessage('Argument #5 ($options) must be of type array');
 
 		Requests::request('/', array(), array(), Requests::GET, $input);
+	}
+
+	/**
+	 * Tests receiving an exception when the request_multiple() method received an invalid input type as `$requests`.
+	 *
+	 * @dataProvider dataRequestMultipleInvalidRequests
+	 *
+	 * @covers \WpOrg\Requests\Requests::request_multiple
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testRequestMultipleInvalidRequests($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($requests) must be of type array|ArrayAccess&Traversable');
+
+		Requests::request_multiple($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataRequestMultipleInvalidRequests() {
+		return array(
+			'null'                                 => array(null),
+			'text string'                          => array('array'),
+			'iterator object without array access' => array(new EmptyIterator()),
+			'array accessible object not iterable' => array(new ArrayAccessibleObject(array(1, 2, 3))),
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when the request_multiple() method received an invalid input type as `$option`.
+	 *
+	 * @dataProvider dataInvalidTypeNotArray
+	 *
+	 * @covers \WpOrg\Requests\Requests::request_multiple
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testRequestMultipleInvalidOptions($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #2 ($options) must be of type array');
+
+		Requests::request_multiple(array(), $input);
 	}
 
 	/**


### PR DESCRIPTION
### Requests::get_transport[_class]/has_capabilities(): add type declaration

Follow up on #492

The new `Requests::get_transport_class()` and `Requests::has_capabilities()` can safely be given a type declaration as they are new in Requests 2.0.0 and as the `Requests::get_transport()` method is a protected method, we may as well add it there too.

### Requests::request(): add input validation

This adds input validation to the `Requests::request()` method and all direct "fall-through" methods calling this method.

* The `$url` parameter is validated to allow for a string or Stringable (Iri) object.
* The `$type` parameter is validated to allow solely for a string as it expects one of the `Requests` class constants.
* The `$options` parameter is validated to allow only an array as the parameter is used with `array_merge()`.

The `$headers` and `$data` parameters remain unvalidated as they are not actually used within the method itself, but only passed through and should be validated in the `Transport::request()` method instead.

Includes adding perfunctory tests for the new exceptions + adjusting one existing test to ensure that passing the `$url` as a stringable object is safeguarded.

### Requests::request_multiple(): add input validation

This commit adds input validation for all parameters of the `Requests::request_multiple()` method:
* For `$requests`, arrays and iterable objects with array access should be accepted based on how the parameter is used within this class.
* For the `$options` parameter, only plain arrays can be accepted due to the use of `array_merge()` in the method.

Includes tests for these new exceptions.

Includes adding perfunctory tests for the new exceptions.

### Request::set_certificate_path(): add input validation

Based on the documentation for the `Requests::request()` method, the `$options['verify']` allows for a string path or a boolean value, so let's allow the same for the `Requests:;set_certificate_path()` method (and include Stringable as well).

Includes perfunctory tests for the exception + for actually setting the path with valid input.

Includes:
* Removing the `DEFAULT_CERT_PATH` constant (not a BC-break as the constant was only introduced in 2.0.0-dev) and adding the default value to the `$certificate_path`.
* Simplifying the `get_certificate_path()` method.
* And using the `Requests::$certificate_path` property directly in the `get_default_options()` method as `get_certificate_path()` now no longer contains logic.

### Requests::flatten(): add input validation

While the documented parameter type for the `$dictionary` parameter was `array`, in reality, the only real requirement is that the parameter is iterable, so adding input validation to match the real requirement.

Includes adding perfunctory tests for the new exception + for the method itself which was otherwise untested.

### Requests::decompress()/compatible_gzinflate(): add input validation

The documented accepted parameter type for both these methods is `string`, but no input validation was done on the parameter, which could lead to various PHP errors, most notably a "passing null to non-nullable" deprecation notice on PHP 8.1.

This commit adds input validation to the `Requests::decompress()` and the `Requests::compatible_gzinflate()` methods, allowing only for strings.
Note: Stringable objects will not be considered as valid input for these methods.

Includes adding perfunctory tests for the new exceptions.


---

### Regarding the other `public` methods:

* The `add_transport()` method expects a class name as a string, where the class implements the `Transport` interface. Checking this, however, isn't really an option without also (auto-)loading the class.
    As this is a user-selected overwrite, let's just defer to the error PHP will throw when the class will be instantiated and cannot be found.
* The `get()`, `head()` etc methods don't need input validation as they will fall through to the `Requests::request()` method for which (partial) input validation has been added.
* The `get_default_options()` method only uses the parameter in one condition and does a hard check against the default value, so doesn't need further input validation.
* The `set_defaults()` method is `protected`. While it could definitely use improvement, that's outside the scope of this PR.
* The `parse_multiple()` method is `public`, but only intended for internal use.