### PR TITLE
GH Pages/Actions: minor tweaks for the website generation

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -115,17 +115,17 @@ jobs:
       # So we always need to make sure that the old version of the API docs are
       # cleared out completely.
       - name: Clear out the API directory
-        run: rm -vrf ./api/*
+        run: rm -vrf ./api-2.x/*
 
       - name: Move the updated API doc files
-        run: mv -fv artifacts/api/* ./api/
+        run: mv -fv artifacts/api-2.x/* ./api-2.x/
 
       # The commit should contain all changes in the API directory, both tracked and untracked!
       - name: Commit the API docs separately
         run: |
           git config user.name 'GitHub Action'
           git config user.email '${{ github.actor }}@users.noreply.github.com'
-          git add -A ./api/
+          git add -A ./api-2.x/
           git commit --allow-empty --message="GH Pages: update API docs for Requests ${{ steps.get_pr_info.outputs.REF }}"
 
       # Similar to the API docs, files could be removed from the prose docs, so

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ or
 ```json
 {
     "require": {
-        "rmccue/requests": ">=1.0"
+        "rmccue/requests": "^2.0"
     }
 }
 ```
@@ -124,12 +124,12 @@ After that, take a look at [the documentation for
 `\WpOrg\Requests\Requests::request()`][request_method], where all the parameters are fully
 documented.
 
-Requests is [100% documented with PHPDoc](https://requests.ryanmccue.info/api/).
+Requests is [100% documented with PHPDoc](https://requests.ryanmccue.info/api-2.x/).
 If you find any problems with it, [create a new
 issue](https://github.com/WordPress/Requests/issues/new)!
 
 [prose-based documentation]: https://github.com/WordPress/Requests/blob/stable/docs/README.md
-[request_method]: https://requests.ryanmccue.info/api/class-Requests.html#_request
+[request_method]: https://requests.ryanmccue.info/api-2.x/classes/WpOrg-Requests-Requests.html#method_request
 
 Testing
 -------

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Documentation
 If you're here, you're looking for documentation for Requests! The documents
 here are prose; you might also want to check out the [API documentation][].
 
-[API documentation]: https://requests.ryanmccue.info/api/
+[API documentation]: https://requests.ryanmccue.info/api-2.x/
 
 <!-- Splitter DO NOT REMOVE Splitter -->
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -7,7 +7,7 @@ process along with internal transport hooks.
 Check out the [API documentation for `WpOrg\Requests\Hooks`][requests_hooks] for more
 information on how to use the hook system.
 
-[requests_hooks]: {{ '/api/class-Requests_Hooks.html' | prepend: site.baseurl }}
+[requests_hooks]: {{ '/api-2.x/classes/WpOrg-Requests-Hooks.html' | prepend: site.baseurl }}
 
 Available Hooks
 ---------------

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -9,7 +9,7 @@
     <title>Requests #.#.# API</title>
 
     <paths>
-        <output>build/ghpages/artifacts/api/</output>
+        <output>build/ghpages/artifacts/api-2.x/</output>
         <cache>build/ghpages/.phpdoc/</cache>
     </paths>
 


### PR DESCRIPTION
To prevent "dead links" from search engines and otherwise, the _old_ documentation will remain in the `/api/` directory and the _new_ documentation will be placed in the _new_ `/api-2.x/` directory.

Includes updating links in the prose docs.