### PR TITLE
CS: use short arrays

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -101,6 +101,9 @@
 			 Universal.ControlStructures.IfElseDeclaration sniff from PHPCSExtra. -->
 		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
 
+		<!-- WPCS demands long arrays. We'll be using short arrays from now on. -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+
 		<!-- Ignore WP specific sniffs as Requests is also used outside of a WP context. -->
 		<exclude name="WordPress.WP"/>
 		<exclude name="WordPress.DateTime"/>
@@ -162,6 +165,11 @@
 		 Disallow Yoda conditions.
 		 ========================================================================== -->
 	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
+
+	<!-- ==========================================================================
+		 Enforce short arrays.
+		 ========================================================================== -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
 
 	<!--

--- a/build/ghpages/update-docgen-config.php
+++ b/build/ghpages/update-docgen-config.php
@@ -28,9 +28,9 @@ $requests_phpdoc_version_updater = function () {
 	// Retrieve the information about the latest release from the GH API.
 	$response = Requests::get(
 		'https://api.github.com/repos/WordPress/Requests/releases/latest',
-		array(
+		[
 			'Accept' => 'application/vnd.github.v3+json',
-		)
+		]
 	);
 
 	if (!($response instanceof Response) || $response->success !== true || $response->status_code !== 200) {

--- a/examples/basic-auth.php
+++ b/examples/basic-auth.php
@@ -7,10 +7,10 @@ require_once dirname(__DIR__) . '/src/Autoload.php';
 WpOrg\Requests\Autoload::register();
 
 // Now let's make a request!
-$options = array(
-	'auth' => array('someuser', 'password'),
-);
-$request = WpOrg\Requests\Requests::get('http://httpbin.org/basic-auth/someuser/password', array(), $options);
+$options = [
+	'auth' => ['someuser', 'password'],
+];
+$request = WpOrg\Requests\Requests::get('http://httpbin.org/basic-auth/someuser/password', [], $options);
 
 // Check what we received
 var_dump($request);

--- a/examples/cookie.php
+++ b/examples/cookie.php
@@ -10,7 +10,7 @@ WpOrg\Requests\Autoload::register();
 $c = new WpOrg\Requests\Cookie('login_uid', 'something');
 
 // Now let's make a request!
-$request = WpOrg\Requests\Requests::get('http://httpbin.org/cookies', array('Cookie' => $c->format_for_header()));
+$request = WpOrg\Requests\Requests::get('http://httpbin.org/cookies', ['Cookie' => $c->format_for_header()]);
 
 // Check what we received
 var_dump($request);

--- a/examples/get.php
+++ b/examples/get.php
@@ -7,7 +7,7 @@ require_once dirname(__DIR__) . '/src/Autoload.php';
 WpOrg\Requests\Autoload::register();
 
 // Now let's make a request!
-$request = WpOrg\Requests\Requests::get('http://httpbin.org/get', array('Accept' => 'application/json'));
+$request = WpOrg\Requests\Requests::get('http://httpbin.org/get', ['Accept' => 'application/json']);
 
 // Check what we received
 var_dump($request);

--- a/examples/multiple.php
+++ b/examples/multiple.php
@@ -7,22 +7,22 @@ require_once dirname(__DIR__) . '/src/Autoload.php';
 WpOrg\Requests\Autoload::register();
 
 // Setup what we want to request
-$requests = array(
-	array(
+$requests = [
+	[
 		'url'     => 'http://httpbin.org/get',
-		'headers' => array('Accept' => 'application/javascript'),
-	),
-	'post'    => array(
+		'headers' => ['Accept' => 'application/javascript'],
+	],
+	'post'    => [
 		'url'  => 'http://httpbin.org/post',
-		'data' => array('mydata' => 'something'),
-	),
-	'delayed' => array(
+		'data' => ['mydata' => 'something'],
+	],
+	'delayed' => [
 		'url'     => 'http://httpbin.org/delay/10',
-		'options' => array(
+		'options' => [
 			'timeout' => 20,
-		),
-	),
-);
+		],
+	],
+];
 
 // Setup a callback
 function my_callback(&$request, $id) {
@@ -30,9 +30,9 @@ function my_callback(&$request, $id) {
 }
 
 // Tell Requests to use the callback
-$options = array(
+$options = [
 	'complete' => 'my_callback',
-);
+];
 
 // Send the request!
 $responses = WpOrg\Requests\Requests::request_multiple($requests, $options);

--- a/examples/post.php
+++ b/examples/post.php
@@ -7,7 +7,7 @@ require_once dirname(__DIR__) . '/src/Autoload.php';
 WpOrg\Requests\Autoload::register();
 
 // Now let's make a request!
-$request = WpOrg\Requests\Requests::post('http://httpbin.org/post', array(), array('mydata' => 'something'));
+$request = WpOrg\Requests\Requests::post('http://httpbin.org/post', [], ['mydata' => 'something']);
 
 // Check what we received
 var_dump($request);

--- a/examples/proxy.php
+++ b/examples/proxy.php
@@ -7,12 +7,12 @@ require_once dirname(__DIR__) . '/src/Autoload.php';
 WpOrg\Requests\Autoload::register();
 
 // Now let's make a request via a proxy.
-$options = array(
+$options = [
 	'proxy' => '127.0.0.1:8080', // syntax: host:port, eg 12.13.14.14:8080 or someproxy.com:3128
 	// If you need to authenticate, use the following syntax:
 	// 'proxy' => array( '127.0.0.1:8080', 'username', 'password' ),
-);
-$request = WpOrg\Requests\Requests::get('http://httpbin.org/ip', array(), $options);
+];
+$request = WpOrg\Requests\Requests::get('http://httpbin.org/ip', [], $options);
 
 // See result
 var_dump($request->body);

--- a/examples/timeout.php
+++ b/examples/timeout.php
@@ -7,11 +7,11 @@ require_once dirname(__DIR__) . '/src/Autoload.php';
 WpOrg\Requests\Autoload::register();
 
 // Define a timeout of 2.5 seconds
-$options = array(
+$options = [
 	'timeout' => 2.5,
-);
+];
 
 // Now let's make a request to a page that will delay its response by 3 seconds
-$request = WpOrg\Requests\Requests::get('http://httpbin.org/delay/3', array(), $options);
+$request = WpOrg\Requests\Requests::get('http://httpbin.org/delay/3', [], $options);
 
 // An exception will be thrown, stating a timeout of the request !

--- a/src/Auth/Basic.php
+++ b/src/Auth/Basic.php
@@ -69,8 +69,8 @@ class Basic implements Auth {
 	 * @param \WpOrg\Requests\Hooks $hooks Hook system
 	 */
 	public function register(Hooks $hooks) {
-		$hooks->register('curl.before_send', array($this, 'curl_before_send'));
-		$hooks->register('fsockopen.after_headers', array($this, 'fsockopen_header'));
+		$hooks->register('curl.before_send', [$this, 'curl_before_send']);
+		$hooks->register('fsockopen.after_headers', [$this, 'fsockopen_header']);
 	}
 
 	/**

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -37,7 +37,7 @@ if (class_exists('WpOrg\Requests\Autoload') === false) {
 		 *
 		 * @var array
 		 */
-		private static $deprecated_classes = array(
+		private static $deprecated_classes = [
 			// Interfaces.
 			'requests_auth'                              => '\WpOrg\Requests\Auth',
 			'requests_hooker'                            => '\WpOrg\Requests\HookManager',
@@ -98,7 +98,7 @@ if (class_exists('WpOrg\Requests\Autoload') === false) {
 			'requests_exception_http_505'                => '\WpOrg\Requests\Exception\Http\Status505',
 			'requests_exception_http_511'                => '\WpOrg\Requests\Exception\Http\Status511',
 			'requests_exception_http_unknown'            => '\WpOrg\Requests\Exception\Http\StatusUnknown',
-		);
+		];
 
 		/**
 		 * Register the autoloader.
@@ -116,7 +116,7 @@ if (class_exists('WpOrg\Requests\Autoload') === false) {
 		 */
 		public static function register() {
 			if (defined('REQUESTS_AUTOLOAD_REGISTERED') === false) {
-				spl_autoload_register(array(self::class, 'load'), true);
+				spl_autoload_register([self::class, 'load'], true);
 				define('REQUESTS_AUTOLOAD_REGISTERED', true);
 			}
 		}

--- a/src/Capability.php
+++ b/src/Capability.php
@@ -30,7 +30,7 @@ interface Capability {
 	 *
 	 * @var array<string>
 	 */
-	const ALL = array(
+	const ALL = [
 		self::SSL,
-	);
+	];
 }

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -41,7 +41,7 @@ class Cookie {
 	 *
 	 * @var \WpOrg\Requests\Utility\CaseInsensitiveDictionary|array Array-like object
 	 */
-	public $attributes = array();
+	public $attributes = [];
 
 	/**
 	 * Cookie flags
@@ -51,7 +51,7 @@ class Cookie {
 	 *
 	 * @var array
 	 */
-	public $flags = array();
+	public $flags = [];
 
 	/**
 	 * Reference time for relative calculations
@@ -78,7 +78,7 @@ class Cookie {
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $flags argument is not an array.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $reference_time argument is not an integer or null.
 	 */
-	public function __construct($name, $value, $attributes = array(), $flags = array(), $reference_time = null) {
+	public function __construct($name, $value, $attributes = [], $flags = [], $reference_time = null) {
 		if (is_string($name) === false) {
 			throw InvalidArgument::create(1, '$name', 'string', gettype($name));
 		}
@@ -102,12 +102,12 @@ class Cookie {
 		$this->name       = $name;
 		$this->value      = $value;
 		$this->attributes = $attributes;
-		$default_flags    = array(
+		$default_flags    = [
 			'creation'    => time(),
 			'last-access' => time(),
 			'persistent'  => false,
 			'host-only'   => true,
-		);
+		];
 		$this->flags      = array_merge($default_flags, $flags);
 
 		$this->reference_time = time();
@@ -378,7 +378,7 @@ class Cookie {
 	public function format_for_set_cookie() {
 		$header_value = $this->format_for_header();
 		if (!empty($this->attributes)) {
-			$parts = array();
+			$parts = [];
 			foreach ($this->attributes as $key => $value) {
 				// Ignore non-associative attributes
 				if (is_numeric($key)) {
@@ -458,7 +458,7 @@ class Cookie {
 			}
 		}
 
-		return new static($name, $value, $attributes, array(), $reference_time);
+		return new static($name, $value, $attributes, [], $reference_time);
 	}
 
 	/**
@@ -472,10 +472,10 @@ class Cookie {
 	public static function parse_from_headers(Headers $headers, Iri $origin = null, $time = null) {
 		$cookie_headers = $headers->getValues('Set-Cookie');
 		if (empty($cookie_headers)) {
-			return array();
+			return [];
 		}
 
-		$cookies = array();
+		$cookies = [];
 		foreach ($cookie_headers as $header) {
 			$parsed = self::parse($header, '', $time);
 

--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -29,7 +29,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @var array
 	 */
-	protected $cookies = array();
+	protected $cookies = [];
 
 	/**
 	 * Create a new jar
@@ -38,7 +38,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not an array.
 	 */
-	public function __construct($cookies = array()) {
+	public function __construct($cookies = []) {
 		if (is_array($cookies) === false) {
 			throw InvalidArgument::create(1, '$cookies', 'array', gettype($cookies));
 		}
@@ -129,8 +129,8 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	 * @param \WpOrg\Requests\HookManager $hooks Hooking system
 	 */
 	public function register(HookManager $hooks) {
-		$hooks->register('requests.before_request', array($this, 'before_request'));
-		$hooks->register('requests.before_redirect_check', array($this, 'before_redirect_check'));
+		$hooks->register('requests.before_request', [$this, 'before_request']);
+		$hooks->register('requests.before_redirect_check', [$this, 'before_redirect_check']);
 	}
 
 	/**
@@ -150,7 +150,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 		}
 
 		if (!empty($this->cookies)) {
-			$cookies = array();
+			$cookies = [];
 			foreach ($this->cookies as $key => $cookie) {
 				$cookie = $this->normalize_cookie($cookie, $key);
 

--- a/src/HookManager.php
+++ b/src/HookManager.php
@@ -29,5 +29,5 @@ interface HookManager {
 	 * @param array $parameters Parameters to pass to callbacks
 	 * @return boolean Successfulness
 	 */
-	public function dispatch($hook, $parameters = array());
+	public function dispatch($hook, $parameters = []);
 }

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -22,7 +22,7 @@ class Hooks implements HookManager {
 	 *
 	 * @var array
 	 */
-	protected $hooks = array();
+	protected $hooks = [];
 
 	/**
 	 * Register a callback for a hook
@@ -48,11 +48,11 @@ class Hooks implements HookManager {
 		}
 
 		if (!isset($this->hooks[$hook])) {
-			$this->hooks[$hook] = array(
-				$priority => array(),
-			);
+			$this->hooks[$hook] = [
+				$priority => [],
+			];
 		} elseif (!isset($this->hooks[$hook][$priority])) {
-			$this->hooks[$hook][$priority] = array();
+			$this->hooks[$hook][$priority] = [];
 		}
 
 		$this->hooks[$hook][$priority][] = $callback;
@@ -67,7 +67,7 @@ class Hooks implements HookManager {
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $hook argument is not a string.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $parameters argument is not an array.
 	 */
-	public function dispatch($hook, $parameters = array()) {
+	public function dispatch($hook, $parameters = []) {
 		if (is_string($hook) === false) {
 			throw InvalidArgument::create(1, '$hook', 'string', gettype($hook));
 		}

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -165,7 +165,7 @@ class IdnaEncoder {
 	 * @throws \WpOrg\Requests\Exception Invalid UTF-8 codepoint (`idna.invalidcodepoint`)
 	 */
 	protected static function utf8_to_codepoints($input) {
-		$codepoints = array();
+		$codepoints = [];
 
 		// Get number of bytes
 		$strlen = strlen($input);
@@ -269,7 +269,7 @@ class IdnaEncoder {
 		$b = 0; // see loop
 		// copy them to the output in order
 		$codepoints = self::utf8_to_codepoints($input);
-		$extended   = array();
+		$extended   = [];
 
 		foreach ($codepoints as $char) {
 			if ($char < 128) {

--- a/src/Ipv6.php
+++ b/src/Ipv6.php
@@ -143,10 +143,10 @@ final class Ipv6 {
 			$pos       = strrpos($ip, ':');
 			$ipv6_part = substr($ip, 0, $pos);
 			$ipv4_part = substr($ip, $pos + 1);
-			return array($ipv6_part, $ipv4_part);
+			return [$ipv6_part, $ipv4_part];
 		}
 		else {
-			return array($ip, '');
+			return [$ip, ''];
 		}
 	}
 

--- a/src/Proxy/Http.php
+++ b/src/Proxy/Http.php
@@ -99,12 +99,12 @@ final class Http implements Proxy {
 	 * @param \WpOrg\Requests\Hooks $hooks Hook system
 	 */
 	public function register(Hooks $hooks) {
-		$hooks->register('curl.before_send', array($this, 'curl_before_send'));
+		$hooks->register('curl.before_send', [$this, 'curl_before_send']);
 
-		$hooks->register('fsockopen.remote_socket', array($this, 'fsockopen_remote_socket'));
-		$hooks->register('fsockopen.remote_host_path', array($this, 'fsockopen_remote_host_path'));
+		$hooks->register('fsockopen.remote_socket', [$this, 'fsockopen_remote_socket']);
+		$hooks->register('fsockopen.remote_host_path', [$this, 'fsockopen_remote_host_path']);
 		if ($this->use_authentication) {
-			$hooks->register('fsockopen.after_headers', array($this, 'fsockopen_header'));
+			$hooks->register('fsockopen.after_headers', [$this, 'fsockopen_header']);
 		}
 	}
 

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -109,7 +109,7 @@ class Requests {
 	 *
 	 * @var array
 	 */
-	const OPTION_DEFAULTS = array(
+	const OPTION_DEFAULTS = [
 		'timeout'          => 10,
 		'connect_timeout'  => 10,
 		'useragent'        => 'php-requests/' . self::VERSION,
@@ -129,7 +129,7 @@ class Requests {
 		'transport'        => null,
 		'verify'           => null,
 		'verifyname'       => true,
-	);
+	];
 
 	/**
 	 * Default supported Transport classes.
@@ -138,10 +138,10 @@ class Requests {
 	 *
 	 * @var array
 	 */
-	const DEFAULT_TRANSPORTS = array(
+	const DEFAULT_TRANSPORTS = [
 		Curl::class      => Curl::class,
 		Fsockopen::class => Fsockopen::class,
-	);
+	];
 
 	/**
 	 * Current version of Requests
@@ -157,14 +157,14 @@ class Requests {
 	 *
 	 * @var array
 	 */
-	public static $transport = array();
+	public static $transport = [];
 
 	/**
 	 * Registered transport classes
 	 *
 	 * @var array
 	 */
-	protected static $transports = array();
+	protected static $transports = [];
 
 	/**
 	 * Default certificate path.
@@ -187,13 +187,13 @@ class Requests {
 	 *
 	 * @var array
 	 */
-	private static $magic_compression_headers = array(
+	private static $magic_compression_headers = [
 		"\x1f\x8b" => true, // Gzip marker.
 		"\x78\x01" => true, // Zlib marker - level 1.
 		"\x78\x5e" => true, // Zlib marker - level 2 to 5.
 		"\x78\x9c" => true, // Zlib marker - level 6.
 		"\x78\xda" => true, // Zlib marker - level 7 to 9.
-	);
+	];
 
 	/**
 	 * This is a static class, do not instantiate it
@@ -222,7 +222,7 @@ class Requests {
 	 * @return string FQCN of the transport to use, or an empty string if no transport was
 	 *                found which provided the requested capabilities.
 	 */
-	protected static function get_transport_class(array $capabilities = array()) {
+	protected static function get_transport_class(array $capabilities = []) {
 		// Caching code, don't bother testing coverage.
 		// @codeCoverageIgnoreStart
 		// Array of capabilities as a string to be used as an array key.
@@ -265,7 +265,7 @@ class Requests {
 	 * @return \WpOrg\Requests\Transport
 	 * @throws \WpOrg\Requests\Exception If no valid transport is found (`notransport`).
 	 */
-	protected static function get_transport(array $capabilities = array()) {
+	protected static function get_transport(array $capabilities = []) {
 		$class = self::get_transport_class($capabilities);
 
 		if ($class === '') {
@@ -287,7 +287,7 @@ class Requests {
 	 * @param array<string, bool> $capabilities Optional. Associative array of capabilities to test against, i.e. `['<capability>' => true]`.
 	 * @return bool Whether the transport has the requested capabilities.
 	 */
-	public static function has_capabilities(array $capabilities = array()) {
+	public static function has_capabilities(array $capabilities = []) {
 		return self::get_transport_class($capabilities) !== '';
 	}
 
@@ -301,28 +301,28 @@ class Requests {
 	/**
 	 * Send a GET request
 	 */
-	public static function get($url, $headers = array(), $options = array()) {
+	public static function get($url, $headers = [], $options = []) {
 		return self::request($url, $headers, null, self::GET, $options);
 	}
 
 	/**
 	 * Send a HEAD request
 	 */
-	public static function head($url, $headers = array(), $options = array()) {
+	public static function head($url, $headers = [], $options = []) {
 		return self::request($url, $headers, null, self::HEAD, $options);
 	}
 
 	/**
 	 * Send a DELETE request
 	 */
-	public static function delete($url, $headers = array(), $options = array()) {
+	public static function delete($url, $headers = [], $options = []) {
 		return self::request($url, $headers, null, self::DELETE, $options);
 	}
 
 	/**
 	 * Send a TRACE request
 	 */
-	public static function trace($url, $headers = array(), $options = array()) {
+	public static function trace($url, $headers = [], $options = []) {
 		return self::request($url, $headers, null, self::TRACE, $options);
 	}
 	/**#@-*/
@@ -338,20 +338,20 @@ class Requests {
 	/**
 	 * Send a POST request
 	 */
-	public static function post($url, $headers = array(), $data = array(), $options = array()) {
+	public static function post($url, $headers = [], $data = [], $options = []) {
 		return self::request($url, $headers, $data, self::POST, $options);
 	}
 	/**
 	 * Send a PUT request
 	 */
-	public static function put($url, $headers = array(), $data = array(), $options = array()) {
+	public static function put($url, $headers = [], $data = [], $options = []) {
 		return self::request($url, $headers, $data, self::PUT, $options);
 	}
 
 	/**
 	 * Send an OPTIONS request
 	 */
-	public static function options($url, $headers = array(), $data = array(), $options = array()) {
+	public static function options($url, $headers = [], $data = [], $options = []) {
 		return self::request($url, $headers, $data, self::OPTIONS, $options);
 	}
 
@@ -363,7 +363,7 @@ class Requests {
 	 *
 	 * @link https://tools.ietf.org/html/rfc5789
 	 */
-	public static function patch($url, $headers, $data = array(), $options = array()) {
+	public static function patch($url, $headers, $data = [], $options = []) {
 		return self::request($url, $headers, $data, self::PATCH, $options);
 	}
 	/**#@-*/
@@ -431,7 +431,7 @@ class Requests {
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 * @throws \WpOrg\Requests\Exception On invalid URLs (`nonhttp`)
 	 */
-	public static function request($url, $headers = array(), $data = array(), $type = self::GET, $options = array()) {
+	public static function request($url, $headers = [], $data = [], $type = self::GET, $options = []) {
 		if (InputValidator::is_string_or_stringable($url) === false) {
 			throw InvalidArgument::create(1, '$url', 'string|Stringable', gettype($url));
 		}
@@ -451,7 +451,7 @@ class Requests {
 
 		self::set_defaults($url, $headers, $data, $type, $options);
 
-		$options['hooks']->dispatch('requests.before_request', array(&$url, &$headers, &$data, &$type, &$options));
+		$options['hooks']->dispatch('requests.before_request', [&$url, &$headers, &$data, &$type, &$options]);
 
 		if (!empty($options['transport'])) {
 			$transport = $options['transport'];
@@ -462,12 +462,12 @@ class Requests {
 		}
 		else {
 			$need_ssl     = (stripos($url, 'https://') === 0);
-			$capabilities = array(Capability::SSL => $need_ssl);
+			$capabilities = [Capability::SSL => $need_ssl];
 			$transport    = self::get_transport($capabilities);
 		}
 		$response = $transport->request($url, $headers, $data, $options);
 
-		$options['hooks']->dispatch('requests.before_parse', array(&$response, $url, $headers, $data, $type, $options));
+		$options['hooks']->dispatch('requests.before_parse', [&$response, $url, $headers, $data, $type, $options]);
 
 		return self::parse_response($response, $url, $headers, $data, $options);
 	}
@@ -516,7 +516,7 @@ class Requests {
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $requests argument is not an array or iterable object with array access.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 */
-	public static function request_multiple($requests, $options = array()) {
+	public static function request_multiple($requests, $options = []) {
 		if (InputValidator::has_array_access($requests) === false || InputValidator::is_iterable($requests) === false) {
 			throw InvalidArgument::create(1, '$requests', 'array|ArrayAccess&Traversable', gettype($requests));
 		}
@@ -528,7 +528,7 @@ class Requests {
 		$options = array_merge(self::get_default_options(true), $options);
 
 		if (!empty($options['hooks'])) {
-			$options['hooks']->register('transport.internal.parse_response', array(static::class, 'parse_multiple'));
+			$options['hooks']->register('transport.internal.parse_response', [static::class, 'parse_multiple']);
 			if (!empty($options['complete'])) {
 				$options['hooks']->register('multiple.request.complete', $options['complete']);
 			}
@@ -536,10 +536,10 @@ class Requests {
 
 		foreach ($requests as $id => &$request) {
 			if (!isset($request['headers'])) {
-				$request['headers'] = array();
+				$request['headers'] = [];
 			}
 			if (!isset($request['data'])) {
-				$request['data'] = array();
+				$request['data'] = [];
 			}
 			if (!isset($request['type'])) {
 				$request['type'] = self::GET;
@@ -559,7 +559,7 @@ class Requests {
 
 			// Ensure we only hook in once
 			if ($request['options']['hooks'] !== $options['hooks']) {
-				$request['options']['hooks']->register('transport.internal.parse_response', array(static::class, 'parse_multiple'));
+				$request['options']['hooks']->register('transport.internal.parse_response', [static::class, 'parse_multiple']);
 				if (!empty($request['options']['complete'])) {
 					$request['options']['hooks']->register('multiple.request.complete', $request['options']['complete']);
 				}
@@ -585,7 +585,7 @@ class Requests {
 			if (is_string($response)) {
 				$request = $requests[$id];
 				self::parse_multiple($response, $request);
-				$request['options']['hooks']->dispatch('multiple.request.complete', array(&$response, $id));
+				$request['options']['hooks']->dispatch('multiple.request.complete', [&$response, $id]);
 			}
 		}
 
@@ -688,7 +688,7 @@ class Requests {
 		$type = strtoupper($type);
 
 		if (!isset($options['data_format'])) {
-			if (in_array($type, array(self::HEAD, self::GET, self::DELETE), true)) {
+			if (in_array($type, [self::HEAD, self::GET, self::DELETE], true)) {
 				$options['data_format'] = 'query';
 			}
 			else {
@@ -769,7 +769,7 @@ class Requests {
 			unset($return->headers['connection']);
 		}
 
-		$options['hooks']->dispatch('requests.before_redirect_check', array(&$return, $req_headers, $req_data, $options));
+		$options['hooks']->dispatch('requests.before_redirect_check', [&$return, $req_headers, $req_data, $options]);
 
 		if ($return->is_redirect() && $options['follow_redirects'] === true) {
 			if (isset($return->headers['location']) && $options['redirected'] < $options['redirects']) {
@@ -784,13 +784,13 @@ class Requests {
 					$location = $location->uri;
 				}
 
-				$hook_args = array(
+				$hook_args = [
 					&$location,
 					&$req_headers,
 					&$req_data,
 					&$options,
 					$return,
-				);
+				];
 				$options['hooks']->dispatch('requests.before_redirect', $hook_args);
 				$redirected            = self::request($location, $req_headers, $req_data, $options['type'], $options);
 				$redirected->history[] = $return;
@@ -803,7 +803,7 @@ class Requests {
 
 		$return->redirects = $options['redirected'];
 
-		$options['hooks']->dispatch('requests.after_request', array(&$return, $req_headers, $req_data, $options));
+		$options['hooks']->dispatch('requests.after_request', [&$return, $req_headers, $req_data, $options]);
 		return $return;
 	}
 
@@ -885,7 +885,7 @@ class Requests {
 			throw InvalidArgument::create(1, '$dictionary', 'iterable', gettype($dictionary));
 		}
 
-		$return = array();
+		$return = [];
 		foreach ($dictionary as $key => $value) {
 			$return[] = sprintf('%s: %s', $key, $value);
 		}

--- a/src/Response.php
+++ b/src/Response.php
@@ -42,7 +42,7 @@ class Response {
 	 *
 	 * @var \WpOrg\Requests\Response\Headers Array-like object representing headers
 	 */
-	public $headers = array();
+	public $headers = [];
 
 	/**
 	 * Status code, false if non-blocking
@@ -84,14 +84,14 @@ class Response {
 	 *
 	 * @var array Array of \WpOrg\Requests\Response objects
 	 */
-	public $history = array();
+	public $history = [];
 
 	/**
 	 * Cookies from the request
 	 *
 	 * @var \WpOrg\Requests\Cookie\Jar Array-like object representing a cookie jar
 	 */
-	public $cookies = array();
+	public $cookies = [];
 
 	/**
 	 * Constructor
@@ -108,7 +108,7 @@ class Response {
 	 */
 	public function is_redirect() {
 		$code = $this->status_code;
-		return in_array($code, array(300, 301, 302, 303, 307), true) || $code > 307 && $code < 400;
+		return in_array($code, [300, 301, 302, 303, 307], true) || $code > 307 && $code < 400;
 	}
 
 	/**

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -60,7 +60,7 @@ class Headers extends CaseInsensitiveDictionary {
 		}
 
 		if (!isset($this->data[$offset])) {
-			$this->data[$offset] = array();
+			$this->data[$offset] = [];
 		}
 
 		$this->data[$offset][] = $value;
@@ -119,6 +119,6 @@ class Headers extends CaseInsensitiveDictionary {
 	 * @return \ArrayIterator
 	 */
 	public function getIterator() {
-		return new FilteredIterator($this->data, array($this, 'flatten'));
+		return new FilteredIterator($this->data, [$this, 'flatten']);
 	}
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -38,7 +38,7 @@ class Session {
 	 *
 	 * @var array
 	 */
-	public $headers = array();
+	public $headers = [];
 
 	/**
 	 * Base data for requests
@@ -48,7 +48,7 @@ class Session {
 	 *
 	 * @var array
 	 */
-	public $data = array();
+	public $data = [];
 
 	/**
 	 * Base options for requests
@@ -61,7 +61,7 @@ class Session {
 	 *
 	 * @var array
 	 */
-	public $options = array();
+	public $options = [];
 
 	/**
 	 * Create a new session
@@ -76,7 +76,7 @@ class Session {
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $data argument is not an array.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 */
-	public function __construct($url = null, $headers = array(), $data = array(), $options = array()) {
+	public function __construct($url = null, $headers = [], $data = [], $options = []) {
 		if ($url !== null && InputValidator::is_string_or_stringable($url) === false) {
 			throw InvalidArgument::create(1, '$url', 'string|Stringable|null', gettype($url));
 		}
@@ -155,21 +155,21 @@ class Session {
 	/**
 	 * Send a GET request
 	 */
-	public function get($url, $headers = array(), $options = array()) {
+	public function get($url, $headers = [], $options = []) {
 		return $this->request($url, $headers, null, Requests::GET, $options);
 	}
 
 	/**
 	 * Send a HEAD request
 	 */
-	public function head($url, $headers = array(), $options = array()) {
+	public function head($url, $headers = [], $options = []) {
 		return $this->request($url, $headers, null, Requests::HEAD, $options);
 	}
 
 	/**
 	 * Send a DELETE request
 	 */
-	public function delete($url, $headers = array(), $options = array()) {
+	public function delete($url, $headers = [], $options = []) {
 		return $this->request($url, $headers, null, Requests::DELETE, $options);
 	}
 	/**#@-*/
@@ -185,14 +185,14 @@ class Session {
 	/**
 	 * Send a POST request
 	 */
-	public function post($url, $headers = array(), $data = array(), $options = array()) {
+	public function post($url, $headers = [], $data = [], $options = []) {
 		return $this->request($url, $headers, $data, Requests::POST, $options);
 	}
 
 	/**
 	 * Send a PUT request
 	 */
-	public function put($url, $headers = array(), $data = array(), $options = array()) {
+	public function put($url, $headers = [], $data = [], $options = []) {
 		return $this->request($url, $headers, $data, Requests::PUT, $options);
 	}
 
@@ -204,7 +204,7 @@ class Session {
 	 *
 	 * @link https://tools.ietf.org/html/rfc5789
 	 */
-	public function patch($url, $headers, $data = array(), $options = array()) {
+	public function patch($url, $headers, $data = [], $options = []) {
 		return $this->request($url, $headers, $data, Requests::PATCH, $options);
 	}
 	/**#@-*/
@@ -226,7 +226,7 @@ class Session {
 	 * @param array $options Options for the request (see {@see \WpOrg\Requests\Requests::request()})
 	 * @return \WpOrg\Requests\Response
 	 */
-	public function request($url, $headers = array(), $data = array(), $type = Requests::GET, $options = array()) {
+	public function request($url, $headers = [], $data = [], $type = Requests::GET, $options = []) {
 		$request = $this->merge_request(compact('url', 'headers', 'data', 'options'));
 
 		return Requests::request($request['url'], $request['headers'], $request['data'], $type, $request['options']);
@@ -244,7 +244,7 @@ class Session {
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $requests argument is not an array or iterable object with array access.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 */
-	public function request_multiple($requests, $options = array()) {
+	public function request_multiple($requests, $options = []) {
 		if (InputValidator::has_array_access($requests) === false || InputValidator::is_iterable($requests) === false) {
 			throw InvalidArgument::create(1, '$requests', 'array|ArrayAccess&Traversable', gettype($requests));
 		}
@@ -279,7 +279,7 @@ class Session {
 		}
 
 		if (empty($request['headers'])) {
-			$request['headers'] = array();
+			$request['headers'] = [];
 		}
 		$request['headers'] = array_merge($this->headers, $request['headers']);
 

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -22,7 +22,7 @@ interface Transport {
 	 * @param array $options Request options, see {@see \WpOrg\Requests\Requests::response()} for documentation
 	 * @return string Raw HTTP result
 	 */
-	public function request($url, $headers = array(), $data = array(), $options = array());
+	public function request($url, $headers = [], $data = [], $options = []);
 
 	/**
 	 * Send multiple requests simultaneously
@@ -41,5 +41,5 @@ interface Transport {
 	 * @param array<string, bool> $capabilities Optional. Associative array of capabilities to test against, i.e. `['<capability>' => true]`.
 	 * @return bool Whether the transport can be used.
 	 */
-	public static function test($capabilities = array());
+	public static function test($capabilities = []);
 }

--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -24,14 +24,14 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @var array
 	 */
-	protected $data = array();
+	protected $data = [];
 
 	/**
 	 * Creates a case insensitive dictionary.
 	 *
 	 * @param array $data Dictionary/map to convert to case-insensitive
 	 */
-	public function __construct(array $data = array()) {
+	public function __construct(array $data = []) {
 		foreach ($data as $offset => $value) {
 			$this->offsetSet($offset, $value);
 		}

--- a/tests/Auth/BasicTest.php
+++ b/tests/Auth/BasicTest.php
@@ -24,11 +24,11 @@ final class BasicTest extends TestCase {
 	public function testUsingArray($transport) {
 		$this->skipWhenTransportNotAvailable($transport);
 
-		$options = array(
-			'auth'      => array('user', 'passwd'),
+		$options = [
+			'auth'      => ['user', 'passwd'],
 			'transport' => $transport,
-		);
-		$request = Requests::get(httpbin('/basic-auth/user/passwd'), array(), $options);
+		];
+		$request = Requests::get(httpbin('/basic-auth/user/passwd'), [], $options);
 
 		// Verify the request succeeded.
 		$this->assertInstanceOf(
@@ -71,11 +71,11 @@ final class BasicTest extends TestCase {
 	public function testUsingInstantiation($transport) {
 		$this->skipWhenTransportNotAvailable($transport);
 
-		$options = array(
-			'auth'      => new Basic(array('user', 'passwd')),
+		$options = [
+			'auth'      => new Basic(['user', 'passwd']),
 			'transport' => $transport,
-		);
-		$request = Requests::get(httpbin('/basic-auth/user/passwd'), array(), $options);
+		];
+		$request = Requests::get(httpbin('/basic-auth/user/passwd'), [], $options);
 
 		// Verify the request succeeded.
 		$this->assertInstanceOf(
@@ -118,14 +118,14 @@ final class BasicTest extends TestCase {
 	public function testUsingInstantiationWithDelayedSettingOfCredentials($transport) {
 		$this->skipWhenTransportNotAvailable($transport);
 
-		$options = array(
+		$options = [
 			'auth'      => new Basic(),
 			'transport' => $transport,
-		);
+		];
 
 		$options['auth']->user = 'user';
 		$options['auth']->pass = 'passwd';
-		$request               = Requests::get(httpbin('/basic-auth/user/passwd'), array(), $options);
+		$request               = Requests::get(httpbin('/basic-auth/user/passwd'), [], $options);
 
 		// Verify the request succeeded.
 		$this->assertInstanceOf(
@@ -168,12 +168,12 @@ final class BasicTest extends TestCase {
 	public function testPOSTUsingInstantiation($transport) {
 		$this->skipWhenTransportNotAvailable($transport);
 
-		$options = array(
-			'auth'      => new Basic(array('user', 'passwd')),
+		$options = [
+			'auth'      => new Basic(['user', 'passwd']),
 			'transport' => $transport,
-		);
+		];
 		$data    = 'test';
-		$request = Requests::post(httpbin('/post'), array(), $data, $options);
+		$request = Requests::post(httpbin('/post'), [], $data, $options);
 
 		// Verify the request succeeded.
 		$this->assertInstanceOf(
@@ -237,10 +237,10 @@ final class BasicTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidInputType() {
-		return array(
-			'boolean false'         => array(false),
-			'authentication string' => array('user:psw'),
-		);
+		return [
+			'boolean false'         => [false],
+			'authentication string' => ['user:psw'],
+		];
 	}
 
 	/**
@@ -265,11 +265,11 @@ final class BasicTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidArgumentCount() {
-		return array(
-			'empty array'                 => array(array()),
-			'array with only one element' => array(array('user')),
-			'array with extra element'    => array(array('user', 'psw', 'port')),
-		);
+		return [
+			'empty array'                 => [[]],
+			'array with only one element' => [['user']],
+			'array with extra element'    => [['user', 'psw', 'port']],
+		];
 	}
 
 	/**

--- a/tests/AutoloadTest.php
+++ b/tests/AutoloadTest.php
@@ -42,7 +42,7 @@ final class AutoloadTest extends TestCase {
 	public function testAutoloadOfOldRequestsClassDoesNotThrowAFatalForFinalClass() {
 		define('REQUESTS_SILENCE_PSR0_DEPRECATIONS', true);
 
-		$this->assertInstanceOf(FilteredIterator::class, new Requests_utility_filteredIterator(array(), function() {}));
+		$this->assertInstanceOf(FilteredIterator::class, new Requests_utility_filteredIterator([], function() {}));
 	}
 
 	/**

--- a/tests/Cookie/JarTest.php
+++ b/tests/Cookie/JarTest.php
@@ -19,9 +19,9 @@ final class JarTest extends TestCase {
 		$jar1['requests-testcookie'] = 'testvalue';
 
 		$jar2 = new Jar(
-			array(
+			[
 				'requests-testcookie' => 'testvalue',
-			)
+			]
 		);
 		$this->assertEquals($jar1, $jar2);
 	}
@@ -45,10 +45,10 @@ final class JarTest extends TestCase {
 	}
 
 	public function testCookieJarIterator() {
-		$cookies = array(
+		$cookies = [
 			'requests-testcookie1' => 'testvalue1',
 			'requests-testcookie2' => 'testvalue2',
-		);
+		];
 		$jar     = new Jar($cookies);
 
 		foreach ($jar as $key => $value) {
@@ -58,9 +58,9 @@ final class JarTest extends TestCase {
 
 	public function testSendingCookieWithJar() {
 		$cookies = new Jar(
-			array(
+			[
 				'requests-testcookie1' => 'testvalue1',
-			)
+			]
 		);
 		$data    = $this->setCookieRequest($cookies);
 
@@ -70,10 +70,10 @@ final class JarTest extends TestCase {
 
 	public function testSendingMultipleCookiesWithJar() {
 		$cookies = new Jar(
-			array(
+			[
 				'requests-testcookie1' => 'testvalue1',
 				'requests-testcookie2' => 'testvalue2',
-			)
+			]
 		);
 		$data    = $this->setCookieRequest($cookies);
 
@@ -86,9 +86,9 @@ final class JarTest extends TestCase {
 
 	public function testSendingPrebakedCookie() {
 		$cookies = new Jar(
-			array(
+			[
 				new Cookie('requests-testcookie', 'testvalue'),
-			)
+			]
 		);
 		$data    = $this->setCookieRequest($cookies);
 
@@ -97,10 +97,10 @@ final class JarTest extends TestCase {
 	}
 
 	private function setCookieRequest($cookies) {
-		$options  = array(
+		$options  = [
 			'cookies' => $cookies,
-		);
-		$response = Requests::get(httpbin('/cookies/set'), array(), $options);
+		];
+		$response = Requests::get(httpbin('/cookies/set'), [], $options);
 
 		$data = json_decode($response->body, true);
 		$this->assertIsArray($data);

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -27,10 +27,10 @@ final class CookiesTest extends TestCase {
 	}
 
 	public function testCookieWithAttributes() {
-		$attributes = array(
+		$attributes = [
 			'httponly',
 			'path' => '/',
-		);
+		];
 		$cookie     = new Cookie('requests-testcookie', 'testvalue', $attributes);
 
 		$this->assertSame('requests-testcookie=testvalue', $cookie->format_for_header());
@@ -49,12 +49,12 @@ final class CookiesTest extends TestCase {
 	}
 
 	public function testReceivingCookies() {
-		$options = array(
+		$options = [
 			'follow_redirects' => false,
-		);
+		];
 		$url     = httpbin('/cookies/set?requests-testcookie=testvalue');
 
-		$response = Requests::get($url, array(), $options);
+		$response = Requests::get($url, [], $options);
 
 		$cookie = $response->cookies['requests-testcookie'];
 		$this->assertNotEmpty($cookie);
@@ -62,12 +62,12 @@ final class CookiesTest extends TestCase {
 	}
 
 	public function testPersistenceOnRedirect() {
-		$options = array(
+		$options = [
 			'follow_redirects' => true,
-		);
+		];
 		$url     = httpbin('/cookies/set?requests-testcookie=testvalue');
 
-		$response = Requests::get($url, array(), $options);
+		$response = Requests::get($url, [], $options);
 
 		$cookie = $response->cookies['requests-testcookie'];
 		$this->assertNotEmpty($cookie);
@@ -75,10 +75,10 @@ final class CookiesTest extends TestCase {
 	}
 
 	private function setCookieRequest($cookies) {
-		$options  = array(
+		$options  = [
 			'cookies' => $cookies,
-		);
-		$response = Requests::get(httpbin('/cookies/set'), array(), $options);
+		];
+		$response = Requests::get(httpbin('/cookies/set'), [], $options);
 
 		$data = json_decode($response->body, true);
 		$this->assertIsArray($data);
@@ -87,9 +87,9 @@ final class CookiesTest extends TestCase {
 	}
 
 	public function testSendingCookie() {
-		$cookies = array(
+		$cookies = [
 			'requests-testcookie1' => 'testvalue1',
-		);
+		];
 
 		$data = $this->setCookieRequest($cookies);
 
@@ -101,13 +101,13 @@ final class CookiesTest extends TestCase {
 	 * @depends testSendingCookie
 	 */
 	public function testCookieExpiration() {
-		$options = array(
+		$options = [
 			'follow_redirects' => true,
-		);
+		];
 		$url     = httpbin('/cookies/set/testcookie/testvalue');
 		$url    .= '?expiry=1';
 
-		$response = Requests::get($url, array(), $options);
+		$response = Requests::get($url, [], $options);
 		$response->throw_for_status();
 
 		$data = json_decode($response->body, true);
@@ -115,10 +115,10 @@ final class CookiesTest extends TestCase {
 	}
 
 	public function testSendingMultipleCookies() {
-		$cookies = array(
+		$cookies = [
 			'requests-testcookie1' => 'testvalue1',
 			'requests-testcookie2' => 'testvalue2',
-		);
+		];
 		$data    = $this->setCookieRequest($cookies);
 
 		$this->assertArrayHasKey('requests-testcookie1', $data);
@@ -129,30 +129,30 @@ final class CookiesTest extends TestCase {
 	}
 
 	public function domainMatchProvider() {
-		return array(
-			'Invalid check domain (type): null'         => array('example.com', null, false, false),
-			'Invalid check domain (type): boolean true' => array('example.com', true, false, false),
-			array('example.com', 'example.com', true, true),
-			array('example.com', 'www.example.com', false, true),
-			array('example.com', 'example.net', false, false),
+		return [
+			'Invalid check domain (type): null'         => ['example.com', null, false, false],
+			'Invalid check domain (type): boolean true' => ['example.com', true, false, false],
+			['example.com', 'example.com', true, true],
+			['example.com', 'www.example.com', false, true],
+			['example.com', 'example.net', false, false],
 
 			// Leading period
-			array('.example.com', 'example.com', true, true),
-			array('.example.com', 'www.example.com', false, true),
-			array('.example.com', 'example.net', false, false),
+			['.example.com', 'example.com', true, true],
+			['.example.com', 'www.example.com', false, true],
+			['.example.com', 'example.net', false, false],
 
 			// Prefix, but not subdomain
-			array('example.com', 'notexample.com', false, false),
-			array('example.com', 'notexample.net', false, false),
+			['example.com', 'notexample.com', false, false],
+			['example.com', 'notexample.net', false, false],
 
 			// Reject IP address prefixes
-			array('127.0.0.1', '127.0.0.1', true, true),
-			array('127.0.0.1', 'abc.127.0.0.1', false, false),
-			array('127.0.0.1', 'example.com', false, false),
+			['127.0.0.1', '127.0.0.1', true, true],
+			['127.0.0.1', 'abc.127.0.0.1', false, false],
+			['127.0.0.1', 'example.com', false, false],
 
 			// Check that we're checking the actual length
-			array('127.com', 'test.127.com', false, true),
-		);
+			['127.com', 'test.127.com', false, true],
+		];
 	}
 
 	/**
@@ -171,35 +171,35 @@ final class CookiesTest extends TestCase {
 	public function testDomainMatch($original, $check, $matches, $domain_matches) {
 		$attributes           = new CaseInsensitiveDictionary();
 		$attributes['domain'] = $original;
-		$flags                = array(
+		$flags                = [
 			'host-only' => false,
-		);
+		];
 		$cookie               = new Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
 		$this->assertSame($domain_matches, $cookie->domain_matches($check));
 	}
 
 	public function pathMatchProvider() {
-		return array(
-			'Invalid check path (type): null'    => array('/', null, true),
-			'Invalid check path (type): true'    => array('/', true, false),
-			'Invalid check path (type): integer' => array('/', 123, false),
-			'Invalid check path (type): array'   => array('/', array(1, 2), false),
-			array('/', '', true),
-			array('/', '/', true),
+		return [
+			'Invalid check path (type): null'    => ['/', null, true],
+			'Invalid check path (type): true'    => ['/', true, false],
+			'Invalid check path (type): integer' => ['/', 123, false],
+			'Invalid check path (type): array'   => ['/', [1, 2], false],
+			['/', '', true],
+			['/', '/', true],
 
-			array('/', '/test', true),
-			array('/', '/test/', true),
+			['/', '/test', true],
+			['/', '/test/', true],
 
-			array('/test', '/', false),
-			array('/test', '/test', true),
-			array('/test', '/testing', false),
-			array('/test', '/test/', true),
-			array('/test', '/test/ing', true),
-			array('/test', '/test/ing/', true),
+			['/test', '/', false],
+			['/test', '/test', true],
+			['/test', '/testing', false],
+			['/test', '/test/', true],
+			['/test', '/test/ing', true],
+			['/test', '/test/ing/', true],
 
-			array('/test/', '/test/', true),
-			array('/test/', '/', false),
-		);
+			['/test/', '/test/', true],
+			['/test/', '/', false],
+		];
 	}
 
 	/**
@@ -213,30 +213,30 @@ final class CookiesTest extends TestCase {
 	}
 
 	public function urlMatchProvider() {
-		return array(
+		return [
 			// Domain handling
-			array('example.com', '/', 'http://example.com/', true, true),
-			array('example.com', '/', 'http://www.example.com/', false, true),
-			array('example.com', '/', 'http://example.net/', false, false),
-			array('example.com', '/', 'http://www.example.net/', false, false),
+			['example.com', '/', 'http://example.com/', true, true],
+			['example.com', '/', 'http://www.example.com/', false, true],
+			['example.com', '/', 'http://example.net/', false, false],
+			['example.com', '/', 'http://www.example.net/', false, false],
 
 			// /test
-			array('example.com', '/test', 'http://example.com/', false, false),
-			array('example.com', '/test', 'http://www.example.com/', false, false),
+			['example.com', '/test', 'http://example.com/', false, false],
+			['example.com', '/test', 'http://www.example.com/', false, false],
 
-			array('example.com', '/test', 'http://example.com/test', true, true),
-			array('example.com', '/test', 'http://www.example.com/test', false, true),
+			['example.com', '/test', 'http://example.com/test', true, true],
+			['example.com', '/test', 'http://www.example.com/test', false, true],
 
-			array('example.com', '/test', 'http://example.com/testing', false, false),
-			array('example.com', '/test', 'http://www.example.com/testing', false, false),
+			['example.com', '/test', 'http://example.com/testing', false, false],
+			['example.com', '/test', 'http://www.example.com/testing', false, false],
 
-			array('example.com', '/test', 'http://example.com/test/', true, true),
-			array('example.com', '/test', 'http://www.example.com/test/', false, true),
+			['example.com', '/test', 'http://example.com/test/', true, true],
+			['example.com', '/test', 'http://www.example.com/test/', false, true],
 
 			// /test/
-			array('example.com', '/test/', 'http://example.com/', false, false),
-			array('example.com', '/test/', 'http://www.example.com/', false, false),
-		);
+			['example.com', '/test/', 'http://example.com/', false, false],
+			['example.com', '/test/', 'http://www.example.com/', false, false],
+		];
 	}
 
 	/**
@@ -262,9 +262,9 @@ final class CookiesTest extends TestCase {
 		$attributes           = new CaseInsensitiveDictionary();
 		$attributes['domain'] = $domain;
 		$attributes['path']   = $path;
-		$flags                = array(
+		$flags                = [
 			'host-only' => false,
-		);
+		];
 		$check                = new Iri($check);
 		$cookie               = new Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
 		$this->assertSame($domain_matches, $cookie->uri_matches($check));
@@ -275,9 +275,9 @@ final class CookiesTest extends TestCase {
 		$attributes['domain'] = 'example.com';
 		$attributes['path']   = '/';
 		$attributes['secure'] = true;
-		$flags                = array(
+		$flags                = [
 			'host-only' => false,
-		);
+		];
 		$cookie               = new Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
 
 		$this->assertTrue($cookie->uri_matches(new Iri('https://example.com/')));
@@ -311,89 +311,89 @@ final class CookiesTest extends TestCase {
 	}
 
 	public static function parseResultProvider() {
-		return array(
+		return [
 			// Basic parsing
-			array(
+			[
 				'foo=bar',
-				array('name' => 'foo', 'value' => 'bar'),
-			),
-			array(
+				['name' => 'foo', 'value' => 'bar'],
+			],
+			[
 				'bar',
-				array('name' => '', 'value' => 'bar'),
-			),
+				['name' => '', 'value' => 'bar'],
+			],
 
 			// Expiration
 			// RFC 822, updated by RFC 1123
-			array(
+			[
 				'foo=bar; Expires=Thu, 5-Dec-2013 04:50:12 GMT',
-				array('expired' => true),
-				array('expires' => gmmktime(4, 50, 12, 12, 5, 2013)),
-			),
-			array(
+				['expired' => true],
+				['expires' => gmmktime(4, 50, 12, 12, 5, 2013)],
+			],
+			[
 				'foo=bar; Expires=Fri, 5-Dec-2014 04:50:12 GMT',
-				array('expired' => false),
-				array('expires' => gmmktime(4, 50, 12, 12, 5, 2014)),
-			),
+				['expired' => false],
+				['expires' => gmmktime(4, 50, 12, 12, 5, 2014)],
+			],
 			// RFC 850, obsoleted by RFC 1036
-			array(
+			[
 				'foo=bar; Expires=Thursday, 5-Dec-2013 04:50:12 GMT',
-				array('expired' => true),
-				array('expires' => gmmktime(4, 50, 12, 12, 5, 2013)),
-			),
-			array(
+				['expired' => true],
+				['expires' => gmmktime(4, 50, 12, 12, 5, 2013)],
+			],
+			[
 				'foo=bar; Expires=Friday, 5-Dec-2014 04:50:12 GMT',
-				array('expired' => false),
-				array('expires' => gmmktime(4, 50, 12, 12, 5, 2014)),
-			),
+				['expired' => false],
+				['expires' => gmmktime(4, 50, 12, 12, 5, 2014)],
+			],
 			// Test with asctime()
-			array(
+			[
 				'foo=bar; Expires=Thu Dec  5 04:50:12 2013',
-				array('expired' => true),
-				array('expires' => gmmktime(4, 50, 12, 12, 5, 2013)),
-			),
-			array(
+				['expired' => true],
+				['expires' => gmmktime(4, 50, 12, 12, 5, 2013)],
+			],
+			[
 				'foo=bar; Expires=Fri Dec  5 04:50:12 2014',
-				array('expired' => false),
-				array('expires' => gmmktime(4, 50, 12, 12, 5, 2014)),
-			),
-			array(
+				['expired' => false],
+				['expires' => gmmktime(4, 50, 12, 12, 5, 2014)],
+			],
+			[
 				// Invalid
 				'foo=bar; Expires=never',
-				array(),
-				array('expires' => null),
-			),
+				[],
+				['expires' => null],
+			],
 
 			// Max-Age
-			array(
+			[
 				'foo=bar; Max-Age=10',
-				array('expired' => false),
-				array('max-age' => gmmktime(0, 0, 10, 1, 1, 2014)),
-			),
-			array(
+				['expired' => false],
+				['max-age' => gmmktime(0, 0, 10, 1, 1, 2014)],
+			],
+			[
 				'foo=bar; Max-Age=3660',
-				array('expired' => false),
-				array('max-age' => gmmktime(1, 1, 0, 1, 1, 2014)),
-			),
-			array(
+				['expired' => false],
+				['max-age' => gmmktime(1, 1, 0, 1, 1, 2014)],
+			],
+			[
 				'foo=bar; Max-Age=0',
-				array('expired' => true),
-				array('max-age' => 0),
-			),
-			array(
+				['expired' => true],
+				['max-age' => 0],
+			],
+			[
 				'foo=bar; Max-Age=-1000',
-				array('expired' => true),
-				array('max-age' => 0),
-			),
-			array(
+				['expired' => true],
+				['max-age' => 0],
+			],
+			[
 				// Invalid (non-digit character)
 				'foo=bar; Max-Age=1e6',
-				array('expired' => false),
-				array('max-age' => null),
-			),
-		);
+				['expired' => false],
+				['max-age' => null],
+			],
+		];
 	}
 
-	private function check_parsed_cookie($cookie, $expected, $expected_attributes, $expected_flags = array()) {
+	private function check_parsed_cookie($cookie, $expected, $expected_attributes, $expected_flags = []) {
 		if (isset($expected['name'])) {
 			$this->assertSame($expected['name'], $cookie->name);
 		}
@@ -418,7 +418,7 @@ final class CookiesTest extends TestCase {
 	/**
 	 * @dataProvider parseResultProvider
 	 */
-	public function testParsingHeader($header, $expected, $expected_attributes = array(), $expected_flags = array()) {
+	public function testParsingHeader($header, $expected, $expected_attributes = [], $expected_flags = []) {
 		// Set the reference time to 2014-01-01 00:00:00
 		$reference_time = gmmktime(0, 0, 0, 1, 1, 2014);
 
@@ -431,7 +431,7 @@ final class CookiesTest extends TestCase {
 	 *
 	 * @dataProvider parseResultProvider
 	 */
-	public function testParsingHeaderDouble($header, $expected, $expected_attributes = array(), $expected_flags = array()) {
+	public function testParsingHeaderDouble($header, $expected, $expected_attributes = [], $expected_flags = []) {
 		// Set the reference time to 2014-01-01 00:00:00
 		$reference_time = gmmktime(0, 0, 0, 1, 1, 2014);
 
@@ -446,7 +446,7 @@ final class CookiesTest extends TestCase {
 	/**
 	 * @dataProvider parseResultProvider
 	 */
-	public function testParsingHeaderObject($header, $expected, $expected_attributes = array(), $expected_flags = array()) {
+	public function testParsingHeaderObject($header, $expected, $expected_attributes = [], $expected_flags = []) {
 		$headers               = new Headers();
 		$headers['Set-Cookie'] = $header;
 
@@ -461,119 +461,119 @@ final class CookiesTest extends TestCase {
 	}
 
 	public function parseFromHeadersProvider() {
-		return array(
+		return [
 			# Varying origin path
-			array(
+			[
 				'name=value',
 				'http://example.com/',
-				array(),
-				array('path' => '/'),
-				array('host-only' => true),
-			),
-			array(
+				[],
+				['path' => '/'],
+				['host-only' => true],
+			],
+			[
 				'name=value',
 				'http://example.com/test',
-				array(),
-				array('path' => '/'),
-				array('host-only' => true),
-			),
-			array(
+				[],
+				['path' => '/'],
+				['host-only' => true],
+			],
+			[
 				'name=value',
 				'http://example.com/test/',
-				array(),
-				array('path' => '/test'),
-				array('host-only' => true),
-			),
-			array(
+				[],
+				['path' => '/test'],
+				['host-only' => true],
+			],
+			[
 				'name=value',
 				'http://example.com/test/abc',
-				array(),
-				array('path' => '/test'),
-				array('host-only' => true),
-			),
-			array(
+				[],
+				['path' => '/test'],
+				['host-only' => true],
+			],
+			[
 				'name=value',
 				'http://example.com/test/abc/',
-				array(),
-				array('path' => '/test/abc'),
-				array('host-only' => true),
-			),
+				[],
+				['path' => '/test/abc'],
+				['host-only' => true],
+			],
 
 			# With specified path
-			array(
+			[
 				'name=value; path=/',
 				'http://example.com/',
-				array(),
-				array('path' => '/'),
-				array('host-only' => true),
-			),
-			array(
+				[],
+				['path' => '/'],
+				['host-only' => true],
+			],
+			[
 				'name=value; path=/test',
 				'http://example.com/',
-				array(),
-				array('path' => '/test'),
-				array('host-only' => true),
-			),
-			array(
+				[],
+				['path' => '/test'],
+				['host-only' => true],
+			],
+			[
 				'name=value; path=/test/',
 				'http://example.com/',
-				array(),
-				array('path' => '/test/'),
-				array('host-only' => true),
-			),
+				[],
+				['path' => '/test/'],
+				['host-only' => true],
+			],
 
 			# Invalid path
-			array(
+			[
 				'name=value; path=yolo',
 				'http://example.com/',
-				array(),
-				array('path' => '/'),
-				array('host-only' => true),
-			),
-			array(
+				[],
+				['path' => '/'],
+				['host-only' => true],
+			],
+			[
 				'name=value; path=yolo',
 				'http://example.com/test/',
-				array(),
-				array('path' => '/test'),
-				array('host-only' => true),
-			),
+				[],
+				['path' => '/test'],
+				['host-only' => true],
+			],
 
 			# Cross-origin cookies, reject!
-			array(
+			[
 				'name=value; domain=example.org',
 				'http://example.com/',
-				array('invalid' => false),
-			),
+				['invalid' => false],
+			],
 
 			# Empty Domain
-			array(
+			[
 				'name=value; domain=',
 				'http://example.com/test/',
-				array(),
-			),
+				[],
+			],
 
 			# Subdomain cookies
-			array(
+			[
 				'name=value; domain=test.example.com',
 				'http://test.example.com/',
-				array(),
-				array('domain' => 'test.example.com'),
-				array('host-only' => false),
-			),
-			array(
+				[],
+				['domain' => 'test.example.com'],
+				['host-only' => false],
+			],
+			[
 				'name=value; domain=example.com',
 				'http://test.example.com/',
-				array(),
-				array('domain' => 'example.com'),
-				array('host-only' => false),
-			),
-		);
+				[],
+				['domain' => 'example.com'],
+				['host-only' => false],
+			],
+		];
 	}
 
 	/**
 	 * @dataProvider parseFromHeadersProvider
 	 */
-	public function testParsingHeaderWithOrigin($header, $origin, $expected, $expected_attributes = array(), $expected_flags = array()) {
+	public function testParsingHeaderWithOrigin($header, $origin, $expected, $expected_attributes = [], $expected_flags = []) {
 		$origin                = new Iri($origin);
 		$headers               = new Headers();
 		$headers['Set-Cookie'] = $header;
@@ -634,11 +634,11 @@ final class CookiesTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidStringInput() {
-		return array(
-			'null'              => array(null),
-			'float'             => array(1.1),
-			'stringable object' => array(new StringableObject('name')),
-		);
+		return [
+			'null'              => [null],
+			'float'             => [1.1],
+			'stringable object' => [new StringableObject('name')],
+		];
 	}
 
 	/**
@@ -665,12 +665,12 @@ final class CookiesTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidAttributes() {
-		return array(
-			'null'                                 => array(null),
-			'text string'                          => array('array'),
-			'iterator object without array access' => array(new EmptyIterator()),
-			'array accessible object not iterable' => array(new ArrayAccessibleObject(array(1, 2, 3))),
-		);
+		return [
+			'null'                                 => [null],
+			'text string'                          => ['array'],
+			'iterator object without array access' => [new EmptyIterator()],
+			'array accessible object not iterable' => [new ArrayAccessibleObject([1, 2, 3])],
+		];
 	}
 
 	/**
@@ -688,7 +688,7 @@ final class CookiesTest extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #4 ($flags) must be of type array');
 
-		new Cookie('name', 'value', array(), $input);
+		new Cookie('name', 'value', [], $input);
 	}
 
 	/**
@@ -697,11 +697,11 @@ final class CookiesTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidFlags() {
-		return array(
-			'null'                    => array(null),
-			'integer'                 => array(101),
-			'array accessible object' => array(new ArrayAccessibleObject(array())),
-		);
+		return [
+			'null'                    => [null],
+			'integer'                 => [101],
+			'array accessible object' => [new ArrayAccessibleObject([])],
+		];
 	}
 
 	/**
@@ -719,7 +719,7 @@ final class CookiesTest extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #5 ($reference_time) must be of type integer|null');
 
-		new Cookie('name', 'value', array(), array(), $input);
+		new Cookie('name', 'value', [], [], $input);
 	}
 
 	/**
@@ -728,11 +728,11 @@ final class CookiesTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidReferenceTime() {
-		return array(
-			'float'           => array(1.1),
-			'string'          => array('now'),
-			'DateTime object' => array(new DateTime('now')),
-		);
+		return [
+			'float'           => [1.1],
+			'string'          => ['now'],
+			'DateTime object' => [new DateTime('now')],
+		];
 	}
 
 	/**

--- a/tests/Exception/Http/StatusUnknownTest.php
+++ b/tests/Exception/Http/StatusUnknownTest.php
@@ -39,22 +39,22 @@ final class StatusUnknownTest extends TestCase {
 
 		$response_without_status = new Response();
 
-		return array(
-			'null (or not passed)' => array(
+		return [
+			'null (or not passed)' => [
 				'expectedCode' => 0,
-			),
-			'integer error code as data' => array(
+			],
+			'integer error code as data' => [
 				'expectedCode' => 0,
 				'data'         => 507,
-			),
-			'Response object with status code' => array(
+			],
+			'Response object with status code' => [
 				'expectedCode' => 12345,
 				'data'         => $response_with_status,
-			),
-			'Response object without status code' => array(
+			],
+			'Response object without status code' => [
 				'expectedCode' => 0,
 				'data'         => $response_without_status,
-			),
-		);
+			],
+		];
 	}
 }

--- a/tests/Exception/HttpTest.php
+++ b/tests/Exception/HttpTest.php
@@ -40,17 +40,17 @@ final class HttpTest extends TestCase {
 	 * @return array
 	 */
 	public function dataException() {
-		return array(
-			'null (or not passed)' => array(
+		return [
+			'null (or not passed)' => [
 				'expected_msg'    => 'Unknown',
 				'expected_reason' => 'Unknown',
-			),
-			'text string: "testing-1-2-3"' => array(
+			],
+			'text string: "testing-1-2-3"' => [
 				'expected_msg'    => '0 testing-1-2-3',
 				'expected_reason' => 'testing-1-2-3',
 				'reason'          => 'testing-1-2-3',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -75,31 +75,31 @@ final class HttpTest extends TestCase {
 	public function dataGetClass() {
 		$default = StatusUnknown::class;
 
-		return array(
-			'null' => array(
+		return [
+			'null' => [
 				'code'     => null,
 				'expected' => $default,
-			),
-			'false' => array(
+			],
+			'false' => [
 				'code'     => null,
 				'expected' => $default,
-			),
-			'integer 0' => array(
+			],
+			'integer 0' => [
 				'code'     => 0,
 				'expected' => $default,
-			),
-			'integer 404' => array(
+			],
+			'integer 404' => [
 				'code'     => 404,
 				'expected' => '\\' . Status404::class,
-			),
-			'string 404' => array(
+			],
+			'string 404' => [
 				'code'     => '404',
 				'expected' => '\\' . Status404::class,
-			),
-			'integer 422: class does not exist' => array(
+			],
+			'integer 422: class does not exist' => [
 				'code'     => 422,
 				'expected' => $default,
-			),
-		);
+			],
+		];
 	}
 }

--- a/tests/Exception/Transport/CurlTest.php
+++ b/tests/Exception/Transport/CurlTest.php
@@ -51,8 +51,8 @@ final class CurlTest extends TestCase {
 	 * @return array
 	 */
 	public function dataException() {
-		return array(
-			'Everything set to null (or not passed)' => array(
+		return [
+			'Everything set to null (or not passed)' => [
 				'expected_msg'    => '-1 Unknown',
 				'expected_code'   => -1,
 				'expected_reason' => 'Unknown',
@@ -60,8 +60,8 @@ final class CurlTest extends TestCase {
 				'type'            => null,
 				'data'            => null,
 				'code'            => null,
-			),
-			'Message passed, everything else set to null (or not passed)' => array(
+			],
+			'Message passed, everything else set to null (or not passed)' => [
 				'expected_msg'    => '-1 testing-1-2-3',
 				'expected_code'   => -1,
 				'expected_reason' => 'testing-1-2-3',
@@ -69,8 +69,8 @@ final class CurlTest extends TestCase {
 				'type'            => null,
 				'data'            => null,
 				'code'            => null,
-			),
-			'Type passed, everything else set to null (or not passed)' => array(
+			],
+			'Type passed, everything else set to null (or not passed)' => [
 				'expected_msg'    => '-1 Unknown',
 				'expected_code'   => -1,
 				'expected_reason' => 'Unknown',
@@ -78,8 +78,8 @@ final class CurlTest extends TestCase {
 				'type'            => Curl::EASY,
 				'data'            => null,
 				'code'            => null,
-			),
-			'Code passed, everything else set to null (or not passed)' => array(
+			],
+			'Code passed, everything else set to null (or not passed)' => [
 				'expected_msg'    => CURLE_COULDNT_RESOLVE_HOST . ' Unknown',
 				'expected_code'   => CURLE_COULDNT_RESOLVE_HOST,
 				'expected_reason' => 'Unknown',
@@ -87,8 +87,8 @@ final class CurlTest extends TestCase {
 				'type'            => null,
 				'data'            => null,
 				'code'            => CURLE_COULDNT_RESOLVE_HOST,
-			),
-			'Message and type passed, everything else set to null (or not passed)' => array(
+			],
+			'Message and type passed, everything else set to null (or not passed)' => [
 				'expected_msg'    => '-1 testing-1-2-3',
 				'expected_code'   => -1,
 				'expected_reason' => 'testing-1-2-3',
@@ -96,8 +96,8 @@ final class CurlTest extends TestCase {
 				'type'            => Curl::EASY,
 				'data'            => null,
 				'code'            => null,
-			),
-			'Message and code passed, everything else set to null (or not passed)' => array(
+			],
+			'Message and code passed, everything else set to null (or not passed)' => [
 				'expected_msg'    => CURLE_COULDNT_RESOLVE_HOST . ' testing-1-2-3',
 				'expected_code'   => CURLE_COULDNT_RESOLVE_HOST,
 				'expected_reason' => 'testing-1-2-3',
@@ -105,8 +105,8 @@ final class CurlTest extends TestCase {
 				'type'            => null,
 				'data'            => null,
 				'code'            => CURLE_COULDNT_RESOLVE_HOST,
-			),
-			'Type and code passed, everything else set to null (or not passed)' => array(
+			],
+			'Type and code passed, everything else set to null (or not passed)' => [
 				'expected_msg'    => CURLE_COULDNT_RESOLVE_HOST . ' Unknown',
 				'expected_code'   => CURLE_COULDNT_RESOLVE_HOST,
 				'expected_reason' => 'Unknown',
@@ -114,16 +114,16 @@ final class CurlTest extends TestCase {
 				'type'            => Curl::EASY,
 				'data'            => null,
 				'code'            => CURLE_COULDNT_RESOLVE_HOST,
-			),
-			'Everything set; code not integer' => array(
+			],
+			'Everything set; code not integer' => [
 				'expected_msg'    => '61 testing-1-2-3',
 				'expected_code'   => 61,
 				'expected_reason' => 'testing-1-2-3',
 				'message'         => 'testing-1-2-3',
 				'type'            => Curl::EASY,
-				'data'            => array(),
+				'data'            => [],
 				'code'            => '61 text',
-			),
-		);
+			],
+		];
 	}
 }

--- a/tests/Fixtures/ArrayAccessibleObject.php
+++ b/tests/Fixtures/ArrayAccessibleObject.php
@@ -8,7 +8,7 @@ use ReturnTypeWillChange;
 final class ArrayAccessibleObject implements ArrayAccess {
 	private $value;
 
-	public function __construct($value = array()) {
+	public function __construct($value = []) {
 		$this->value = $value;
 	}
 

--- a/tests/Fixtures/RawTransportMock.php
+++ b/tests/Fixtures/RawTransportMock.php
@@ -6,7 +6,7 @@ use WpOrg\Requests\Transport;
 
 final class RawTransportMock implements Transport {
 	public $data = '';
-	public function request($url, $headers = array(), $data = array(), $options = array()) {
+	public function request($url, $headers = [], $data = [], $options = []) {
 		return $this->data;
 	}
 	public function request_multiple($requests, $options) {
@@ -18,7 +18,7 @@ final class RawTransportMock implements Transport {
 
 		return $requests;
 	}
-	public static function test($capabilities = array()) {
+	public static function test($capabilities = []) {
 		return true;
 	}
 }

--- a/tests/Fixtures/TestTransportMock.php
+++ b/tests/Fixtures/TestTransportMock.php
@@ -5,13 +5,13 @@ namespace WpOrg\Requests\Tests\Fixtures;
 use WpOrg\Requests\Transport;
 
 final class TestTransportMock implements Transport {
-	public function request($url, $headers = array(), $data = array(), $options = array()) {
+	public function request($url, $headers = [], $data = [], $options = []) {
 		return '';
 	}
 	public function request_multiple($requests, $options) {
-		return array();
+		return [];
 	}
-	public static function test($capabilities = array()) {
+	public static function test($capabilities = []) {
 		// Time travel is not yet supported by this transport.
 		if (isset($capabilities['time-travel']) && $capabilities['time-travel']) {
 			return false;

--- a/tests/Fixtures/TransportMock.php
+++ b/tests/Fixtures/TransportMock.php
@@ -10,7 +10,7 @@ final class TransportMock implements Transport {
 	public $body        = 'Test Body';
 	public $raw_headers = '';
 
-	private static $messages = array(
+	private static $messages = [
 		100 => '100 Continue',
 		101 => '101 Switching Protocols',
 		200 => '200 OK',
@@ -57,9 +57,9 @@ final class TransportMock implements Transport {
 		504 => '504 Gateway Timeout',
 		505 => '505 HTTP Version Not Supported',
 		511 => '511 Network Authentication Required',
-	);
+	];
 
-	public function request($url, $headers = array(), $data = array(), $options = array()) {
+	public function request($url, $headers = [], $data = [], $options = []) {
 		$status    = isset(self::$messages[$this->code]) ? self::$messages[$this->code] : $this->code . ' unknown';
 		$response  = "HTTP/1.0 $status\r\n";
 		$response .= "Content-Type: text/plain\r\n";
@@ -73,7 +73,7 @@ final class TransportMock implements Transport {
 	}
 
 	public function request_multiple($requests, $options) {
-		$responses = array();
+		$responses = [];
 		foreach ($requests as $id => $request) {
 			$handler              = new self();
 			$handler->code        = $request['options']['mock.code'];
@@ -83,15 +83,15 @@ final class TransportMock implements Transport {
 			$responses[$id]       = $handler->request($request['url'], $request['headers'], $request['data'], $request['options']);
 
 			if (!empty($options['mock.parse'])) {
-				$request['options']['hooks']->dispatch('transport.internal.parse_response', array(&$responses[$id], $request));
-				$request['options']['hooks']->dispatch('multiple.request.complete', array(&$responses[$id], $id));
+				$request['options']['hooks']->dispatch('transport.internal.parse_response', [&$responses[$id], $request]);
+				$request['options']['hooks']->dispatch('multiple.request.complete', [&$responses[$id], $id]);
 			}
 		}
 
 		return $responses;
 	}
 
-	public static function test($capabilities = array()) {
+	public static function test($capabilities = []) {
 		return true;
 	}
 }

--- a/tests/HooksTest.php
+++ b/tests/HooksTest.php
@@ -41,36 +41,36 @@ class HooksTest extends TestCase {
 	public function testRegister() {
 		// Verify initial state or the hooks property.
 		$this->assertSame(
-			array(),
+			[],
 			$this->getPropertyValue($this->hooks, 'hooks'),
 			'Initial state of $hooks is not an empty array'
 		);
 
 		// Verify that the subkeys are created correctly when they don't exist yet.
-		$this->hooks->register('hookname', array($this, 'dummyCallback1'));
+		$this->hooks->register('hookname', [$this, 'dummyCallback1']);
 		$this->assertSame(
-			array(
-				'hookname' => array(
-					0 => array(
-						array($this, 'dummyCallback1'),
-					),
-				),
-			),
+			[
+				'hookname' => [
+					0 => [
+						[$this, 'dummyCallback1'],
+					],
+				],
+			],
 			$this->getPropertyValue($this->hooks, 'hooks'),
 			'Initial hook registration failed'
 		);
 
 		// Verify that the subkeys are re-used when they already exist.
-		$this->hooks->register('hookname', array($this, 'dummyCallback2'));
+		$this->hooks->register('hookname', [$this, 'dummyCallback2']);
 		$this->assertSame(
-			array(
-				'hookname' => array(
-					0 => array(
-						array($this, 'dummyCallback1'),
-						array($this, 'dummyCallback2'),
-					),
-				),
-			),
+			[
+				'hookname' => [
+					0 => [
+						[$this, 'dummyCallback1'],
+						[$this, 'dummyCallback2'],
+					],
+				],
+			],
 			$this->getPropertyValue($this->hooks, 'hooks'),
 			'Registering a second callback on the same hook with the same priority failed'
 		);
@@ -81,17 +81,17 @@ class HooksTest extends TestCase {
 		 */
 		$this->hooks->register('hookname', 'is_int', '10');
 		$this->assertSame(
-			array(
-				'hookname' => array(
-					0  => array(
-						array($this, 'dummyCallback1'),
-						array($this, 'dummyCallback2'),
-					),
-					10 => array(
+			[
+				'hookname' => [
+					0  => [
+						[$this, 'dummyCallback1'],
+						[$this, 'dummyCallback2'],
+					],
+					10 => [
 						'is_int',
-					),
-				),
-			),
+					],
+				],
+			],
 			$this->getPropertyValue($this->hooks, 'hooks'),
 			'Registering a callback on a different priority for an existing hook failed'
 		);
@@ -140,7 +140,7 @@ class HooksTest extends TestCase {
 	 * @return void
 	 */
 	public function testDispatchWithoutRegisteredHooksOnDispatchedHook() {
-		$this->hooks->register('hookname', array($this, 'dummyCallback1'));
+		$this->hooks->register('hookname', [$this, 'dummyCallback1']);
 
 		$this->assertFalse($this->hooks->dispatch('other.hookname'));
 	}
@@ -154,13 +154,13 @@ class HooksTest extends TestCase {
 	 */
 	public function testDispatchWithSingleRegisteredHook() {
 		$mock = $this->getMockBuilder(stdClass::class)
-			->setMethods(array('callback'))
+			->setMethods(['callback'])
 			->getMock();
 
 		$mock->expects($this->once())
 			->method('callback');
 
-		$this->hooks->register('hookname', array($mock, 'callback'));
+		$this->hooks->register('hookname', [$mock, 'callback']);
 
 		$this->assertTrue($this->hooks->dispatch('hookname'));
 	}
@@ -174,7 +174,7 @@ class HooksTest extends TestCase {
 	 */
 	public function testDispatchWithMultipleRegisteredHooks() {
 		$mock = $this->getMockBuilder(stdClass::class)
-			->setMethods(array('callback_a', 'callback_b', 'callback_c'))
+			->setMethods(['callback_a', 'callback_b', 'callback_c'])
 			->getMock();
 
 		$mock->expects($this->never())
@@ -194,12 +194,12 @@ class HooksTest extends TestCase {
 				$this->identicalTo('text')
 			);
 
-		$this->hooks->register('hook_a', array($mock, 'callback_a'));
-		$this->hooks->register('hook_b', array($mock, 'callback_b'));
-		$this->hooks->register('hook_b', array($mock, 'callback_b'), 10);
-		$this->hooks->register('hook_b', array($mock, 'callback_c'));
+		$this->hooks->register('hook_a', [$mock, 'callback_a']);
+		$this->hooks->register('hook_b', [$mock, 'callback_b']);
+		$this->hooks->register('hook_b', [$mock, 'callback_b'], 10);
+		$this->hooks->register('hook_b', [$mock, 'callback_c']);
 
-		$this->assertTrue($this->hooks->dispatch('hook_b', array(10, 'text')));
+		$this->assertTrue($this->hooks->dispatch('hook_b', [10, 'text']));
 	}
 
 	/**
@@ -210,20 +210,20 @@ class HooksTest extends TestCase {
 	 * @return void
 	 */
 	public function testDispatchHandlesParametersPassedByReference() {
-		$this->hooks->register('hookname', array($this, 'dummyCallbackExpectingReferences'));
+		$this->hooks->register('hookname', [$this, 'dummyCallbackExpectingReferences']);
 		$url             = 'original';
-		$headers         = array('original');
+		$headers         = ['original'];
 		$unchanged       = 'original';
 		$not_a_reference = 'original';
 
 		$this->assertTrue(
-			$this->hooks->dispatch('hookname', array(&$url, &$headers, &$unchanged, $not_a_reference)),
+			$this->hooks->dispatch('hookname', [&$url, &$headers, &$unchanged, $not_a_reference]),
 			'Hook dispatch did not return true'
 		);
 
 		// Verify that the variables were updated by reference (when passed as reference).
 		$this->assertSame('changed', $url, 'Value of $url was not changed by reference');
-		$this->assertSame(array('changed'), $headers, 'Value of $headers was not changed by reference');
+		$this->assertSame(['changed'], $headers, 'Value of $headers was not changed by reference');
 		$this->assertSame('original', $unchanged, 'Value of unchanged parameter passed by reference, did not match original value');
 		$this->assertSame('original', $not_a_reference, 'Value of parameter not passed by reference, did not match original value');
 	}
@@ -236,9 +236,9 @@ class HooksTest extends TestCase {
 	 * @return void
 	 */
 	public function testDispatchDoesntBreakWithKeyedParametersArray() {
-		$this->hooks->register('hookname', array($this, 'dummyCallback1'));
+		$this->hooks->register('hookname', [$this, 'dummyCallback1']);
 
-		$this->assertTrue($this->hooks->dispatch('hookname', array('paramA' => 10, 'paramB' => 'text')));
+		$this->assertTrue($this->hooks->dispatch('hookname', ['paramA' => 10, 'paramB' => 'text']));
 	}
 
 	/**
@@ -283,11 +283,11 @@ class HooksTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidHookname() {
-		return array(
-			'null'              => array(null),
-			'float'             => array(1.1),
-			'stringable object' => array(new StringableObject('value')),
-		);
+		return [
+			'null'              => [null],
+			'float'             => [1.1],
+			'stringable object' => [new StringableObject('value')],
+		];
 	}
 
 	/**
@@ -314,13 +314,13 @@ class HooksTest extends TestCase {
 	 * @return array
 	 */
 	public function dataRegisterInvalidCallback() {
-		return array(
-			'null'                  => array(null),
-			'non-existent function' => array('functionname'),
-			'non-existent method'   => array(array($this, 'dummyCallbackDoesNotExist')),
-			'empty array'           => array(array()),
-			'plain object'          => array(new stdClass(), 'method'),
-		);
+		return [
+			'null'                  => [null],
+			'non-existent function' => ['functionname'],
+			'non-existent method'   => [[$this, 'dummyCallbackDoesNotExist']],
+			'empty array'           => [[]],
+			'plain object'          => [new stdClass(), 'method'],
+		];
 	}
 
 	/**
@@ -338,7 +338,7 @@ class HooksTest extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #3 ($priority) must be of type int');
 
-		$this->hooks->register('hookname', array($this, 'dummyCallback1'), $input);
+		$this->hooks->register('hookname', [$this, 'dummyCallback1'], $input);
 	}
 
 	/**
@@ -347,11 +347,11 @@ class HooksTest extends TestCase {
 	 * @return array
 	 */
 	public function dataRegisterInvalidPriority() {
-		return array(
-			'null'             => array(null),
-			'float'            => array(1.1),
-			'string "123 abc"' => array('123 abc'),
-		);
+		return [
+			'null'             => [null],
+			'float'            => [1.1],
+			'string "123 abc"' => ['123 abc'],
+		];
 	}
 
 	/**
@@ -378,13 +378,13 @@ class HooksTest extends TestCase {
 	 * @return array
 	 */
 	public function dataDispatchInvalidParameters() {
-		return array(
-			'null'                            => array(null),
-			'bool false'                      => array(false),
-			'float'                           => array(1.1),
-			'string'                          => array('param'),
-			'object implementing ArrayAccess' => array(new ArrayAccessibleObject()),
-		);
+		return [
+			'null'                            => [null],
+			'bool false'                      => [false],
+			'float'                           => [1.1],
+			'string'                          => ['param'],
+			'object implementing ArrayAccess' => [new ArrayAccessibleObject()],
+		];
 	}
 
 	/**
@@ -408,7 +408,7 @@ class HooksTest extends TestCase {
 	 */
 	public function dummyCallbackExpectingReferences(&$url, &$headers, &$unchanged, $not_a_reference) {
 		$url             = 'changed';
-		$headers         = array('changed');
+		$headers         = ['changed'];
 		$not_a_reference = 'changed';
 	}
 }

--- a/tests/IdnaEncoderTest.php
+++ b/tests/IdnaEncoderTest.php
@@ -34,32 +34,32 @@ final class IdnaEncoderTest extends TestCase {
 	 * @return array
 	 */
 	public function dataEncoding() {
-		return array(
-			'empty string' => array(
+		return [
+			'empty string' => [
 				'data'     => '',
 				'expected' => '',
-			),
-			'ascii character' => array(
+			],
+			'ascii character' => [
 				'data'     => 'a',
 				'expected' => 'a',
-			),
-			'two-byte character' => array(
+			],
+			'two-byte character' => [
 				'data'     => "\xc2\xb6", // Pilcrow character
 				'expected' => 'xn--tba',
-			),
-			'three-byte character' => array(
+			],
+			'three-byte character' => [
 				'data'     => "\xe2\x82\xac", // Euro symbol
 				'expected' => 'xn--lzg',
-			),
-			'four-byte character' => array(
+			],
+			'four-byte character' => [
 				'data'     => "\xf0\xa4\xad\xa2", // Chinese symbol?
 				'expected' => 'xn--ww6j',
-			),
+			],
 
-			'stringable object' => array(
+			'stringable object' => [
 				'data'     => new StringableObject("\xc2\xb6"),
 				'expected' => 'xn--tba',
-			),
+			],
 
 			/*
 			 * Examples taken from RFC: https://datatracker.ietf.org/doc/html/rfc3492#section-7
@@ -70,86 +70,86 @@ final class IdnaEncoderTest extends TestCase {
 			 * - Use the "Send to Unicode Converter Tool" option.
 			 * - In the tool, copy the UTF-8 sequence, lowercase it and add the `\x` between each set.
 			 */
-			'example from specs: RFC3492, section 7.1-A: Arabic' => array(
+			'example from specs: RFC3492, section 7.1-A: Arabic' => [
 				'data'     => "\xd9\x84\xd9\x8a\xd9\x87\xd9\x85\xd8\xa7\xd8\xa8\xd8\xaa\xd9\x83\xd9\x84\xd9\x85\xd9\x88\xd8\xb4\xd8\xb9\xd8\xb1\xd8\xa8\xd9\x8a\xd8\x9f",
 				'expected' => 'xn--egbpdaj6bu4bxfgehfvwxn',
-			),
-			'example from specs: RFC3492, section 7.1-B: Simplified Chinese' => array(
+			],
+			'example from specs: RFC3492, section 7.1-B: Simplified Chinese' => [
 				'data'     => "\xe4\xbb\x96\xe4\xbb\xac\xe4\xb8\xba\xe4\xbb\x80\xe4\xb9\x88\xe4\xb8\x8d\xe8\xaf\xb4\xe4\xb8\xad\xe6\x96\x87",
 				'expected' => 'xn--ihqwcrb4cv8a8dqg056pqjye',
-			),
-			'example from specs: RFC3492, section 7.1-C: Traditional Chinese' => array(
+			],
+			'example from specs: RFC3492, section 7.1-C: Traditional Chinese' => [
 				'data'     => "\xe4\xbb\x96\xe5\x80\x91\xe7\x88\xb2\xe4\xbb\x80\xe9\xba\xbd\xe4\xb8\x8d\xe8\xaa\xaa\xe4\xb8\xad\xe6\x96\x87",
 				'expected' => 'xn--ihqwctvzc91f659drss3x8bo0yb',
-			),
-			'example from specs: RFC3492, section 7.1-D: Czech' => array(
+			],
+			'example from specs: RFC3492, section 7.1-D: Czech' => [
 				'data'     => "\x50\x72\x6f\xc4\x8d\x70\x72\x6f\x73\x74\xc4\x9b\x6e\x65\x6d\x6c\x75\x76\xc3\xad\xc4\x8d\x65\x73\x6b\x79",
 				'expected' => 'xn--Proprostnemluvesky-uyb24dma41a',
-			),
-			'example from specs: RFC3492, section 7.1-E: Hebrew' => array(
+			],
+			'example from specs: RFC3492, section 7.1-E: Hebrew' => [
 				'data'     => "\xd7\x9c\xd7\x9e\xd7\x94\xd7\x94\xd7\x9d\xd7\xa4\xd7\xa9\xd7\x95\xd7\x98\xd7\x9c\xd7\x90\xd7\x9e\xd7\x93\xd7\x91\xd7\xa8\xd7\x99\xd7\x9d\xd7\xa2\xd7\x91\xd7\xa8\xd7\x99\xd7\xaa",
 				'expected' => 'xn--4dbcagdahymbxekheh6e0a7fei0b',
-			),
-			'example from specs: RFC3492, section 7.1-F: Hindi (Devanagari)' => array(
+			],
+			'example from specs: RFC3492, section 7.1-F: Hindi (Devanagari)' => [
 				'data'     => "\xe0\xa4\xaf\xe0\xa4\xb9\xe0\xa4\xb2\xe0\xa5\x8b\xe0\xa4\x97\xe0\xa4\xb9\xe0\xa4\xbf\xe0\xa4\xa8\xe0\xa5\x8d\xe0\xa4\xa6\xe0\xa5\x80\xe0\xa4\x95\xe0\xa5\x8d\xe0\xa4\xaf\xe0\xa5\x8b\xe0\xa4\x82\xe0\xa4\xa8\xe0\xa4\xb9\xe0\xa5\x80\xe0\xa4\x82\xe0\xa4\xac\xe0\xa5\x8b\xe0\xa4\xb2\xe0\xa4\xb8\xe0\xa4\x95\xe0\xa4\xa4\xe0\xa5\x87\xe0\xa4\xb9\xe0\xa5\x88\xe0\xa4\x82",
 				'expected' => 'xn--i1baa7eci9glrd9b2ae1bj0hfcgg6iyaf8o0a1dig0cd',
-			),
-			'example from specs: RFC3492, section 7.1-G: Japanese (Kanji and hiragana)' => array(
+			],
+			'example from specs: RFC3492, section 7.1-G: Japanese (Kanji and hiragana)' => [
 				'data'     => "\xe3\x81\xaa\xe3\x81\x9c\xe3\x81\xbf\xe3\x82\x93\xe3\x81\xaa\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e\xe3\x82\x92\xe8\xa9\xb1\xe3\x81\x97\xe3\x81\xa6\xe3\x81\x8f\xe3\x82\x8c\xe3\x81\xaa\xe3\x81\x84\xe3\x81\xae\xe3\x81\x8b",
 				'expected' => 'xn--n8jok5ay5dzabd5bym9f0cm5685rrjetr6pdxa',
-			),
+			],
 			/* Does not validate - output too long.
 			'example from specs: RFC3492, section 7.1-H: Korean (Hangul)' => array(
 				'data'     => "\xec\x84\xb8\xea\xb3\x84\xec\x9d\x98\xeb\xaa\xa8\xeb\x93\xa0\xec\x82\xac\xeb\x9e\x8c\xeb\x93\xa4\xec\x9d\xb4\xed\x95\x9c\xea\xb5\xad\xec\x96\xb4\xeb\xa5\xbc\xec\x9d\xb4\xed\x95\xb4\xed\x95\x9c\xeb\x8b\xa4\xeb\xa9\xb4\xec\x96\xbc\xeb\xa7\x88\xeb\x82\x98\xec\xa2\x8b\xec\x9d\x84\xea\xb9\x8c",
 				'expected' => 'xn--989aomsvi5e83db1d2a355cv1e0vak1dwrv93d5xbh15a0dt30a5jpsd879ccm6fea98c',
 			),
 			*/
-			'example from specs: RFC3492, section 7.1-I: Russian (Cyrillic)' => array(
+			'example from specs: RFC3492, section 7.1-I: Russian (Cyrillic)' => [
 				'data'     => "\xd0\xbf\xd0\xbe\xd1\x87\xd0\xb5\xd0\xbc\xd1\x83\xd0\xb6\xd0\xb5\xd0\xbe\xd0\xbd\xd0\xb8\xd0\xbd\xd0\xb5\xd0\xb3\xd0\xbe\xd0\xb2\xd0\xbe\xd1\x80\xd1\x8f\xd1\x82\xd0\xbf\xd0\xbe\xd1\x80\xd1\x83\xd1\x81\xd1\x81\xd0\xba\xd0\xb8",
 				// Officially, the `d` in `dot` should be uppercase ? Needs double-check. Either a typo in the RFC or a bug.
 				'expected' => 'xn--b1abfaaepdrnnbgefbadotcwatmq2g4l',
-			),
-			'example from specs: RFC3492, section 7.1-J: Spanish' => array(
+			],
+			'example from specs: RFC3492, section 7.1-J: Spanish' => [
 				'data'     => "\x50\x6f\x72\x71\x75\xc3\xa9\x6e\x6f\x70\x75\x65\x64\x65\x6e\x73\x69\x6d\x70\x6c\x65\x6d\x65\x6e\x74\x65\x68\x61\x62\x6c\x61\x72\x65\x6e\x45\x73\x70\x61\xc3\xb1\x6f\x6c",
 				'expected' => 'xn--PorqunopuedensimplementehablarenEspaol-fmd56a',
-			),
-			'example from specs: RFC3492, section 7.1-K: Vietnamese' => array(
+			],
+			'example from specs: RFC3492, section 7.1-K: Vietnamese' => [
 				'data'     => "\x54\xe1\xba\xa1\x69\x73\x61\x6f\x68\xe1\xbb\x8d\x6b\x68\xc3\xb4\x6e\x67\x74\x68\xe1\xbb\x83\x63\x68\xe1\xbb\x89\x6e\xc3\xb3\x69\x74\x69\xe1\xba\xbf\x6e\x67\x56\x69\xe1\xbb\x87\x74",
 				'expected' => 'xn--TisaohkhngthchnitingVit-kjcr8268qyxafd2f1b9g',
-			),
-			'example from specs: RFC3492, section 7.1-L: Japanese artist' => array(
+			],
+			'example from specs: RFC3492, section 7.1-L: Japanese artist' => [
 				'data'     => "\x33\xe5\xb9\xb4\x42\xe7\xb5\x84\xe9\x87\x91\xe5\x85\xab\xe5\x85\x88\xe7\x94\x9f",
 				'expected' => 'xn--3B-ww4c5e180e575a65lsy2b',
-			),
-			'example from specs: RFC3492, section 7.1-M: Japanese artist' => array(
+			],
+			'example from specs: RFC3492, section 7.1-M: Japanese artist' => [
 				'data'     => "\xe5\xae\x89\xe5\xae\xa4\xe5\xa5\x88\xe7\xbe\x8e\xe6\x81\xb5\x2d\x77\x69\x74\x68\x2d\x53\x55\x50\x45\x52\x2d\x4d\x4f\x4e\x4b\x45\x59\x53",
 				'expected' => 'xn---with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n',
-			),
-			'example from specs: RFC3492, section 7.1-N: Japanese artist' => array(
+			],
+			'example from specs: RFC3492, section 7.1-N: Japanese artist' => [
 				'data'     => "\x48\x65\x6c\x6c\x6f\x2d\x41\x6e\x6f\x74\x68\x65\x72\x2d\x57\x61\x79\x2d\xe3\x81\x9d\xe3\x82\x8c\xe3\x81\x9e\xe3\x82\x8c\xe3\x81\xae\xe5\xa0\xb4\xe6\x89\x80",
 				'expected' => 'xn--Hello-Another-Way--fc4qua05auwb3674vfr0b',
-			),
-			'example from specs: RFC3492, section 7.1-O: Japanese artist' => array(
+			],
+			'example from specs: RFC3492, section 7.1-O: Japanese artist' => [
 				'data'     => "\xe3\x81\xb2\xe3\x81\xa8\xe3\x81\xa4\xe5\xb1\x8b\xe6\xa0\xb9\xe3\x81\xae\xe4\xb8\x8b\x32",
 				'expected' => 'xn--2-u9tlzr9756bt3uc0v',
-			),
-			'example from specs: RFC3492, section 7.1-P: Japanese artist' => array(
+			],
+			'example from specs: RFC3492, section 7.1-P: Japanese artist' => [
 				'data'     => "\x4d\x61\x6a\x69\xe3\x81\xa7\x4b\x6f\x69\xe3\x81\x99\xe3\x82\x8b\x35\xe7\xa7\x92\xe5\x89\x8d",
 				'expected' => 'xn--MajiKoi5-783gue6qz075azm5e',
-			),
-			'example from specs: RFC3492, section 7.1-Q: Japanese artist' => array(
+			],
+			'example from specs: RFC3492, section 7.1-Q: Japanese artist' => [
 				'data'     => "\xe3\x83\x91\xe3\x83\x95\xe3\x82\xa3\xe3\x83\xbc\x64\x65\xe3\x83\xab\xe3\x83\xb3\xe3\x83\x90",
 				'expected' => 'xn--de-jg4avhby1noc0d',
-			),
-			'example from specs: RFC3492, section 7.1-R: Japanese artist' => array(
+			],
+			'example from specs: RFC3492, section 7.1-R: Japanese artist' => [
 				'data'     => "\xe3\x81\x9d\xe3\x81\xae\xe3\x82\xb9\xe3\x83\x94\xe3\x83\xbc\xe3\x83\x89\xe3\x81\xa7",
 				'expected' => 'xn--d9juau41awczczp',
-			),
-			'example from specs: RFC3492, section 7.1-S: ASCII string which breaks the rules' => array(
+			],
+			'example from specs: RFC3492, section 7.1-S: ASCII string which breaks the rules' => [
 				'data'     => "\x2d\x3e\x20\x24\x31\x2e\x30\x30\x20\x3c\x2d",
 				'expected' => '-> $1.00 <-',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -174,13 +174,13 @@ final class IdnaEncoderTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidUnicode() {
-		return array(
-			'Five-byte character'                    => array("\xfb\xb6\xb6\xb6\xb6"),
-			'Six-byte character'                     => array("\xfd\xb6\xb6\xb6\xb6\xb6"),
-			'Invalid ASCII character with multibyte' => array("\0\xc2\xb6"),
-			'Unfinished multibyte'                   => array("\xc2"),
-			'Partial multibyte'                      => array("\xc2\xc2\xb6"),
-		);
+		return [
+			'Five-byte character'                    => ["\xfb\xb6\xb6\xb6\xb6"],
+			'Six-byte character'                     => ["\xfd\xb6\xb6\xb6\xb6\xb6"],
+			'Invalid ASCII character with multibyte' => ["\0\xc2\xb6"],
+			'Unfinished multibyte'                   => ["\xc2"],
+			'Partial multibyte'                      => ["\xc2\xc2\xb6"],
+		];
 	}
 
 	/**
@@ -205,12 +205,12 @@ final class IdnaEncoderTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidInputType() {
-		return array(
-			'null'          => array(null),
-			'boolean false' => array(false),
-			'integer'       => array(12345),
-			'array'         => array(array(1, 2, 3)),
-		);
+		return [
+			'null'          => [null],
+			'boolean false' => [false],
+			'integer'       => [12345],
+			'array'         => [[1, 2, 3]],
+		];
 	}
 
 	public function testASCIITooLong() {

--- a/tests/Ipv6Test.php
+++ b/tests/Ipv6Test.php
@@ -65,10 +65,10 @@ final class Ipv6Test extends TestCase {
 	 * @return array
 	 */
 	public function dataValidInputType() {
-		return array(
-			'string'     => array('::1'),
-			'stringable' => array(new StringableObject('0:1234:dc0:41:216:3eff:fe67:3e01')),
-		);
+		return [
+			'string'     => ['::1'],
+			'stringable' => [new StringableObject('0:1234:dc0:41:216:3eff:fe67:3e01')],
+		];
 	}
 
 	/**
@@ -128,11 +128,11 @@ final class Ipv6Test extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidInputType() {
-		return array(
-			'null'          => array(null),
-			'boolean false' => array(false),
-			'integer'       => array(12345),
-			'array'         => array(array(1, 2, 3)),
-		);
+		return [
+			'null'          => [null],
+			'boolean false' => [false],
+			'integer'       => [12345],
+			'array'         => [[1, 2, 3]],
+		];
 	}
 }

--- a/tests/PortTest.php
+++ b/tests/PortTest.php
@@ -32,20 +32,20 @@ final class PortTest extends TestCase {
 	 * @return array
 	 */
 	public function dataGetPort() {
-		return array(
-			'lowercase type' => array(
+		return [
+			'lowercase type' => [
 				'input'    => 'https',
 				'expected' => Port::HTTPS,
-			),
-			'mixed type' => array(
+			],
+			'mixed type' => [
 				'input'    => 'Dict',
 				'expected' => Port::DICT,
-			),
-			'uppercase type' => array(
+			],
+			'uppercase type' => [
 				'input'    => 'ACAP',
 				'expected' => Port::ACAP,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -70,10 +70,10 @@ final class PortTest extends TestCase {
 	 * @return array
 	 */
 	public function dataGetPortThrowsExceptionOnInvalidInputType() {
-		return array(
-			'null'                => array(null),
-			'integer port number' => array(443),
-		);
+		return [
+			'null'                => [null],
+			'integer port number' => [443],
+		];
 	}
 
 	/**
@@ -98,9 +98,9 @@ final class PortTest extends TestCase {
 	 * @return array
 	 */
 	public function dataGetPortThrowsExceptionOnUnsupportedPortType() {
-		return array(
-			'type not supported' => array('FTP'),
-			'empty string'       => array(''),
-		);
+		return [
+			'type not supported' => ['FTP'],
+			'empty string'       => [''],
+		];
 	}
 }

--- a/tests/Proxy/HttpTest.php
+++ b/tests/Proxy/HttpTest.php
@@ -33,11 +33,11 @@ final class HttpTest extends TestCase {
 	public function testConnectWithString($transport) {
 		$this->checkProxyAvailable();
 
-		$options  = array(
+		$options  = [
 			'proxy'     => REQUESTS_HTTP_PROXY,
 			'transport' => $transport,
-		);
-		$response = Requests::get(httpbin('/get'), array(), $options);
+		];
+		$response = Requests::get(httpbin('/get'), [], $options);
 		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 		$data = json_decode($response->body, true);
@@ -50,11 +50,11 @@ final class HttpTest extends TestCase {
 	public function testConnectWithArray($transport) {
 		$this->checkProxyAvailable();
 
-		$options  = array(
-			'proxy'     => array(REQUESTS_HTTP_PROXY),
+		$options  = [
+			'proxy'     => [REQUESTS_HTTP_PROXY],
 			'transport' => $transport,
-		);
-		$response = Requests::get(httpbin('/get'), array(), $options);
+		];
+		$response = Requests::get(httpbin('/get'), [], $options);
 		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 		$data = json_decode($response->body, true);
@@ -67,13 +67,13 @@ final class HttpTest extends TestCase {
 	public function testConnectInvalidParameters($transport) {
 		$this->checkProxyAvailable();
 
-		$options = array(
-			'proxy'     => array(REQUESTS_HTTP_PROXY, 'testuser', 'password', 'something'),
+		$options = [
+			'proxy'     => [REQUESTS_HTTP_PROXY, 'testuser', 'password', 'something'],
 			'transport' => $transport,
-		);
+		];
 		$this->expectException(ArgumentCount::class);
 		$this->expectExceptionMessage('WpOrg\Requests\Proxy\Http::__construct() expects an array with exactly one element or exactly three elements');
-		Requests::get(httpbin('/get'), array(), $options);
+		Requests::get(httpbin('/get'), [], $options);
 	}
 
 	/**
@@ -82,11 +82,11 @@ final class HttpTest extends TestCase {
 	public function testConnectWithInstance($transport) {
 		$this->checkProxyAvailable();
 
-		$options  = array(
+		$options  = [
 			'proxy'     => new Http(REQUESTS_HTTP_PROXY),
 			'transport' => $transport,
-		);
-		$response = Requests::get(httpbin('/get'), array(), $options);
+		];
+		$response = Requests::get(httpbin('/get'), [], $options);
 		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 		$data = json_decode($response->body, true);
@@ -99,15 +99,15 @@ final class HttpTest extends TestCase {
 	public function testConnectWithAuth($transport) {
 		$this->checkProxyAvailable('auth');
 
-		$options  = array(
-			'proxy'     => array(
+		$options  = [
+			'proxy'     => [
 				REQUESTS_HTTP_PROXY_AUTH,
 				REQUESTS_HTTP_PROXY_AUTH_USER,
 				REQUESTS_HTTP_PROXY_AUTH_PASS,
-			),
+			],
 			'transport' => $transport,
-		);
-		$response = Requests::get(httpbin('/get'), array(), $options);
+		];
+		$response = Requests::get(httpbin('/get'), [], $options);
 		$this->assertSame(200, $response->status_code);
 		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
@@ -121,14 +121,14 @@ final class HttpTest extends TestCase {
 	public function testConnectWithInvalidAuth($transport) {
 		$this->checkProxyAvailable('auth');
 
-		$options = array(
-			'proxy'     => array(
+		$options = [
+			'proxy'     => [
 				REQUESTS_HTTP_PROXY_AUTH,
 				REQUESTS_HTTP_PROXY_AUTH_USER . '!',
 				REQUESTS_HTTP_PROXY_AUTH_PASS . '!',
-			),
+			],
 			'transport' => $transport,
-		);
+		];
 
 		if (version_compare(phpversion(), '5.5.0', '>=') === true
 			&& $transport === Fsockopen::class
@@ -138,7 +138,7 @@ final class HttpTest extends TestCase {
 			$this->expectExceptionMessage('fsocket timed out');
 		}
 
-		$response = Requests::get(httpbin('/get'), array(), $options);
+		$response = Requests::get(httpbin('/get'), [], $options);
 		$this->assertSame(407, $response->status_code);
 	}
 

--- a/tests/Requests/ChunkedEncodingTest.php
+++ b/tests/Requests/ChunkedEncodingTest.php
@@ -26,10 +26,10 @@ final class ChunkedDecodingTest extends TestCase {
 		$transport->body    = $body;
 		$transport->chunked = true;
 
-		$options  = array(
+		$options  = [
 			'transport' => $transport,
-		);
-		$response = Requests::get('http://example.com/', array(), $options);
+		];
+		$response = Requests::get('http://example.com/', [], $options);
 
 		$this->assertInstanceOf(Response::class, $response, 'Response is not an instance of the Response class.');
 		$this->assertSame($expected, $response->body, 'Response body does not match expected dechunked body');
@@ -41,32 +41,32 @@ final class ChunkedDecodingTest extends TestCase {
 	 * @return array
 	 */
 	public function dataChunked() {
-		return array(
-			array(
+		return [
+			[
 				'body'     => "25\r\nThis is the data in the first chunk\r\n\r\n1A\r\nand this is the second one\r\n0\r\n",
 				'expected' => "This is the data in the first chunk\r\nand this is the second one",
-			),
-			array(
+			],
+			[
 				'body'     => "02\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0\r\nnothing\n",
 				'expected' => "abra\ncadabra",
-			),
-			array(
+			],
+			[
 				'body'     => "02\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
 				'expected' => "abra\ncadabra\nall we got\n",
-			),
-			array(
+			],
+			[
 				'body'     => "02;foo=bar;hello=world\r\nab\r\n04;foo=baz\r\nra\nc\r\n06;justfoo\r\nadabra\r\n0c\r\n\nall we got\n",
 				'expected' => "abra\ncadabra\nall we got\n",
-			),
-			array(
+			],
+			[
 				'body'     => "02;foo=\"quoted value\"\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
 				'expected' => "abra\ncadabra\nall we got\n",
-			),
-			array(
+			],
+			[
 				'body'     => "02;foo-bar=baz\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n",
 				'expected' => "abra\ncadabra\nall we got\n",
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -83,10 +83,10 @@ final class ChunkedDecodingTest extends TestCase {
 		$transport->body    = $body;
 		$transport->chunked = true;
 
-		$options  = array(
+		$options  = [
 			'transport' => $transport,
-		);
-		$response = Requests::get('http://example.com/', array(), $options);
+		];
+		$response = Requests::get('http://example.com/', [], $options);
 
 		$this->assertInstanceOf(Response::class, $response, 'Response is not an instance of the Response class.');
 		$this->assertSame($transport->body, $response->body, 'Response body does not match original body');
@@ -98,15 +98,15 @@ final class ChunkedDecodingTest extends TestCase {
 	 * @return array
 	 */
 	public function dataNotActuallyChunked() {
-		return array(
-			'empty string'                         => array(''),
-			'invalid chunk size'                   => array('Hello! This is a non-chunked response!'),
-			'invalid chunk extension'              => array('1BNot chunked\r\nLooks chunked but it is not\r\n'),
-			'unquoted chunk-ext-val with space'    => array("02;foo=unquoted with space\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n"),
-			'unquoted chunk-ext-val with forbidden character' => array("02;foo={unquoted}\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n"),
-			'invalid chunk-ext-name'               => array("02;{foo}=bar\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n"),
-			'incomplete quote for chunk-ext-value' => array("02;foo=\"no end quote\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n"),
-		);
+		return [
+			'empty string'                         => [''],
+			'invalid chunk size'                   => ['Hello! This is a non-chunked response!'],
+			'invalid chunk extension'              => ['1BNot chunked\r\nLooks chunked but it is not\r\n'],
+			'unquoted chunk-ext-val with space'    => ["02;foo=unquoted with space\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n"],
+			'unquoted chunk-ext-val with forbidden character' => ["02;foo={unquoted}\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n"],
+			'invalid chunk-ext-name'               => ["02;{foo}=bar\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n"],
+			'incomplete quote for chunk-ext-value' => ["02;foo=\"no end quote\r\nab\r\n04\r\nra\nc\r\n06\r\nadabra\r\n0c\r\n\nall we got\n"],
+		];
 	}
 
 	/**
@@ -120,10 +120,10 @@ final class ChunkedDecodingTest extends TestCase {
 		$transport->body    = "02\r\nab\r\nNot actually chunked!";
 		$transport->chunked = true;
 
-		$options  = array(
+		$options  = [
 			'transport' => $transport,
-		);
-		$response = Requests::get('http://example.com/', array(), $options);
+		];
+		$response = Requests::get('http://example.com/', [], $options);
 
 		$this->assertInstanceOf(Response::class, $response, 'Response is not an instance of the Response class.');
 		$this->assertSame($transport->body, $response->body, 'Response body does not match original body');

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -55,20 +55,20 @@ final class DecompressionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataDecompressNotCompressed() {
-		return array(
-			'not compressed: empty string' => array(
+		return [
+			'not compressed: empty string' => [
 				'expected'   => '',
 				'compressed' => '',
-			),
-			'not compressed: whitespace only string' => array(
+			],
+			'not compressed: whitespace only string' => [
 				'expected'   => "  \n\r  ",
 				'compressed' => "  \n\r  ",
-			),
-			'not compressed: Requests for PHP' => array(
+			],
+			'not compressed: Requests for PHP' => [
 				'expected'   => 'Requests for PHP',
 				'compressed' => 'Requests for PHP',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -91,27 +91,27 @@ final class DecompressionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataGzip() {
-		return array(
+		return [
 			/*
 			 * Test data generated using CLI command:
 			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzencode("foobar")),2,"\\x"), 0, -2) . "\n";'
 			 */
-			'gzip: foobar' => array(
+			'gzip: foobar' => [
 				'expected'   => 'foobar',
 				'compressed' => "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x4b\xcb\xcf\x4f\x4a"
 							. "\x2c\x02\x00\x95\x1f\xf6\x9e\x06\x00\x00\x00",
-			),
+			],
 			/*
 			 * Test data generated using CLI command:
 			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzencode("Requests for PHP")),2,"\\x"), 0, -2) . "\n";'
 			 */
-			'gzip: Requests for PHP' => array(
+			'gzip: Requests for PHP' => [
 				'expected'   => 'Requests for PHP',
 				'compressed' => "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x0b\x4a\x2d\x2c\x4d"
 							. "\x2d\x2e\x29\x56\x48\xcb\x2f\x52\x08\xf0\x08\x00\x00\x58\x35"
 							. "\x18\x17\x10\x00\x00\x00",
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -120,21 +120,21 @@ final class DecompressionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataDeflate() {
-		return array(
+		return [
 			// TODO: What is this byte stream representing? Looks like GZIP header with ZLIB compressed data...
-			'deflate: foobar' => array(
+			'deflate: foobar' => [
 				'expected'   => 'foobar',
 				'compressed' => "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x78\x9c\x4b\xcb\xcf"
 							. "\x4f\x4a\x2c\x02\x00\x08\xab\x02\x7a",
-			),
+			],
 			// TODO: What is this byte stream representing? Looks like GZIP header with ZLIB compressed data...
-			'deflate: Requests for PHP' => array(
+			'deflate: Requests for PHP' => [
 				'expected'   => 'Requests for PHP',
 				'compressed' => "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x78\x9c\x0b\x4a\x2d"
 							. "\x2c\x4d\x2d\x2e\x29\x56\x48\xcb\x2f\x52\x08\xf0\x08\x00\x00"
 							. "\x34\x68\x05\xcc",
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -143,52 +143,52 @@ final class DecompressionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataDeflateWithoutHeaders() {
-		return array(
+		return [
 			/*
 			 * Test data generated using CLI command:
 			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzcompress("foobar")),2,"\\x"), 0, -2) . "\n";'
 			 */
-			'deflate without zlib headers: foobar' => array(
+			'deflate without zlib headers: foobar' => [
 				'expected'   => 'foobar',
 				'compressed' => "\x78\x9c\x4b\xcb\xcf\x4f\x4a\x2c\x02\x00\x08\xab\x02\x7a",
-			),
+			],
 			/*
 			 * Test data generated using CLI command:
 			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzcompress("Requests for PHP")),2,"\\x"), 0, -2) . "\n";'
 			 */
-			'deflate without zlib headers: Requests for PHP' => array(
+			'deflate without zlib headers: Requests for PHP' => [
 				'expected'   => 'Requests for PHP',
 				'compressed' => "\x78\x9c\x0b\x4a\x2d\x2c\x4d\x2d\x2e\x29\x56\x48\xcb\x2f\x52"
 							. "\x08\xf0\x08\x00\x00\x34\x68\x05\xcc",
-			),
+			],
 			/*
 			 * Test data generated using CLI command:
 			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzcompress("compression level 1", 1)),2,"\\x"), 0, -2) . "\n";'
 			 */
-			'deflate without zlib headers: compression level 1' => array(
+			'deflate without zlib headers: compression level 1' => [
 				'expected'   => 'compression level 1',
 				'compressed' => "\x78\x01\x4b\xce\xcf\x2d\x28\x4a\x2d\x2e\xce\xcc\xcf\x53\xc8\x49"
 							. "\x2d\x4b\xcd\x51\x30\x04\x00\x4d\x86\x07\x3c",
-			),
+			],
 			/*
 			 * Test data generated using CLI command:
 			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzcompress("compression level 3", 3)),2,"\\x"), 0, -2) . "\n";'
 			 */
-			'deflate without zlib headers: compression level 3' => array(
+			'deflate without zlib headers: compression level 3' => [
 				'expected'   => 'compression level 3',
 				'compressed' => "\x78\x5e\x4b\xce\xcf\x2d\x28\x4a\x2d\x2e\xce\xcc\xcf\x53\xc8\x49"
 							. "\x2d\x4b\xcd\x51\x30\x06\x00\x4d\x88\x07\x3e",
-			),
+			],
 			/*
 			 * Test data generated using CLI command:
 			 * php -r 'echo "\\x" . substr(chunk_split(bin2hex(gzcompress("compression level 9", 9)),2,"\\x"), 0, -2) . "\n";'
 			 */
-			'deflate without zlib headers: compression level 9' => array(
+			'deflate without zlib headers: compression level 9' => [
 				'expected'   => 'compression level 9',
 				'compressed' => "\x78\xda\x4b\xce\xcf\x2d\x28\x4a\x2d\x2e\xce\xcc\xcf\x53\xc8\x49"
 							. "\x2d\x4b\xcd\x51\xb0\x04\x00\x4d\x8e\x07\x44",
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -233,9 +233,9 @@ final class DecompressionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidInputType() {
-		return array(
-			'null'              => array(null),
-			'stringable object' => array(new StringableObject('value')),
-		);
+		return [
+			'null'              => [null],
+			'stringable object' => [new StringableObject('value')],
+		];
 	}
 }

--- a/tests/RequestsTest.php
+++ b/tests/RequestsTest.php
@@ -44,11 +44,11 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataRequestInvalidUrl() {
-		return array(
-			'null'                  => array(null),
-			'array'                 => array(array(httpbin('/'))),
-			'non-stringable object' => array(new stdClass('name')),
-		);
+		return [
+			'null'                  => [null],
+			'array'                 => [[httpbin('/')]],
+			'non-stringable object' => [new stdClass('name')],
+		];
 	}
 
 	/**
@@ -66,7 +66,7 @@ final class RequestsTest extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #4 ($type) must be of type string');
 
-		Requests::request('/', array(), array(), $input);
+		Requests::request('/', [], [], $input);
 	}
 
 	/**
@@ -75,10 +75,10 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidTypeNotString() {
-		return array(
-			'null'              => array(null),
-			'stringable object' => array(new StringableObject('type')),
-		);
+		return [
+			'null'              => [null],
+			'stringable object' => [new StringableObject('type')],
+		];
 	}
 
 	/**
@@ -96,7 +96,7 @@ final class RequestsTest extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #5 ($options) must be of type array');
 
-		Requests::request('/', array(), array(), Requests::GET, $input);
+		Requests::request('/', [], [], Requests::GET, $input);
 	}
 
 	/**
@@ -123,12 +123,12 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataRequestMultipleInvalidRequests() {
-		return array(
-			'null'                                 => array(null),
-			'text string'                          => array('array'),
-			'iterator object without array access' => array(new EmptyIterator()),
-			'array accessible object not iterable' => array(new ArrayAccessibleObject(array(1, 2, 3))),
-		);
+		return [
+			'null'                                 => [null],
+			'text string'                          => ['array'],
+			'iterator object without array access' => [new EmptyIterator()],
+			'array accessible object not iterable' => [new ArrayAccessibleObject([1, 2, 3])],
+		];
 	}
 
 	/**
@@ -146,7 +146,7 @@ final class RequestsTest extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #2 ($options) must be of type array');
 
-		Requests::request_multiple(array(), $input);
+		Requests::request_multiple([], $input);
 	}
 
 	/**
@@ -155,10 +155,10 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidTypeNotArray() {
-		return array(
-			'null'                    => array(null),
-			'array accessible object' => array(new ArrayAccessibleObject(array())),
-		);
+		return [
+			'null'                    => [null],
+			'array accessible object' => [new ArrayAccessibleObject([])],
+		];
 	}
 
 	public function testInvalidProtocol() {
@@ -190,10 +190,10 @@ final class RequestsTest extends TestCase {
 			"  three\r\n\r\n" .
 			"stop\r\n";
 
-		$options               = array(
+		$options               = [
 			'transport' => $transport,
-		);
-		$response              = Requests::get('http://example.com/', array(), $options);
+		];
+		$response              = Requests::get('http://example.com/', [], $options);
 		$expected              = new Headers();
 		$expected['host']      = 'localhost,ambiguous';
 		$expected['nospace']   = 'here';
@@ -216,11 +216,11 @@ final class RequestsTest extends TestCase {
 			"HTTP/1.0 200 OK\r\n" .
 			"Host: localhost\r\n\r\n";
 
-		$options = array(
+		$options = [
 			'transport' => $transport,
-		);
+		];
 
-		$response = Requests::get('http://example.com/', array(), $options);
+		$response = Requests::get('http://example.com/', [], $options);
 		$this->assertSame(1.0, $response->protocol_version);
 	}
 
@@ -231,10 +231,10 @@ final class RequestsTest extends TestCase {
 			"Host: localhost\r\n\r\n" .
 			'Test';
 
-		$options  = array(
+		$options  = [
 			'transport' => $transport,
-		);
-		$response = Requests::get('http://example.com/', array(), $options);
+		];
+		$response = Requests::get('http://example.com/', [], $options);
 		$this->assertSame($transport->data, $response->raw);
 	}
 
@@ -245,10 +245,10 @@ final class RequestsTest extends TestCase {
 		$transport       = new RawTransportMock();
 		$transport->data = "HTTP/1.0 200 OK\r\nTest: value\nAnother-Test: value\r\n\r\n";
 
-		$options  = array(
+		$options  = [
 			'transport' => $transport,
-		);
-		$response = Requests::get('http://example.com/', array(), $options);
+		];
+		$response = Requests::get('http://example.com/', [], $options);
 		$this->assertSame('value', $response->headers['test']);
 		$this->assertSame('value', $response->headers['another-test']);
 	}
@@ -263,13 +263,13 @@ final class RequestsTest extends TestCase {
 		$transport       = new RawTransportMock();
 		$transport->data = "HTTP/0.9 200 OK\r\n\r\n<p>Test";
 
-		$options = array(
+		$options = [
 			'transport' => $transport,
-		);
+		];
 
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Response could not be parsed');
-		Requests::get('http://example.com/', array(), $options);
+		Requests::get('http://example.com/', [], $options);
 	}
 
 	/**
@@ -279,45 +279,45 @@ final class RequestsTest extends TestCase {
 		$transport       = new RawTransportMock();
 		$transport->data = "HTTP/0.9 200 OK\r\n<p>Test";
 
-		$options = array(
+		$options = [
 			'transport' => $transport,
-		);
+		];
 
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Missing header/body separator');
-		Requests::get('http://example.com/', array(), $options);
+		Requests::get('http://example.com/', [], $options);
 	}
 
 	public function testInvalidStatus() {
 		$transport       = new RawTransportMock();
 		$transport->data = "HTTP/1.1 OK\r\nTest: value\nAnother-Test: value\r\n\r\nTest";
 
-		$options = array(
+		$options = [
 			'transport' => $transport,
-		);
+		];
 
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Response could not be parsed');
-		Requests::get('http://example.com/', array(), $options);
+		Requests::get('http://example.com/', [], $options);
 	}
 
 	public function test30xWithoutLocation() {
 		$transport       = new TransportMock();
 		$transport->code = 302;
 
-		$options  = array(
+		$options  = [
 			'transport' => $transport,
-		);
-		$response = Requests::get('http://example.com/', array(), $options);
+		];
+		$response = Requests::get('http://example.com/', [], $options);
 		$this->assertSame(302, $response->status_code);
 		$this->assertSame(0, $response->redirects);
 	}
 
 	public function testTimeoutException() {
-		$options = array('timeout' => 0.5);
+		$options = ['timeout' => 0.5];
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('timed out');
-		Requests::get(httpbin('/delay/3'), array(), $options);
+		Requests::get(httpbin('/delay/3'), [], $options);
 	}
 
 	/**
@@ -327,7 +327,7 @@ final class RequestsTest extends TestCase {
 		if (!extension_loaded('curl') && !extension_loaded('openssl')) {
 			$this->markTestSkipped('Testing for SSL requires either the curl or the openssl extension');
 		}
-		$this->assertTrue(Requests::has_capabilities(array(Capability::SSL => true)));
+		$this->assertTrue(Requests::has_capabilities([Capability::SSL => true]));
 	}
 
 	/**
@@ -336,11 +336,11 @@ final class RequestsTest extends TestCase {
 	public function testHasCapabilitiesFailsForUnsupportedCapabilities() {
 		$transports = new ReflectionProperty(Requests::class, 'transports');
 		$transports->setAccessible(true);
-		$transports->setValue(array(TestTransportMock::class));
+		$transports->setValue([TestTransportMock::class]);
 
-		$result = Requests::has_capabilities(array('time-travel' => true));
+		$result = Requests::has_capabilities(['time-travel' => true]);
 
-		$transports->setValue(array());
+		$transports->setValue([]);
 		$transports->setAccessible(false);
 
 		$this->assertFalse($result);
@@ -369,12 +369,12 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataSetCertificatePathValidData() {
-		return array(
-			'boolean false'     => array(false),
-			'boolean true'      => array(true),
-			'string'            => array('path/to/file.pem'),
-			'stringable object' => array(new StringableObject('path/to/file.pem')),
-		);
+		return [
+			'boolean false'     => [false],
+			'boolean true'      => [true],
+			'string'            => ['path/to/file.pem'],
+			'stringable object' => [new StringableObject('path/to/file.pem')],
+		];
 	}
 
 	/**
@@ -401,10 +401,10 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataSetCertificatePathInvalidData() {
-		return array(
-			'null'                  => array(null),
-			'non-stringable object' => array(new stdClass('value')),
-		);
+		return [
+			'null'                  => [null],
+			'non-stringable object' => [new stdClass('value')],
+		];
 	}
 
 	/**
@@ -419,10 +419,10 @@ final class RequestsTest extends TestCase {
 	 * @return void
 	 */
 	public function testFlattenValidData($input) {
-		$expected = array(
+		$expected = [
 			0 => 'key1: value1',
 			1 => 'key2: value2',
-		);
+		];
 
 		$this->assertSame($expected, Requests::flatten($input));
 	}
@@ -433,12 +433,12 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataFlattenValidData() {
-		$to_flatten = array('key1' => 'value1', 'key2' => 'value2');
+		$to_flatten = ['key1' => 'value1', 'key2' => 'value2'];
 
-		return array(
-			'array'           => array($to_flatten),
-			'iterable object' => array(new ArrayIterator($to_flatten)),
-		);
+		return [
+			'array'           => [$to_flatten],
+			'iterable object' => [new ArrayIterator($to_flatten)],
+		];
 	}
 
 	/**
@@ -465,9 +465,9 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataFlattenInvalidData() {
-		return array(
-			'null'                                 => array(null),
-			'array accessible object not iterable' => array(new ArrayAccessibleObject(array(1, 2, 3))),
-		);
+		return [
+			'null'                                 => [null],
+			'array accessible object not iterable' => [new ArrayAccessibleObject([1, 2, 3])],
+		];
 	}
 }

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -53,11 +53,11 @@ final class HeadersTest extends TestCase {
 	 * @return array
 	 */
 	public function dataCaseInsensitiveArrayAccess() {
-		return array(
-			'access using case as set' => array('Content-Type'),
-			'access using lowercase'   => array('content-type'),
-			'access using uppercase'   => array('CONTENT-TYPE'),
-		);
+		return [
+			'access using case as set' => ['Content-Type'],
+			'access using lowercase'   => ['content-type'],
+			'access using uppercase'   => ['CONTENT-TYPE'],
+		];
 	}
 
 	/**
@@ -107,10 +107,10 @@ final class HeadersTest extends TestCase {
 	 * @return array
 	 */
 	public function dataOffsetSetDoesNotTryToLowercaseNonStringKeys() {
-		return array(
-			'integer key'       => array(10),
-			'boolean false key' => array(false, 0),
-		);
+		return [
+			'integer key'       => [10],
+			'boolean false key' => [false, 0],
+		];
 	}
 
 	/**
@@ -153,12 +153,12 @@ final class HeadersTest extends TestCase {
 	 * @return array
 	 */
 	public function dataOffsetGetReturnsNullForNonRegisteredHeader() {
-		return array(
+		return [
 			// This test case also tests that no "passing null to non-nullable" deprecation is thrown in PHP 8.1.
-			'null'                       => array(null),
-			'non-registered integer key' => array(10),
-			'non-registred string key'   => array('not-content-type'),
-		);
+			'null'                       => [null],
+			'non-registered integer key' => [10],
+			'non-registred string key'   => ['not-content-type'],
+		];
 	}
 
 	/**
@@ -189,35 +189,35 @@ final class HeadersTest extends TestCase {
 	 * @return array
 	 */
 	public function dataGetValues() {
-		return array(
-			'using case as set, single entry header' => array(
+		return [
+			'using case as set, single entry header' => [
 				'key'      => 'Content-Type',
-				'expected' => array(
+				'expected' => [
 					'text/plain',
-				),
-			),
-			'using lowercase, single entry header' => array(
+				],
+			],
+			'using lowercase, single entry header' => [
 				'key'      => 'content-length',
-				'expected' => array(
+				'expected' => [
 					10,
-				),
-			),
-			'using uppercase, multiple entry header' => array(
+				],
+			],
+			'using uppercase, multiple entry header' => [
 				'key'      => 'ACCEPT',
-				'expected' => array(
+				'expected' => [
 					'text/html;q=1.0',
 					'*/*;q=0.1',
-				),
-			),
-			'non-registered string key' => array(
+				],
+			],
+			'non-registered string key' => [
 				'key'      => 'my-custom-header',
 				'expected' => null,
-			),
-			'non-registered integer key' => array(
+			],
+			'non-registered integer key' => [
 				'key'      => 10,
 				'expected' => null,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -245,10 +245,10 @@ final class HeadersTest extends TestCase {
 	 * @return array
 	 */
 	public function dataGetValuesInvalidOffset() {
-		return array(
-			'null'          => array(null),
-			'boolean false' => array(false),
-		);
+		return [
+			'null'          => [null],
+			'boolean false' => [false],
+		];
 	}
 
 	/**
@@ -310,11 +310,11 @@ final class HeadersTest extends TestCase {
 	 * @return array
 	 */
 	public function dataFlatten() {
-		return array(
-			'string'            => array('text', 'text'),
-			'empty array'       => array(array(), ''),
-			'array with values' => array(array('text', 10, 'more text'), 'text,10,more text'),
-		);
+		return [
+			'string'            => ['text', 'text'],
+			'empty array'       => [[], ''],
+			'array with values' => [['text', 10, 'more text'], 'text,10,more text'],
+		];
 	}
 
 	/**
@@ -342,10 +342,10 @@ final class HeadersTest extends TestCase {
 	 * @return array
 	 */
 	public function dataFlattenInvalidValue() {
-		return array(
-			'null'          => array(null),
-			'boolean false' => array(false),
-			'plain object'  => array(new stdClass()),
-		);
+		return [
+			'null'          => [null],
+			'boolean false' => [false],
+			'plain object'  => [new stdClass()],
+		];
 	}
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -40,14 +40,14 @@ final class ResponseTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidJsonResponse() {
-		$data = array(
-			'text string, not JSON (syntax error)'       => array('Invalid JSON'),
-			'invalid JSON: single quotes (syntax error)' => array("{ 'bar': 'baz' }"),
-		);
+		$data = [
+			'text string, not JSON (syntax error)'       => ['Invalid JSON'],
+			'invalid JSON: single quotes (syntax error)' => ["{ 'bar': 'baz' }"],
+		];
 
 		// An empty string is only regarded as invalid JSON since PHP 7.0.
 		if (PHP_VERSION_ID >= 70000) {
-			$data['empty string (syntax error)'] = array('');
+			$data['empty string (syntax error)'] = [''];
 		}
 
 		return $data;
@@ -67,11 +67,11 @@ final class ResponseTest extends TestCase {
 		$response->body = '{"success": false, "error": [], "data": null}';
 		$decoded_body   = $response->decode_body();
 
-		$expected = array(
+		$expected = [
 			'success' => false,
-			'error'   => array(),
+			'error'   => [],
 			'data'    => null,
-		);
+		];
 
 		$this->assertSame($expected, $decoded_body);
 	}

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -35,12 +35,12 @@ final class SessionTest extends TestCase {
 	}
 
 	public function testBasicGET() {
-		$session_headers = array(
+		$session_headers = [
 			'X-Requests-Session' => 'BasicGET',
 			'X-Requests-Request' => 'notset',
-		);
+		];
 		$session         = new Session(httpbin('/'), $session_headers);
-		$response        = $session->get('/get', array('X-Requests-Request' => 'GET'));
+		$response        = $session->get('/get', ['X-Requests-Request' => 'GET']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
 
@@ -52,23 +52,23 @@ final class SessionTest extends TestCase {
 	}
 
 	public function testBasicHEAD() {
-		$session_headers = array(
+		$session_headers = [
 			'X-Requests-Session' => 'BasicHEAD',
 			'X-Requests-Request' => 'notset',
-		);
+		];
 		$session         = new Session(httpbin('/'), $session_headers);
-		$response        = $session->head('/get', array('X-Requests-Request' => 'HEAD'));
+		$response        = $session->head('/get', ['X-Requests-Request' => 'HEAD']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
 	}
 
 	public function testBasicDELETE() {
-		$session_headers = array(
+		$session_headers = [
 			'X-Requests-Session' => 'BasicDELETE',
 			'X-Requests-Request' => 'notset',
-		);
+		];
 		$session         = new Session(httpbin('/'), $session_headers);
-		$response        = $session->delete('/delete', array('X-Requests-Request' => 'DELETE'));
+		$response        = $session->delete('/delete', ['X-Requests-Request' => 'DELETE']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
 
@@ -80,12 +80,12 @@ final class SessionTest extends TestCase {
 	}
 
 	public function testBasicPOST() {
-		$session_headers = array(
+		$session_headers = [
 			'X-Requests-Session' => 'BasicPOST',
 			'X-Requests-Request' => 'notset',
-		);
+		];
 		$session         = new Session(httpbin('/'), $session_headers);
-		$response        = $session->post('/post', array('X-Requests-Request' => 'POST'), array('postdata' => 'exists'));
+		$response        = $session->post('/post', ['X-Requests-Request' => 'POST'], ['postdata' => 'exists']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
 
@@ -97,12 +97,12 @@ final class SessionTest extends TestCase {
 	}
 
 	public function testBasicPUT() {
-		$session_headers = array(
+		$session_headers = [
 			'X-Requests-Session' => 'BasicPUT',
 			'X-Requests-Request' => 'notset',
-		);
+		];
 		$session         = new Session(httpbin('/'), $session_headers);
-		$response        = $session->put('/put', array('X-Requests-Request' => 'PUT'), array('postdata' => 'exists'));
+		$response        = $session->put('/put', ['X-Requests-Request' => 'PUT'], ['postdata' => 'exists']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
 
@@ -114,12 +114,12 @@ final class SessionTest extends TestCase {
 	}
 
 	public function testBasicPATCH() {
-		$session_headers = array(
+		$session_headers = [
 			'X-Requests-Session' => 'BasicPATCH',
 			'X-Requests-Request' => 'notset',
-		);
+		];
 		$session         = new Session(httpbin('/'), $session_headers);
-		$response        = $session->patch('/patch', array('X-Requests-Request' => 'PATCH'), array('postdata' => 'exists'));
+		$response        = $session->patch('/patch', ['X-Requests-Request' => 'PATCH'], ['postdata' => 'exists']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
 
@@ -131,15 +131,15 @@ final class SessionTest extends TestCase {
 	}
 
 	public function testMultiple() {
-		$session   = new Session(httpbin('/'), array('X-Requests-Session' => 'Multiple'));
-		$requests  = array(
-			'test1' => array(
+		$session   = new Session(httpbin('/'), ['X-Requests-Session' => 'Multiple']);
+		$requests  = [
+			'test1' => [
 				'url' => httpbin('/get'),
-			),
-			'test2' => array(
+			],
+			'test2' => [
 				'url' => httpbin('/get'),
-			),
-		);
+			],
+		];
 		$responses = $session->request_multiple($requests);
 
 		// test1
@@ -162,22 +162,22 @@ final class SessionTest extends TestCase {
 	}
 
 	public function testPropertyUsage() {
-		$headers = array(
+		$headers = [
 			'X-TestHeader'  => 'testing',
 			'X-TestHeader2' => 'requests-test',
-		);
-		$data    = array(
+		];
+		$data    = [
 			'testdata' => 'value1',
 			'test2'    => 'value2',
-			'test3'    => array(
+			'test3'    => [
 				'foo' => 'bar',
 				'abc' => 'xyz',
-			),
-		);
-		$options = array(
+			],
+		];
+		$options = [
 			'testoption' => 'test',
 			'foo'        => 'bar',
-		);
+		];
 
 		$session = new Session('http://example.com/', $headers, $data, $options);
 		$this->assertSame('http://example.com/', $session->url);
@@ -209,10 +209,10 @@ final class SessionTest extends TestCase {
 	public function testSharedCookies() {
 		$session = new Session(httpbin('/'));
 
-		$options  = array(
+		$options  = [
 			'follow_redirects' => false,
-		);
-		$response = $session->get('/cookies/set?requests-testcookie=testvalue', array(), $options);
+		];
+		$response = $session->get('/cookies/set?requests-testcookie=testvalue', [], $options);
 		$this->assertSame(302, $response->status_code);
 
 		// Check the cookies
@@ -224,9 +224,9 @@ final class SessionTest extends TestCase {
 		$this->assertNotNull($data);
 		$this->assertArrayHasKey('cookies', $data);
 
-		$cookies = array(
+		$cookies = [
 			'requests-testcookie' => 'testvalue',
-		);
+		];
 		$this->assertSame($cookies, $data['cookies']);
 	}
 
@@ -251,11 +251,11 @@ final class SessionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorValidUrl() {
-		return array(
-			'null'              => array(null),
-			'string'            => array(httpbin('/')),
-			'stringable object' => array(new Iri(httpbin('/'))),
-		);
+		return [
+			'null'              => [null],
+			'string'            => [httpbin('/')],
+			'stringable object' => [new Iri(httpbin('/'))],
+		];
 	}
 
 	/**
@@ -282,11 +282,11 @@ final class SessionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidUrl() {
-		return array(
-			'boolean false'         => array(false),
-			'array'                 => array(array(httpbin('/'))),
-			'non-stringable object' => array(new stdClass('name')),
-		);
+		return [
+			'boolean false'         => [false],
+			'array'                 => [[httpbin('/')]],
+			'non-stringable object' => [new stdClass('name')],
+		];
 	}
 
 	/**
@@ -322,7 +322,7 @@ final class SessionTest extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #3 ($data) must be of type array');
 
-		new Session('/', array(), $input);
+		new Session('/', [], $input);
 	}
 
 	/**
@@ -340,7 +340,7 @@ final class SessionTest extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #4 ($options) must be of type array');
 
-		new Session('/', array(), array(), $input);
+		new Session('/', [], [], $input);
 	}
 
 	/**
@@ -368,12 +368,12 @@ final class SessionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataRequestMultipleInvalidRequests() {
-		return array(
-			'null'                                 => array(null),
-			'text string'                          => array('array'),
-			'iterator object without array access' => array(new EmptyIterator()),
-			'array accessible object not iterable' => array(new ArrayAccessibleObject(array(1, 2, 3))),
-		);
+		return [
+			'null'                                 => [null],
+			'text string'                          => ['array'],
+			'iterator object without array access' => [new EmptyIterator()],
+			'array accessible object not iterable' => [new ArrayAccessibleObject([1, 2, 3])],
+		];
 	}
 
 	/**
@@ -392,7 +392,7 @@ final class SessionTest extends TestCase {
 		$this->expectExceptionMessage('Argument #2 ($options) must be of type array');
 
 		$session = new Session();
-		$session->request_multiple(array(), $input);
+		$session->request_multiple([], $input);
 	}
 
 	/**
@@ -401,10 +401,10 @@ final class SessionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidTypeNotArray() {
-		return array(
-			'null'                    => array(null),
-			'boolean false'           => array(false),
-			'array accessible object' => array(new ArrayAccessibleObject(array())),
-		);
+		return [
+			'null'                    => [null],
+			'boolean false'           => [false],
+			'array accessible object' => [new ArrayAccessibleObject([])],
+		];
 	}
 }

--- a/tests/SslTest.php
+++ b/tests/SslTest.php
@@ -57,20 +57,20 @@ final class SslTest extends TestCase {
 	 * @return array
 	 */
 	public function dataMatch() {
-		return array(
-			'top-level domain (stringable object)' => array(
+		return [
+			'top-level domain (stringable object)' => [
 				'host'      => new StringableObject('example.com'),
 				'reference' => new StringableObject('example.com'),
-			),
-			'subdomain' => array(
+			],
+			'subdomain' => [
 				'host'      => 'test.example.com',
 				'reference' => 'test.example.com',
-			),
-			'subdomain with wildcard reference' => array(
+			],
+			'subdomain with wildcard reference' => [
 				'host'      => 'test.example.com',
 				'reference' => '*.example.com',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -79,33 +79,33 @@ final class SslTest extends TestCase {
 	 * @return array
 	 */
 	public function dataMatchViaCertificate() {
-		return array(
-			'top-level domain; missing SAN, fallback to CN' => array(
+		return [
+			'top-level domain; missing SAN, fallback to CN' => [
 				'host'      => 'example.com',
 				'reference' => 'example.com',
 				'with_san'  => false,
-			),
-			'SAN available, multiple alternatives provided; matching is second' => array(
+			],
+			'SAN available, multiple alternatives provided; matching is second' => [
 				'host'      => 'example.net',
 				'reference' => 'example.net',
 				'with_san'  => 'DNS: example.com, DNS: example.net, DNS: example.info',
-			),
-			'SAN available, multiple alternatives provided; matching is last' => array(
+			],
+			'SAN available, multiple alternatives provided; matching is last' => [
 				'host'      => 'example.net',
 				'reference' => 'example.net',
 				'with_san'  => 'DNS: example.com, DNS: example.org, DNS: example.net',
-			),
-			'SAN available, DNS prefix missing in first, not (matching) second' => array(
+			],
+			'SAN available, DNS prefix missing in first, not (matching) second' => [
 				'host'      => 'example.net',
 				'reference' => 'example.com',
 				'with_san'  => 'example.com, DNS: example.net',
-			),
-			'SAN available, DNS prefix missing in all, fallback to CN' => array(
+			],
+			'SAN available, DNS prefix missing in all, fallback to CN' => [
 				'host'      => 'example.net',
 				'reference' => 'example.net',
 				'with_san'  => 'example.com, example.net',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -152,59 +152,59 @@ final class SslTest extends TestCase {
 	 * @return array
 	 */
 	public function dataNoMatch() {
-		return array(
+		return [
 			// Check that we need at least 3 components
-			'not a domain; wildcard reference' => array(
+			'not a domain; wildcard reference' => [
 				'host'      => 'com',
 				'reference' => '*',
-			),
-			'domain name; wildcard on TLD as reference' => array(
+			],
+			'domain name; wildcard on TLD as reference' => [
 				'host'      => 'example.com',
 				'reference' => '*.com',
-			),
+			],
 
 			// Check that double wildcards don't work
-			'domain name; double wildcard in reference' => array(
+			'domain name; double wildcard in reference' => [
 				'host'      => 'abc.def.example.com',
 				'reference' => '*.*.example.com',
-			),
+			],
 
 			// Check that we only match with the correct number of components
-			'four-level domain; three-level reference' => array(
+			'four-level domain; three-level reference' => [
 				'host'      => 'abc.def.example.com',
 				'reference' => 'def.example.com',
-			),
-			'four-level domain; three-level wildcard reference' => array(
+			],
+			'four-level domain; three-level wildcard reference' => [
 				'host'      => 'abc.def.example.com',
 				'reference' => '*.example.com',
-			),
+			],
 
 			// Check that the wildcard only works as the full first component
-			'four-level domain; four-level reference, but wildcard not stand-alone' => array(
+			'four-level domain; four-level reference, but wildcard not stand-alone' => [
 				'host'      => 'abc.def.example.com',
 				'reference' => 'a*.def.example.com',
-			),
+			],
 
 			// Check that wildcards are not allowed for IPs
-			'IP address; wildcard in refence (start)' => array(
+			'IP address; wildcard in refence (start)' => [
 				'host'      => '192.168.0.1',
 				'reference' => '*.168.0.1',
-			),
-			'IP address; wildcard in refence (end)' => array(
+			],
+			'IP address; wildcard in refence (end)' => [
 				'host'      => '192.168.0.1',
 				'reference' => '192.168.0.*',
-			),
+			],
 
 			// IP vs named address.
-			'IP address vs named address' => array(
+			'IP address vs named address' => [
 				'host'      => '192.168.0.1',
 				'reference' => '*.example.com',
-			),
-			'Named address vs IP address' => array(
+			],
+			'Named address vs IP address' => [
 				'host'      => 'example.com',
 				'reference' => '192.168.0.1',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -213,33 +213,33 @@ final class SslTest extends TestCase {
 	 * @return array
 	 */
 	public function dataNoMatchViaCertificate() {
-		return array(
-			'top-level domain; missing SAN, fallback to invalid CN' => array(
+		return [
+			'top-level domain; missing SAN, fallback to invalid CN' => [
 				'host'      => 'example.net',
 				'reference' => 'example.com',
 				'with_san'  => false,
-			),
-			'SAN empty' => array(
+			],
+			'SAN empty' => [
 				'host'      => 'example.net',
 				'reference' => 'example.com',
 				'with_san'  => '',
-			),
-			'SAN available, DNS prefix missing' => array(
+			],
+			'SAN available, DNS prefix missing' => [
 				'host'      => 'example.net',
 				'reference' => 'example.com',
 				'with_san'  => 'example.com',
-			),
-			'SAN available, multiple alternatives provided; none of the SANs match, DNS prefix missing in first, not second' => array(
+			],
+			'SAN available, multiple alternatives provided; none of the SANs match, DNS prefix missing in first, not second' => [
 				'host'      => 'example.net',
 				'reference' => 'example.com',
 				'with_san'  => 'example.com, DNS: example.org',
-			),
-			'SAN available, multiple alternatives provided; none of the SANs match, even though CN does' => array(
+			],
+			'SAN available, multiple alternatives provided; none of the SANs match, even though CN does' => [
 				'host'      => 'example.net',
 				'reference' => 'example.net',
 				'with_san'  => 'DNS: example.com, DNS: example.org, DNS: example.info',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -248,20 +248,20 @@ final class SslTest extends TestCase {
 	 * @return array
 	 */
 	private function fakeCertificate($dnsname, $with_san = true) {
-		$certificate = array(
-			'subject' => array(
+		$certificate = [
+			'subject' => [
 				'CN' => $dnsname,
-			),
-		);
+			],
+		];
 
 		if ($with_san !== false) {
 			// If SAN is set to true, default it to the dNSName
 			if ($with_san === true) {
 				$with_san = 'DNS: ' . $dnsname;
 			}
-			$certificate['extensions'] = array(
+			$certificate['extensions'] = [
 				'subjectAltName' => $with_san,
-			);
+			];
 		}
 
 		return $certificate;
@@ -305,95 +305,95 @@ final class SslTest extends TestCase {
 	 * @return array
 	 */
 	public function dataVerifyCertificateWithInvalidCertificates() {
-		return array(
-			'empty array' => array(
+		return [
+			'empty array' => [
 				'host'        => 'example.com',
-				'certificate' => array(),
+				'certificate' => [],
 				'expected'    => false,
-			),
-			'subject, but missing CN entry; no SAN' => array(
+			],
+			'subject, but missing CN entry; no SAN' => [
 				'host'        => 'example.com',
-				'certificate' => array(
-					'subject' => array(),
-				),
+				'certificate' => [
+					'subject' => [],
+				],
 				'expected'    => false,
-			),
-			'subject with empty CN entry; no SAN' => array(
+			],
+			'subject with empty CN entry; no SAN' => [
 				'host'        => 'example.com',
-				'certificate' => array(
-					'subject' => array(
+				'certificate' => [
+					'subject' => [
 						'CN' => '',
-					),
-				),
+					],
+				],
 				'expected'    => false,
-			),
-			'subject, but missing CN entry; SAN exists, missing DNS' => array(
+			],
+			'subject, but missing CN entry; SAN exists, missing DNS' => [
 				'host'        => 'example.com',
-				'certificate' => array(
-					'subject'    => array(),
-					'extensions' => array(
+				'certificate' => [
+					'subject'    => [],
+					'extensions' => [
 						'subjectAltName' => 'example.net',
-					),
-				),
+					],
+				],
 				'expected'    => false,
-			),
-			'subject with empty CN entry; SAN exists, missing DNS' => array(
+			],
+			'subject with empty CN entry; SAN exists, missing DNS' => [
 				'host'        => 'example.com',
-				'certificate' => array(
-					'subject' => array(
+				'certificate' => [
+					'subject' => [
 						'CN' => '',
-					),
-					'extensions' => array(
+					],
+					'extensions' => [
 						'subjectAltName' => 'example.net',
-					),
-				),
+					],
+				],
 				'expected'    => false,
-			),
-			'subject, but missing CN entry; SAN exists, but non-matching' => array(
+			],
+			'subject, but missing CN entry; SAN exists, but non-matching' => [
 				'host'        => 'example.com',
-				'certificate' => array(
-					'subject'    => array(),
-					'extensions' => array(
+				'certificate' => [
+					'subject'    => [],
+					'extensions' => [
 						'subjectAltName' => 'DNS: example.net',
-					),
-				),
+					],
+				],
 				'expected'    => false,
-			),
-			'subject with empty CN entry; SAN exists, but non-matching' => array(
+			],
+			'subject with empty CN entry; SAN exists, but non-matching' => [
 				'host'        => 'example.com',
-				'certificate' => array(
-					'subject' => array(
+				'certificate' => [
+					'subject' => [
 						'CN' => '',
-					),
-					'extensions' => array(
+					],
+					'extensions' => [
 						'subjectAltName' => 'DNS:   example.net',
-					),
-				),
+					],
+				],
 				'expected'    => false,
-			),
-			'extensions, but missing SAN entry' => array(
+			],
+			'extensions, but missing SAN entry' => [
 				'host'        => 'example.com',
-				'certificate' => array(
-					'subject'    => array(
+				'certificate' => [
+					'subject'    => [
 						'CN' => 'example.net',
-					),
-					'extensions' => array(),
-				),
+					],
+					'extensions' => [],
+				],
 				'expected'    => false,
-			),
-			'extensions with empty SAN entry' => array(
+			],
+			'extensions with empty SAN entry' => [
 				'host'        => 'example.com',
-				'certificate' => array(
-					'subject' => array(
+				'certificate' => [
+					'subject' => [
 						'CN' => 'example.net',
-					),
-					'extensions' => array(
+					],
+					'extensions' => [
 						'subjectAltName' => '',
-					),
-				),
+					],
+				],
 				'expected'    => false,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -418,76 +418,76 @@ final class SslTest extends TestCase {
 	 * @return array
 	 */
 	public function dataVerifyReferenceName() {
-		return array(
-			'empty string' => array(
+		return [
+			'empty string' => [
 				'reference' => '',
 				'expected'  => false,
-			),
-			'one part, no dot' => array(
+			],
+			'one part, no dot' => [
 				'reference' => 'example',
 				'expected'  => true,
-			),
-			'one part, only wildcard' => array(
+			],
+			'one part, only wildcard' => [
 				'reference' => '*',
 				'expected'  => false,
-			),
-			'two parts, no wildcard' => array(
+			],
+			'two parts, no wildcard' => [
 				'reference' => 'example.com',
 				'expected'  => true,
-			),
-			'two parts, wildcard in first' => array(
+			],
+			'two parts, wildcard in first' => [
 				'reference' => '*.com',
 				'expected'  => false,
-			),
-			'two parts, wildcard in last' => array(
+			],
+			'two parts, wildcard in last' => [
 				'reference' => 'example.*',
 				'expected'  => false,
-			),
-			'three parts, only dots' => array(
+			],
+			'three parts, only dots' => [
 				'reference' => '..',
 				'expected'  => false,
-			),
-			'three parts, no wildcard' => array(
+			],
+			'three parts, no wildcard' => [
 				'reference' => new StringableObject('www.example.com'),
 				'expected'  => true,
-			),
-			'three parts, no wildcard, has spaces' => array(
+			],
+			'three parts, no wildcard, has spaces' => [
 				'reference' => 'my dog . and . my cat',
 				'expected'  => false,
-			),
-			'three parts, wildcard in first' => array(
+			],
+			'three parts, wildcard in first' => [
 				'reference' => '*.example.com',
 				'expected'  => true,
-			),
-			'three parts, wildcard in second' => array(
+			],
+			'three parts, wildcard in second' => [
 				'reference' => 'www.*.com',
 				'expected'  => false,
-			),
-			'three parts, wildcard in third' => array(
+			],
+			'three parts, wildcard in third' => [
 				'reference' => 'www.example.*',
 				'expected'  => false,
-			),
-			'three parts, wildcard in first at start with other characters' => array(
+			],
+			'three parts, wildcard in first at start with other characters' => [
 				'reference' => '*ww.example.com',
 				'expected'  => false,
-			),
-			'three parts, wildcard in first at end with other characters' => array(
+			],
+			'three parts, wildcard in first at end with other characters' => [
 				'reference' => 'ww*.example.com',
 				'expected'  => false,
-			),
-			'three parts, wildcard in first and second' => array(
+			],
+			'three parts, wildcard in first and second' => [
 				'reference' => '*.*.com',
 				'expected'  => false,
-			),
-			'three parts, wildcard in second and last' => array(
+			],
+			'three parts, wildcard in second and last' => [
 				'reference' => 'www.*.*',
 				'expected'  => false,
-			),
-			'three parts, wildcard in first and last' => array(
+			],
+			'three parts, wildcard in first and last' => [
 				'reference' => '*.example.*',
 				'expected'  => false,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -505,7 +505,7 @@ final class SslTest extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #1 ($host) must be of type string|Stringable');
 
-		Ssl::verify_certificate($input, array());
+		Ssl::verify_certificate($input, []);
 	}
 
 	/**
@@ -568,9 +568,9 @@ final class SslTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidInputType() {
-		return array(
-			'null'         => array(null),
-			'plain object' => array(new stdClass()),
-		);
+		return [
+			'null'         => [null],
+			'plain object' => [new stdClass()],
+		];
 	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,11 +13,11 @@ abstract class TestCase extends Polyfill_TestCase {
 	 * @var array
 	 */
 	public function transportProvider() {
-		$data = array();
+		$data = [];
 
 		foreach (Requests::DEFAULT_TRANSPORTS as $transport) {
 			$name        = substr($transport, (strrpos($transport, '\\') + 1));
-			$data[$name] = array($transport);
+			$data[$name] = [$transport];
 		}
 
 		return $data;

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -19,7 +19,7 @@ abstract class BaseTestCase extends TestCase {
 
 	public function set_up() {
 		// Intermediary variable $test_method. This can be simplified (removed) once the minimum supported PHP version is 7.0 or higher.
-		$test_method = array($this->transport, 'test');
+		$test_method = [$this->transport, 'test'];
 
 		$supported = $test_method();
 
@@ -28,43 +28,43 @@ abstract class BaseTestCase extends TestCase {
 			return;
 		}
 
-		$ssl_supported = $test_method(array(Capability::SSL => true));
+		$ssl_supported = $test_method([Capability::SSL => true]);
 		if (!$ssl_supported) {
 			$this->skip_https = true;
 		}
 	}
 
-	protected function getOptions($other = array()) {
-		$options = array(
+	protected function getOptions($other = []) {
+		$options = [
 			'transport' => $this->transport,
-		);
+		];
 		$options = array_merge($options, $other);
 		return $options;
 	}
 
 	public function testResponseByteLimit() {
 		$limit    = 104;
-		$options  = array(
+		$options  = [
 			'max_bytes' => $limit,
-		);
-		$response = Requests::get(httpbin('/bytes/325'), array(), $this->getOptions($options));
+		];
+		$response = Requests::get(httpbin('/bytes/325'), [], $this->getOptions($options));
 		$this->assertSame($limit, strlen($response->body));
 	}
 
 	public function testResponseByteLimitWithFile() {
 		$limit    = 300;
-		$options  = array(
+		$options  = [
 			'max_bytes' => $limit,
 			'filename'  => tempnam(sys_get_temp_dir(), 'RLT'), // RequestsLibraryTest
-		);
-		$response = Requests::get(httpbin('/bytes/482'), array(), $this->getOptions($options));
+		];
+		$response = Requests::get(httpbin('/bytes/482'), [], $this->getOptions($options));
 		$this->assertEmpty($response->body);
 		$this->assertSame($limit, filesize($options['filename']));
 		unlink($options['filename']);
 	}
 
 	public function testSimpleGET() {
-		$request = Requests::get(httpbin('/get'), array(), $this->getOptions());
+		$request = Requests::get(httpbin('/get'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -73,59 +73,59 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testGETWithArgs() {
-		$request = Requests::get(httpbin('/get?test=true&test2=test'), array(), $this->getOptions());
+		$request = Requests::get(httpbin('/get?test=true&test2=test'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
 		$this->assertSame(httpbin('/get?test=true&test2=test'), $result['url']);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['args']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['args']);
 	}
 
 	public function testGETWithData() {
-		$data    = array(
+		$data    = [
 			'test'  => 'true',
 			'test2' => 'test',
-		);
-		$request = Requests::request(httpbin('/get'), array(), $data, Requests::GET, $this->getOptions());
+		];
+		$request = Requests::request(httpbin('/get'), [], $data, Requests::GET, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
 		$this->assertSame(httpbin('/get?test=true&test2=test'), $result['url']);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['args']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['args']);
 	}
 
 	public function testGETWithNestedData() {
-		$data    = array(
+		$data    = [
 			'test'  => 'true',
-			'test2' => array(
+			'test2' => [
 				'test3' => 'test',
 				'test4' => 'test-too',
-			),
-		);
-		$request = Requests::request(httpbin('/get'), array(), $data, Requests::GET, $this->getOptions());
+			],
+		];
+		$request = Requests::request(httpbin('/get'), [], $data, Requests::GET, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
 		$this->assertSame(httpbin('/get?test=true&test2%5Btest3%5D=test&test2%5Btest4%5D=test-too'), $result['url']);
-		$this->assertSame(array('test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'), $result['args']);
+		$this->assertSame(['test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'], $result['args']);
 	}
 
 	public function testGETWithDataAndQuery() {
-		$data    = array(
+		$data    = [
 			'test2' => 'test',
-		);
-		$request = Requests::request(httpbin('/get?test=true'), array(), $data, Requests::GET, $this->getOptions());
+		];
+		$request = Requests::request(httpbin('/get?test=true'), [], $data, Requests::GET, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
 		$this->assertSame(httpbin('/get?test=true&test2=test'), $result['url']);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['args']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['args']);
 	}
 
 	public function testGETWithHeaders() {
-		$headers = array(
+		$headers = [
 			'Requested-At' => (string) time(),
-		);
+		];
 		$request = Requests::get(httpbin('/get'), $headers, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
@@ -134,7 +134,7 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testChunked() {
-		$request = Requests::get(httpbin('/stream/1'), array(), $this->getOptions());
+		$request = Requests::get(httpbin('/stream/1'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -143,19 +143,19 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testHEAD() {
-		$request = Requests::head(httpbin('/get'), array(), $this->getOptions());
+		$request = Requests::head(httpbin('/get'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 		$this->assertSame('', $request->body);
 	}
 
 	public function testTRACE() {
-		$request = Requests::trace(httpbin('/trace'), array(), $this->getOptions());
+		$request = Requests::trace(httpbin('/trace'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 	}
 
 	public function testRawPOST() {
 		$data    = 'test';
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -166,7 +166,7 @@ abstract class BaseTestCase extends TestCase {
 	 * Issue #248.
 	 */
 	public function testEmptyPOST() {
-		$request = Requests::post(httpbin('/post'), array(), null, $this->getOptions());
+		$request = Requests::post(httpbin('/post'), [], null, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -200,7 +200,7 @@ abstract class BaseTestCase extends TestCase {
 	 * @return void
 	 */
 	public function testIncorrectDataTypeAcceptedPOST($data, $expected) {
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertIsObject($request, 'POST request did not return an object');
 		$this->assertObjectHasAttribute('status_code', $request, 'POST request object does not have a "status_code" property');
 		$this->assertSame(200, $request->status_code, 'POST request status code is not 200');
@@ -219,11 +219,11 @@ abstract class BaseTestCase extends TestCase {
 	 * @return array
 	 */
 	public function dataIncorrectDataTypeAccepted() {
-		return array(
-			'null'    => array(null, ''),
-			'integer' => array(12345, '12345'),
-			'float'   => array(12.345, '12.345'),
-		);
+		return [
+			'null'    => [null, ''],
+			'integer' => [12345, '12345'],
+			'float'   => [12.345, '12.345'],
+		];
 	}
 
 	/**
@@ -239,7 +239,7 @@ abstract class BaseTestCase extends TestCase {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #3 ($data) must be of type array|string');
 
-		Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+		Requests::post(httpbin('/post'), [], $data, $this->getOptions());
 	}
 
 	/**
@@ -248,51 +248,51 @@ abstract class BaseTestCase extends TestCase {
 	 * @return array
 	 */
 	public function dataIncorrectDataTypeException() {
-		return array(
-			'boolean' => array(true),
-			'object'  => array(new stdClass()),
-		);
+		return [
+			'boolean' => [true],
+			'object'  => [new stdClass()],
+		];
 	}
 
 	public function testFormPost() {
 		$data    = 'test=true&test2=test';
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
 	}
 
 	public function testPOSTWithArray() {
-		$data    = array(
+		$data    = [
 			'test'  => 'true',
 			'test2' => 'test',
-		);
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+		];
+		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
 	}
 
 	public function testPOSTWithNestedData() {
-		$data    = array(
+		$data    = [
 			'test'  => 'true',
-			'test2' => array(
+			'test2' => [
 				'test3' => 'test',
 				'test4' => 'test-too',
-			),
-		);
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+			],
+		];
+		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(array('test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'), $result['form']);
+		$this->assertSame(['test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'], $result['form']);
 	}
 
 	public function testRawPUT() {
 		$data    = 'test';
-		$request = Requests::put(httpbin('/put'), array(), $data, $this->getOptions());
+		$request = Requests::put(httpbin('/put'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -301,28 +301,28 @@ abstract class BaseTestCase extends TestCase {
 
 	public function testFormPUT() {
 		$data    = 'test=true&test2=test';
-		$request = Requests::put(httpbin('/put'), array(), $data, $this->getOptions());
+		$request = Requests::put(httpbin('/put'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
 	}
 
 	public function testPUTWithArray() {
-		$data    = array(
+		$data    = [
 			'test'  => 'true',
 			'test2' => 'test',
-		);
-		$request = Requests::put(httpbin('/put'), array(), $data, $this->getOptions());
+		];
+		$request = Requests::put(httpbin('/put'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
 	}
 
 	public function testRawPATCH() {
 		$data    = 'test';
-		$request = Requests::patch(httpbin('/patch'), array(), $data, $this->getOptions());
+		$request = Requests::patch(httpbin('/patch'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -331,32 +331,32 @@ abstract class BaseTestCase extends TestCase {
 
 	public function testFormPATCH() {
 		$data    = 'test=true&test2=test';
-		$request = Requests::patch(httpbin('/patch'), array(), $data, $this->getOptions());
+		$request = Requests::patch(httpbin('/patch'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code, $request->body);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
 	}
 
 	public function testPATCHWithArray() {
-		$data    = array(
+		$data    = [
 			'test'  => 'true',
 			'test2' => 'test',
-		);
-		$request = Requests::patch(httpbin('/patch'), array(), $data, $this->getOptions());
+		];
+		$request = Requests::patch(httpbin('/patch'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
 	}
 
 	public function testOPTIONS() {
-		$request = Requests::options(httpbin('/options'), array(), array(), $this->getOptions());
+		$request = Requests::options(httpbin('/options'), [], [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 	}
 
 	public function testDELETE() {
-		$request = Requests::delete(httpbin('/delete'), array(), $this->getOptions());
+		$request = Requests::delete(httpbin('/delete'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -365,105 +365,105 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testDELETEWithData() {
-		$data    = array(
+		$data    = [
 			'test'  => 'true',
 			'test2' => 'test',
-		);
-		$request = Requests::request(httpbin('/delete'), array(), $data, Requests::DELETE, $this->getOptions());
+		];
+		$request = Requests::request(httpbin('/delete'), [], $data, Requests::DELETE, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
 		$this->assertSame(httpbin('/delete?test=true&test2=test'), $result['url']);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['args']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['args']);
 	}
 
 	public function testLOCK() {
-		$request = Requests::request(httpbin('/lock'), array(), array(), 'LOCK', $this->getOptions());
+		$request = Requests::request(httpbin('/lock'), [], [], 'LOCK', $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 	}
 
 	public function testLOCKWithData() {
-		$data    = array(
+		$data    = [
 			'test'  => 'true',
 			'test2' => 'test',
-		);
-		$request = Requests::request(httpbin('/lock'), array(), $data, 'LOCK', $this->getOptions());
+		];
+		$request = Requests::request(httpbin('/lock'), [], $data, 'LOCK', $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
 	}
 
 	public function testRedirects() {
-		$request = Requests::get(httpbin('/redirect/6'), array(), $this->getOptions());
+		$request = Requests::get(httpbin('/redirect/6'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$this->assertSame(6, $request->redirects);
 	}
 
 	public function testRelativeRedirects() {
-		$request = Requests::get(httpbin('/relative-redirect/6'), array(), $this->getOptions());
+		$request = Requests::get(httpbin('/relative-redirect/6'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$this->assertSame(6, $request->redirects);
 	}
 
 	public function testTooManyRedirects() {
-		$options = array(
+		$options = [
 			'redirects' => 10, // default, but force just in case
-		);
+		];
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Too many redirects');
-		Requests::get(httpbin('/redirect/11'), array(), $this->getOptions($options));
+		Requests::get(httpbin('/redirect/11'), [], $this->getOptions($options));
 	}
 
 	public static function statusCodeSuccessProvider() {
-		return array(
-			array(200, true),
-			array(201, true),
-			array(202, true),
-			array(203, true),
-			array(204, true),
-			array(205, true),
-			array(206, true),
-			array(300, false),
-			array(301, false),
-			array(302, false),
-			array(303, false),
-			array(304, false),
-			array(305, false),
-			array(306, false),
-			array(307, false),
-			array(400, false),
-			array(401, false),
-			array(402, false),
-			array(403, false),
-			array(404, false),
-			array(405, false),
-			array(406, false),
-			array(407, false),
-			array(408, false),
-			array(409, false),
-			array(410, false),
-			array(411, false),
-			array(412, false),
-			array(413, false),
-			array(414, false),
-			array(415, false),
-			array(416, false),
-			array(417, false),
-			array(418, false), // RFC 2324
-			array(428, false), // RFC 6585
-			array(429, false), // RFC 6585
-			array(431, false), // RFC 6585
-			array(500, false),
-			array(501, false),
-			array(502, false),
-			array(503, false),
-			array(504, false),
-			array(505, false),
-			array(511, false), // RFC 6585
-		);
+		return [
+			[200, true],
+			[201, true],
+			[202, true],
+			[203, true],
+			[204, true],
+			[205, true],
+			[206, true],
+			[300, false],
+			[301, false],
+			[302, false],
+			[303, false],
+			[304, false],
+			[305, false],
+			[306, false],
+			[307, false],
+			[400, false],
+			[401, false],
+			[402, false],
+			[403, false],
+			[404, false],
+			[405, false],
+			[406, false],
+			[407, false],
+			[408, false],
+			[409, false],
+			[410, false],
+			[411, false],
+			[412, false],
+			[413, false],
+			[414, false],
+			[415, false],
+			[416, false],
+			[417, false],
+			[418, false], // RFC 2324
+			[428, false], // RFC 6585
+			[429, false], // RFC 6585
+			[431, false], // RFC 6585
+			[500, false],
+			[501, false],
+			[502, false],
+			[503, false],
+			[504, false],
+			[505, false],
+			[511, false], // RFC 6585
+		];
 	}
 
 	/**
@@ -475,11 +475,11 @@ abstract class BaseTestCase extends TestCase {
 
 		$url = sprintf(httpbin('/status/%d'), $code);
 
-		$options = array(
+		$options = [
 			'follow_redirects' => false,
 			'transport'        => $transport,
-		);
-		$request = Requests::get($url, array(), $options);
+		];
+		$request = Requests::get($url, [], $options);
 		$this->assertSame($code, $request->status_code);
 		$this->assertSame($success, $request->success);
 	}
@@ -492,10 +492,10 @@ abstract class BaseTestCase extends TestCase {
 		$transport->code = $code;
 
 		$url     = sprintf(httpbin('/status/%d'), $code);
-		$options = array(
+		$options = [
 			'follow_redirects' => false,
 			'transport'        => $transport,
-		);
+		];
 
 		if (!$success) {
 			if ($code >= 400) {
@@ -510,7 +510,7 @@ abstract class BaseTestCase extends TestCase {
 		// Prevent a "test does not perform any assertions" message for all other cases.
 		$this->assertTrue(true);
 
-		$request = Requests::get($url, array(), $options);
+		$request = Requests::get($url, [], $options);
 		$request->throw_for_status(false);
 	}
 
@@ -522,10 +522,10 @@ abstract class BaseTestCase extends TestCase {
 		$transport->code = $code;
 
 		$url     = sprintf(httpbin('/status/%d'), $code);
-		$options = array(
+		$options = [
 			'follow_redirects' => false,
 			'transport'        => $transport,
-		);
+		];
 
 		if (!$success) {
 			if ($code >= 400 || $code === 304 || $code === 305 || $code === 306) {
@@ -537,7 +537,7 @@ abstract class BaseTestCase extends TestCase {
 		// Prevent a "test does not perform any assertions" message for all other cases.
 		$this->assertTrue(true);
 
-		$request = Requests::get($url, array(), $options);
+		$request = Requests::get($url, [], $options);
 		$request->throw_for_status(true);
 	}
 
@@ -545,11 +545,11 @@ abstract class BaseTestCase extends TestCase {
 		$transport       = new TransportMock();
 		$transport->code = 599;
 
-		$options = array(
+		$options = [
 			'transport' => $transport,
-		);
+		];
 
-		$request = Requests::get(httpbin('/status/599'), array(), $options);
+		$request = Requests::get(httpbin('/status/599'), [], $options);
 		$this->assertSame(599, $request->status_code);
 		$this->assertFalse($request->success);
 	}
@@ -558,18 +558,18 @@ abstract class BaseTestCase extends TestCase {
 		$transport       = new TransportMock();
 		$transport->code = 599;
 
-		$options = array(
+		$options = [
 			'transport' => $transport,
-		);
+		];
 
-		$request = Requests::get(httpbin('/status/599'), array(), $options);
+		$request = Requests::get(httpbin('/status/599'), [], $options);
 		$this->expectException(StatusUnknown::class);
 		$this->expectExceptionMessage('599 Unknown');
 		$request->throw_for_status(true);
 	}
 
 	public function testGzipped() {
-		$request = Requests::get(httpbin('/gzip'), array(), $this->getOptions());
+		$request = Requests::get(httpbin('/gzip'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body);
@@ -577,10 +577,10 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testStreamToFile() {
-		$options = array(
+		$options = [
 			'filename' => tempnam(sys_get_temp_dir(), 'RLT'), // RequestsLibraryTest
-		);
-		$request = Requests::get(httpbin('/get'), array(), $this->getOptions($options));
+		];
+		$request = Requests::get(httpbin('/get'), [], $this->getOptions($options));
 		$this->assertSame(200, $request->status_code);
 		$this->assertEmpty($request->body);
 
@@ -602,12 +602,12 @@ abstract class BaseTestCase extends TestCase {
 			chmod($filename, 0444);
 		}
 
-		$options = array(
+		$options = [
 			'filename' => $filename,
-		);
+		];
 
 		try {
-			Requests::get(httpbin('/get'), array(), $this->getOptions($options));
+			Requests::get(httpbin('/get'), [], $this->getOptions($options));
 
 			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 		} catch (Exception $e) {
@@ -625,29 +625,29 @@ abstract class BaseTestCase extends TestCase {
 	 * Verify that a stream to an invalid file fails.
 	 */
 	public function testStreamToInvalidFile() {
-		$options = array(
+		$options = [
 			'filename' => tempnam(sys_get_temp_dir(), 'RLT') . '/missing/directory', // RequestsLibraryTest
-		);
+		];
 
 		$this->expectException(Exception::class);
 		// First character (F) can be upper or lowercase depending on PHP version.
 		$this->expectExceptionMessage('ailed to open stream');
 
-		Requests::get(httpbin('/get'), array(), $this->getOptions($options));
+		Requests::get(httpbin('/get'), [], $this->getOptions($options));
 	}
 
 	public function testNonblocking() {
-		$options = array(
+		$options = [
 			'blocking' => false,
-		);
-		$request = Requests::get(httpbin('/get'), array(), $this->getOptions($options));
+		];
+		$request = Requests::get(httpbin('/get'), [], $this->getOptions($options));
 		$empty   = new Response();
 		$this->assertEquals($empty, $request);
 	}
 
 	public function testBadIP() {
 		$this->expectException(Exception::class);
-		Requests::get('http://256.256.256.0/', array(), $this->getOptions());
+		Requests::get('http://256.256.256.0/', [], $this->getOptions());
 	}
 
 	public function testHTTPS() {
@@ -656,7 +656,7 @@ abstract class BaseTestCase extends TestCase {
 			return;
 		}
 
-		$request = Requests::get(httpbin('/get', true), array(), $this->getOptions());
+		$request = Requests::get(httpbin('/get', true), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -670,7 +670,7 @@ abstract class BaseTestCase extends TestCase {
 		}
 
 		$this->expectException(Exception::class);
-		Requests::get('https://testssl-expire.disig.sk/index.en.html', array(), $this->getOptions());
+		Requests::get('https://testssl-expire.disig.sk/index.en.html', [], $this->getOptions());
 	}
 
 	public function testRevokedHTTPS() {
@@ -680,7 +680,7 @@ abstract class BaseTestCase extends TestCase {
 		}
 
 		$this->expectException(Exception::class);
-		Requests::get('https://testssl-revoked.disig.sk/index.en.html', array(), $this->getOptions());
+		Requests::get('https://testssl-revoked.disig.sk/index.en.html', [], $this->getOptions());
 	}
 
 	/**
@@ -693,7 +693,7 @@ abstract class BaseTestCase extends TestCase {
 		}
 
 		$this->expectException(Exception::class);
-		Requests::head('https://wrong.host.badssl.com/', array(), $this->getOptions());
+		Requests::head('https://wrong.host.badssl.com/', [], $this->getOptions());
 	}
 
 	public function testBadDomainNoVerify() {
@@ -702,7 +702,7 @@ abstract class BaseTestCase extends TestCase {
 			return;
 		}
 
-		$response = Requests::head('https://wrong.host.badssl.com/', array(), $this->getOptions(array('verify' => false)));
+		$response = Requests::head('https://wrong.host.badssl.com/', [], $this->getOptions(['verify' => false]));
 		$this->assertTrue($response->success);
 	}
 
@@ -719,7 +719,7 @@ abstract class BaseTestCase extends TestCase {
 			return;
 		}
 
-		$request = Requests::head('https://badssl.com/', array(), $this->getOptions());
+		$request = Requests::head('https://badssl.com/', [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 	}
 
@@ -735,28 +735,28 @@ abstract class BaseTestCase extends TestCase {
 			return;
 		}
 
-		$request = Requests::head('https://humanmade.com/', array(), $this->getOptions());
+		$request = Requests::head('https://humanmade.com/', [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 	}
 
 	public function testTimeout() {
-		$options = array(
+		$options = [
 			'timeout' => 1,
-		);
+		];
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('timed out');
-		Requests::get(httpbin('/delay/10'), array(), $this->getOptions($options));
+		Requests::get(httpbin('/delay/10'), [], $this->getOptions($options));
 	}
 
 	public function testMultiple() {
-		$requests  = array(
-			'test1' => array(
+		$requests  = [
+			'test1' => [
 				'url' => httpbin('/get'),
-			),
-			'test2' => array(
+			],
+			'test2' => [
 				'url' => httpbin('/get'),
-			),
-		);
+			],
+		];
 		$responses = Requests::request_multiple($requests, $this->getOptions());
 
 		// test1
@@ -779,16 +779,16 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testMultipleWithDifferingMethods() {
-		$requests  = array(
-			'get' => array(
+		$requests  = [
+			'get' => [
 				'url' => httpbin('/get'),
-			),
-			'post' => array(
+			],
+			'post' => [
 				'url'  => httpbin('/post'),
 				'type' => Requests::POST,
 				'data' => 'test',
-			),
-		);
+			],
+		];
 		$responses = Requests::request_multiple($requests, $this->getOptions());
 
 		// get
@@ -804,63 +804,63 @@ abstract class BaseTestCase extends TestCase {
 	 * @depends testTimeout
 	 */
 	public function testMultipleWithFailure() {
-		$requests  = array(
-			'success' => array(
+		$requests  = [
+			'success' => [
 				'url' => httpbin('/get'),
-			),
-			'timeout' => array(
+			],
+			'timeout' => [
 				'url'     => httpbin('/delay/10'),
-				'options' => array(
+				'options' => [
 					'timeout' => 1,
-				),
-			),
-		);
+				],
+			],
+		];
 		$responses = Requests::request_multiple($requests, $this->getOptions());
 		$this->assertSame(200, $responses['success']->status_code);
 		$this->assertInstanceOf(Exception::class, $responses['timeout']);
 	}
 
 	public function testMultipleUsingCallback() {
-		$requests        = array(
-			'get' => array(
+		$requests        = [
+			'get' => [
 				'url' => httpbin('/get'),
-			),
-			'post' => array(
+			],
+			'post' => [
 				'url'  => httpbin('/post'),
 				'type' => Requests::POST,
 				'data' => 'test',
-			),
-		);
-		$this->completed = array();
-		$options         = array(
-			'complete' => array($this, 'completeCallback'),
-		);
+			],
+		];
+		$this->completed = [];
+		$options         = [
+			'complete' => [$this, 'completeCallback'],
+		];
 		$responses       = Requests::request_multiple($requests, $this->getOptions($options));
 
 		$this->assertSame($this->completed, $responses);
-		$this->completed = array();
+		$this->completed = [];
 	}
 
 	public function testMultipleUsingCallbackAndFailure() {
-		$requests        = array(
-			'success' => array(
+		$requests        = [
+			'success' => [
 				'url' => httpbin('/get'),
-			),
-			'timeout' => array(
+			],
+			'timeout' => [
 				'url'     => httpbin('/delay/10'),
-				'options' => array(
+				'options' => [
 					'timeout' => 1,
-				),
-			),
-		);
-		$this->completed = array();
-		$options         = array(
-			'complete' => array($this, 'completeCallback'),
-		);
+				],
+			],
+		];
+		$this->completed = [];
+		$options         = [
+			'complete' => [$this, 'completeCallback'],
+		];
 		$responses       = Requests::request_multiple($requests, $this->getOptions($options));
 
 		$this->assertSame($this->completed, $responses);
-		$this->completed = array();
+		$this->completed = [];
 	}
 
 	public function completeCallback($response, $key) {
@@ -868,22 +868,22 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testMultipleToFile() {
-		$requests = array(
-			'get' => array(
+		$requests = [
+			'get' => [
 				'url'     => httpbin('/get'),
-				'options' => array(
+				'options' => [
 					'filename' => tempnam(sys_get_temp_dir(), 'RLT'), // RequestsLibraryTest
-				),
-			),
-			'post' => array(
+				],
+			],
+			'post' => [
 				'url'     => httpbin('/post'),
 				'type'    => Requests::POST,
 				'data'    => 'test',
-				'options' => array(
+				'options' => [
 					'filename' => tempnam(sys_get_temp_dir(), 'RLT'), // RequestsLibraryTest
-				),
-			),
-		);
+				],
+			],
+		];
 		Requests::request_multiple($requests, $this->getOptions());
 
 		// GET request
@@ -903,12 +903,12 @@ abstract class BaseTestCase extends TestCase {
 
 	public function testAlternatePort() {
 		try {
-			$request = Requests::get('http://portquiz.net:8080/', array(), $this->getOptions());
+			$request = Requests::get('http://portquiz.net:8080/', [], $this->getOptions());
 		}
 		catch (Exception $e) {
 			// Retry the request as it often times-out.
 			try {
-				$request = Requests::get('http://portquiz.net:8080/', array(), $this->getOptions());
+				$request = Requests::get('http://portquiz.net:8080/', [], $this->getOptions());
 			}
 			catch (Exception $e) {
 				// If it still times out, mark the test as skipped.
@@ -925,21 +925,21 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testProgressCallback() {
-		$mock = $this->getMockBuilder(stdClass::class)->setMethods(array('progress'))->getMock();
+		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['progress'])->getMock();
 		$mock->expects($this->atLeastOnce())->method('progress');
 		$hooks = new Hooks();
-		$hooks->register('request.progress', array($mock, 'progress'));
-		$options = array(
+		$hooks->register('request.progress', [$mock, 'progress']);
+		$options = [
 			'hooks' => $hooks,
-		);
+		];
 		$options = $this->getOptions($options);
 
-		Requests::get(httpbin('/get'), array(), $options);
+		Requests::get(httpbin('/get'), [], $options);
 	}
 
 	public function testAfterRequestCallback() {
 		$mock = $this->getMockBuilder(stdClass::class)
-			->setMethods(array('after_request'))
+			->setMethods(['after_request'])
 			->getMock();
 
 		$mock->expects($this->atLeastOnce())
@@ -949,21 +949,21 @@ abstract class BaseTestCase extends TestCase {
 				$this->logicalAnd($this->isType('array'), $this->logicalNot($this->isEmpty()))
 			);
 		$hooks = new Hooks();
-		$hooks->register('curl.after_request', array($mock, 'after_request'));
-		$hooks->register('fsockopen.after_request', array($mock, 'after_request'));
-		$options = array(
+		$hooks->register('curl.after_request', [$mock, 'after_request']);
+		$hooks->register('fsockopen.after_request', [$mock, 'after_request']);
+		$options = [
 			'hooks' => $hooks,
-		);
+		];
 		$options = $this->getOptions($options);
 
-		Requests::get(httpbin('/get'), array(), $options);
+		Requests::get(httpbin('/get'), [], $options);
 	}
 
 	public function testReusableTransport() {
-		$options = $this->getOptions(array('transport' => new $this->transport()));
+		$options = $this->getOptions(['transport' => new $this->transport()]);
 
-		$request1 = Requests::get(httpbin('/get'), array(), $options);
-		$request2 = Requests::get(httpbin('/get'), array(), $options);
+		$request1 = Requests::get(httpbin('/get'), [], $options);
+		$request2 = Requests::get(httpbin('/get'), [], $options);
 
 		$this->assertSame(200, $request1->status_code);
 		$this->assertSame(200, $request2->status_code);
@@ -979,8 +979,8 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testQueryDataFormat() {
-		$data    = array('test' => 'true', 'test2' => 'test');
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions(array('data_format' => 'query')));
+		$data    = ['test' => 'true', 'test2' => 'test'];
+		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions(['data_format' => 'query']));
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -989,12 +989,12 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testBodyDataFormat() {
-		$data    = array('test' => 'true', 'test2' => 'test');
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions(array('data_format' => 'body')));
+		$data    = ['test' => 'true', 'test2' => 'test'];
+		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions(['data_format' => 'body']));
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
 		$this->assertSame(httpbin('/post'), $result['url']);
-		$this->assertSame(array('test' => 'true', 'test2' => 'test'), $result['form']);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
 	}
 }

--- a/tests/Transport/CurlTest.php
+++ b/tests/Transport/CurlTest.php
@@ -41,10 +41,10 @@ final class CurlTest extends BaseTestCase {
 	 * @small
 	 */
 	public function testDoesntOverwriteExpectHeaderIfManuallySet() {
-		$headers = array(
+		$headers = [
 			'Expect' => 'foo',
-		);
-		$request = Requests::post(httpbin('/post'), $headers, array(), $this->getOptions());
+		];
+		$request = Requests::post(httpbin('/post'), $headers, [], $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -55,10 +55,10 @@ final class CurlTest extends BaseTestCase {
 	 * @small
 	 */
 	public function testDoesntSetExpectHeaderIfBodyExactly1MbButProtocolIsnt11() {
-		$options = array(
+		$options = [
 			'protocol_version' => 1.0,
-		);
-		$request = Requests::post(httpbin('/post'), array(), str_repeat('x', 1048576), $this->getOptions($options));
+		];
+		$request = Requests::post(httpbin('/post'), [], str_repeat('x', 1048576), $this->getOptions($options));
 
 		$result = json_decode($request->body, true);
 
@@ -69,7 +69,7 @@ final class CurlTest extends BaseTestCase {
 	 * @small
 	 */
 	public function testSetsEmptyExpectHeaderWithDefaultSettings() {
-		$request = Requests::post(httpbin('/post'), array(), array(), $this->getOptions());
+		$request = Requests::post(httpbin('/post'), [], [], $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -80,13 +80,13 @@ final class CurlTest extends BaseTestCase {
 	 * @small
 	 */
 	public function testSetsEmptyExpectHeaderIfBodyIsANestedArrayLessThan1Mb() {
-		$data    = array(
+		$data    = [
 			str_repeat('x', 148576),
-			array(
+			[
 				str_repeat('x', 548576),
-			),
-		);
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+			],
+		];
+		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -94,7 +94,7 @@ final class CurlTest extends BaseTestCase {
 	}
 
 	public function testSetsExpectHeaderIfBodyIsExactlyA1MbString() {
-		$request = Requests::post(httpbin('/post'), array(), str_repeat('x', 1048576), $this->getOptions());
+		$request = Requests::post(httpbin('/post'), [], str_repeat('x', 1048576), $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -102,16 +102,16 @@ final class CurlTest extends BaseTestCase {
 	}
 
 	public function testSetsExpectHeaderIfBodyIsANestedArrayGreaterThan1Mb() {
-		$data    = array(
+		$data    = [
 			str_repeat('x', 148576),
-			array(
+			[
 				str_repeat('x', 548576),
-				array(
+				[
 					str_repeat('x', 648576),
-				),
-			),
-		);
-		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+				],
+			],
+		];
+		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -119,7 +119,7 @@ final class CurlTest extends BaseTestCase {
 	}
 
 	public function testSetsExpectHeaderIfBodyExactly1Mb() {
-		$request = Requests::post(httpbin('/post'), array(), str_repeat('x', 1048576), $this->getOptions());
+		$request = Requests::post(httpbin('/post'), [], str_repeat('x', 1048576), $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -130,7 +130,7 @@ final class CurlTest extends BaseTestCase {
 	 * @small
 	 */
 	public function testSetsEmptyExpectHeaderIfBodySmallerThan1Mb() {
-		$request = Requests::post(httpbin('/post'), array(), str_repeat('x', 1048575), $this->getOptions());
+		$request = Requests::post(httpbin('/post'), [], str_repeat('x', 1048575), $this->getOptions());
 
 		$result = json_decode($request->body, true);
 

--- a/tests/Transport/FsockopenTest.php
+++ b/tests/Transport/FsockopenTest.php
@@ -42,9 +42,9 @@ final class FsockopenTest extends BaseTestCase {
 	 */
 	public function testContentLengthHeader() {
 		$hooks = new Hooks();
-		$hooks->register('fsockopen.after_headers', array($this, 'checkContentLengthHeader'));
+		$hooks->register('fsockopen.after_headers', [$this, 'checkContentLengthHeader']);
 
-		Requests::post(httpbin('/post'), array(), array(), $this->getOptions(array('hooks' => $hooks)));
+		Requests::post(httpbin('/post'), [], [], $this->getOptions(['hooks' => $hooks]));
 	}
 
 	/**
@@ -68,9 +68,9 @@ final class FsockopenTest extends BaseTestCase {
 		$this->assertNotSame($locale, setlocale(LC_NUMERIC, 0), 'Changing the locale failed');
 
 		$hooks = new Hooks();
-		$hooks->register('fsockopen.after_headers', array($this, 'checkHTTPVersionHeader'));
+		$hooks->register('fsockopen.after_headers', [$this, 'checkHTTPVersionHeader']);
 
-		Requests::post(httpbin('/post'), array(), array(), $this->getOptions(array('hooks' => $hooks)));
+		Requests::post(httpbin('/post'), [], [], $this->getOptions(['hooks' => $hooks]));
 
 		// Reset the locale.
 		setlocale(LC_NUMERIC, $locale);

--- a/tests/Utility/CaseInsensitiveDictionaryTest.php
+++ b/tests/Utility/CaseInsensitiveDictionaryTest.php
@@ -20,7 +20,7 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	 *
 	 * @var array
 	 */
-	const DATASET = array(
+	const DATASET = [
 		'UPPER CASE'  => 'Uppercase key',
 		'Proper Case' => 'First char in caps in key',
 		'lower case'  => 'Lowercase key',
@@ -29,14 +29,14 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 		true          => 'true key will become integer 1 key',
 		5.0           => 'Float key will be converted to integer key (cut off)',
 		100           => 'Explicit integer numeric key',
-	);
+	];
 
 	/**
 	 * Data to use in the data provider for the array access tests.
 	 *
 	 * @var array
 	 */
-	const DATASET_REVERSED = array(
+	const DATASET_REVERSED = [
 		'Uppercase key'                              => 'UPPER CASE',
 		'First char in caps in key'                  => 'Proper Case',
 		'Lowercase key'                              => 'lower case',
@@ -45,7 +45,7 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 		'true key will become integer 1 key'         => true,
 		'Float key will be converted to integer key (cut off)' => 5.0,
 		'Explicit integer numeric key'               => 100,
-	);
+	];
 
 	/**
 	 * Text string case changing functions in PHP.
@@ -54,12 +54,12 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	 *
 	 * @var array
 	 */
-	const CHANGE_CASE_FUNCTIONS = array(
+	const CHANGE_CASE_FUNCTIONS = [
 		'strtolower' => true,
 		'strtoupper' => true,
 		'ucfirst'    => true,
 		'ucwords'    => true,
-	);
+	];
 
 	/**
 	 * Test setting up a dictionary without entries.
@@ -117,7 +117,7 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	 * @return array
 	 */
 	public function dataArrayAccessForValidEntries() {
-		$data = array();
+		$data = [];
 
 		foreach (self::DATASET_REVERSED as $key => $value) {
 			if (is_string($value)) {
@@ -125,10 +125,10 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 				$value = $fn($value);
 			}
 
-			$data[$key] = array(
+			$data[$key] = [
 				'key'   => $value,
 				'value' => $key,
-			);
+			];
 		}
 
 		return $data;
@@ -172,10 +172,10 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	 * @return array
 	 */
 	public function dataArrayAccessForInvalidEntry() {
-		return array(
-			'string key'  => array('Non-existant entry'),
-			'integer key' => array(25),
-		);
+		return [
+			'string key'  => ['Non-existant entry'],
+			'integer key' => [25],
+		];
 	}
 
 	/**
@@ -223,7 +223,7 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	 * @return void
 	 */
 	public function testGetAll() {
-		$expected = array(
+		$expected = [
 			'upper case'  => 'Uppercase key',
 			'proper case' => 'First char in caps in key',
 			'lower case'  => 'Lowercase key',
@@ -232,7 +232,7 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 			1             => 'true key will become integer 1 key',
 			5             => 'Float key will be converted to integer key (cut off)',
 			100           => 'Explicit integer numeric key',
-		);
+		];
 
 		$dictionary = new CaseInsensitiveDictionary(self::DATASET);
 		$this->assertSame($expected, $dictionary->getAll());

--- a/tests/Utility/FilteredIteratorTest.php
+++ b/tests/Utility/FilteredIteratorTest.php
@@ -55,20 +55,20 @@ final class FilteredIteratorTest extends TestCase {
 	 * @return array
 	 */
 	public function dataSerializeDeserializeObjects() {
-		return array(
-			'FilteredIterator object with one value, callback: md5' => array(
-				'value' => new FilteredIterator(array(1), 'md5'),
-			),
-			'FilteredIterator object with two values, callback: sha1' => array(
-				'value' => new FilteredIterator(array(1, 2), 'sha1'),
-			),
-			'FilteredIterator object with three values, non-existent callback' => array(
-				'value' => new FilteredIterator(array(1, 2, 3), 'doesnotexist'),
-			),
-			'ArrayIterator object with three values, no callback' => array(
-				'value' => new ArrayIterator(array(1, 2, 3)),
-			),
-		);
+		return [
+			'FilteredIterator object with one value, callback: md5' => [
+				'value' => new FilteredIterator([1], 'md5'),
+			],
+			'FilteredIterator object with two values, callback: sha1' => [
+				'value' => new FilteredIterator([1, 2], 'sha1'),
+			],
+			'FilteredIterator object with three values, non-existent callback' => [
+				'value' => new FilteredIterator([1, 2, 3], 'doesnotexist'),
+			],
+			'ArrayIterator object with three values, no callback' => [
+				'value' => new ArrayIterator([1, 2, 3]),
+			],
+		];
 	}
 
 	/**
@@ -92,10 +92,10 @@ final class FilteredIteratorTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorValidData() {
-		return array(
-			'array'           => array(array(1, 2, 3)),
-			'iterable object' => array(new ArrayIterator(array(1, 2, 3))),
-		);
+		return [
+			'array'           => [[1, 2, 3]],
+			'iterable object' => [new ArrayIterator([1, 2, 3])],
+		];
 	}
 
 	/**
@@ -122,11 +122,11 @@ final class FilteredIteratorTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidData() {
-		return array(
-			'null'              => array(null),
-			'float'             => array(1.1),
-			'stringable object' => array(new StringableObject('value')),
-		);
+		return [
+			'null'              => [null],
+			'float'             => [1.1],
+			'stringable object' => [new StringableObject('value')],
+		];
 	}
 
 	/**
@@ -141,7 +141,7 @@ final class FilteredIteratorTest extends TestCase {
 	 * @return void
 	 */
 	public function testConstructorValidCallback($input) {
-		$obj = new FilteredIterator(array(), $input);
+		$obj = new FilteredIterator([], $input);
 
 		$reflection = new ReflectionObject($obj);
 		$property   = $reflection->getProperty('callback');
@@ -158,10 +158,10 @@ final class FilteredIteratorTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorValidCallback() {
-		return array(
-			'existing PHP native function' => array('strtolower'),
-			'dummy callback method'        => array(array($this, 'dummyCallback')),
-		);
+		return [
+			'existing PHP native function' => ['strtolower'],
+			'dummy callback method'        => [[$this, 'dummyCallback']],
+		];
 	}
 
 	/**
@@ -176,7 +176,7 @@ final class FilteredIteratorTest extends TestCase {
 	 * @return void
 	 */
 	public function testConstructorInvalidCallback($input) {
-		$obj = new FilteredIterator(array(), $input);
+		$obj = new FilteredIterator([], $input);
 
 		$reflection = new ReflectionObject($obj);
 		$property   = $reflection->getProperty('callback');
@@ -193,11 +193,11 @@ final class FilteredIteratorTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidCallback() {
-		return array(
-			'null'                  => array(null),
-			'non-existent function' => array('functionname'),
-			'plain object'          => array(new stdClass(), 'method'),
-		);
+		return [
+			'null'                  => [null],
+			'non-existent function' => ['functionname'],
+			'plain object'          => [new stdClass(), 'method'],
+		];
 	}
 
 	/**

--- a/tests/Utility/InputValidatorTest.php
+++ b/tests/Utility/InputValidatorTest.php
@@ -148,249 +148,249 @@ final class InputValidatorTest extends TestCase {
 			self::$dir_handle  = opendir(__DIR__);
 		}
 
-		return array(
-			'null' => array(
+		return [
+			'null' => [
 				'input'    => null,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'boolean false' => array(
+				],
+			],
+			'boolean false' => [
 				'input'    => false,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'boolean true' => array(
+				],
+			],
+			'boolean true' => [
 				'input'    => true,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'integer 0' => array(
+				],
+			],
+			'integer 0' => [
 				'input'    => 0,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => true,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'negative integer' => array(
+				],
+			],
+			'negative integer' => [
 				'input'    => -123,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => true,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'positive integer' => array(
+				],
+			],
+			'positive integer' => [
 				'input'    => 786687,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => true,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'float 0.0' => array(
+				],
+			],
+			'float 0.0' => [
 				'input'    => 0.0,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'negative float' => array(
+				],
+			],
+			'negative float' => [
 				'input'    => 5.600e-3,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'positive float' => array(
+				],
+			],
+			'positive float' => [
 				'input'    => 124.7,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'empty string' => array(
+				],
+			],
+			'empty string' => [
 				'input'    => '',
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => true,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'string "123"' => array(
+				],
+			],
+			'string "123"' => [
 				'input'    => '123',
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => true,
 					'is_numeric_array_key'    => true,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'string "foobar"' => array(
+				],
+			],
+			'string "foobar"' => [
 				'input'    => 'foobar',
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => true,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'string "123 My Street"' => array(
+				],
+			],
+			'string "123 My Street"' => [
 				'input'    => '123 My Street',
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => true,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'empty array' => array(
-				'input'    => array(),
-				'expected' => array(
+				],
+			],
+			'empty array' => [
+				'input'    => [],
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => true,
 					'is_iterable'             => true,
 					'is_curl_handle'          => false,
-				),
-			),
-			'array with three items, no keys' => array(
-				'input'    => array(1, 2, 3),
-				'expected' => array(
+				],
+			],
+			'array with three items, no keys' => [
+				'input'    => [1, 2, 3],
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => true,
 					'is_iterable'             => true,
 					'is_curl_handle'          => false,
-				),
-			),
-			'array with two items, with keys' => array(
-				'input'    => array('a' => 1, 'b' => 2),
-				'expected' => array(
+				],
+			],
+			'array with two items, with keys' => [
+				'input'    => ['a' => 1, 'b' => 2],
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => true,
 					'is_iterable'             => true,
 					'is_curl_handle'          => false,
-				),
-			),
-			'plain object' => array(
+				],
+			],
+			'plain object' => [
 				'input'    => new stdClass(),
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'object with __toString method' => array(
+				],
+			],
+			'object with __toString method' => [
 				'input'    => new StringableObject('value'),
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => true,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => true,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'object implementing ArrayIterator' => array(
-				'input'    => new ArrayIterator(array(1, 2, 3)),
-				'expected' => array(
+				],
+			],
+			'object implementing ArrayIterator' => [
+				'input'    => new ArrayIterator([1, 2, 3]),
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => true,
 					'is_iterable'             => true,
 					'is_curl_handle'          => false,
-				),
-			),
-			'object implementing ArrayAccess' => array(
+				],
+			],
+			'object implementing ArrayAccess' => [
 				'input'    => new ArrayAccessibleObject(),
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => true,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-			'Curl handle (resource or object depending on PHP version)' => array(
+				],
+			],
+			'Curl handle (resource or object depending on PHP version)' => [
 				'input'    => self::$curl_handle,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => true,
-				),
-			),
-			'Directory handle (resource)' => array(
+				],
+			],
+			'Directory handle (resource)' => [
 				'input'    => self::$dir_handle,
-				'expected' => array(
+				'expected' => [
 					'is_string_or_stringable' => false,
 					'is_numeric_array_key'    => false,
 					'is_stringable_object'    => false,
 					'has_array_access'        => false,
 					'is_iterable'             => false,
 					'is_curl_handle'          => false,
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 }


### PR DESCRIPTION
* Update the PHPCS ruleset to enforce short arrays.
* Update the complete codebase to comply.
