### PR TITLE
Transport\Curl/Fsockopen: add input validation

### DIFF
--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -231,11 +231,22 @@ final class Curl implements Transport {
 	 * @param array $requests Request data
 	 * @param array $options Global options
 	 * @return array Array of \WpOrg\Requests\Response objects (may contain \WpOrg\Requests\Exception or string responses as well)
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $requests argument is not an array or iterable object with array access.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 */
 	public function request_multiple($requests, $options) {
 		// If you're not requesting, we can't get any responses ¯\_(ツ)_/¯
 		if (empty($requests)) {
 			return [];
+		}
+
+		if (InputValidator::has_array_access($requests) === false || InputValidator::is_iterable($requests) === false) {
+			throw InvalidArgument::create(1, '$requests', 'array|ArrayAccess&Traversable', gettype($requests));
+		}
+
+		if (is_array($options) === false) {
+			throw InvalidArgument::create(2, '$options', 'array', gettype($options));
 		}
 
 		$multihandle = curl_multi_init();

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -15,6 +15,7 @@ use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Exception\Transport\Curl as CurlException;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Transport;
+use WpOrg\Requests\Utility\InputValidator;
 
 /**
  * cURL HTTP transport
@@ -130,24 +131,37 @@ final class Curl implements Transport {
 	/**
 	 * Perform a request
 	 *
-	 * @param string $url URL to request
+	 * @param string|Stringable $url URL to request
 	 * @param array $headers Associative array of request headers
 	 * @param string|array $data Data to send either as the POST body, or as parameters in the URL for a GET/HEAD
 	 * @param array $options Request options, see {@see \WpOrg\Requests\Requests::response()} for documentation
 	 * @return string Raw HTTP result
 	 *
-	 * @throws \WpOrg\Requests\InvalidArgument When the $data parameter is not an array or string.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $url argument is not a string or Stringable.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $headers argument is not an array.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $data parameter is not an array or string.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 * @throws \WpOrg\Requests\Exception       On a cURL error (`curlerror`)
 	 */
 	public function request($url, $headers = [], $data = [], $options = []) {
+		if (InputValidator::is_string_or_stringable($url) === false) {
+			throw InvalidArgument::create(1, '$url', 'string|Stringable', gettype($url));
+		}
+
+		if (is_array($headers) === false) {
+			throw InvalidArgument::create(2, '$headers', 'array', gettype($headers));
+		}
+
 		if (!is_array($data) && !is_string($data)) {
 			if ($data === null) {
 				$data = '';
-			} elseif (is_int($data) || is_float($data)) {
-				$data = (string) $data;
 			} else {
 				throw InvalidArgument::create(3, '$data', 'array|string', gettype($data));
 			}
+		}
+
+		if (is_array($options) === false) {
+			throw InvalidArgument::create(4, '$options', 'array', gettype($options));
 		}
 
 		$this->hooks = $options['hooks'];

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -344,8 +344,24 @@ final class Fsockopen implements Transport {
 	 * @param array $requests Request data (array of 'url', 'headers', 'data', 'options') as per {@see \WpOrg\Requests\Transport::request()}
 	 * @param array $options Global options, see {@see \WpOrg\Requests\Requests::response()} for documentation
 	 * @return array Array of \WpOrg\Requests\Response objects (may contain \WpOrg\Requests\Exception or string responses as well)
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $requests argument is not an array or iterable object with array access.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 */
 	public function request_multiple($requests, $options) {
+		// If you're not requesting, we can't get any responses ¯\_(ツ)_/¯
+		if (empty($requests)) {
+			return [];
+		}
+
+		if (InputValidator::has_array_access($requests) === false || InputValidator::is_iterable($requests) === false) {
+			throw InvalidArgument::create(1, '$requests', 'array|ArrayAccess&Traversable', gettype($requests));
+		}
+
+		if (is_array($options) === false) {
+			throw InvalidArgument::create(2, '$options', 'array', gettype($options));
+		}
+
 		$responses = [];
 		$class     = get_class($this);
 		foreach ($requests as $id => $request) {

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -15,6 +15,7 @@ use WpOrg\Requests\Requests;
 use WpOrg\Requests\Ssl;
 use WpOrg\Requests\Transport;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
+use WpOrg\Requests\Utility\InputValidator;
 
 /**
  * fsockopen HTTP transport
@@ -55,25 +56,38 @@ final class Fsockopen implements Transport {
 	/**
 	 * Perform a request
 	 *
-	 * @param string $url URL to request
+	 * @param string|Stringable $url URL to request
 	 * @param array $headers Associative array of request headers
 	 * @param string|array $data Data to send either as the POST body, or as parameters in the URL for a GET/HEAD
 	 * @param array $options Request options, see {@see \WpOrg\Requests\Requests::response()} for documentation
 	 * @return string Raw HTTP result
 	 *
-	 * @throws \WpOrg\Requests\InvalidArgument When the $data parameter is not an array or string.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $url argument is not a string or Stringable.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $headers argument is not an array.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $data parameter is not an array or string.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
 	 * @throws \WpOrg\Requests\Exception       On failure to connect to socket (`fsockopenerror`)
 	 * @throws \WpOrg\Requests\Exception       On socket timeout (`timeout`)
 	 */
 	public function request($url, $headers = [], $data = [], $options = []) {
+		if (InputValidator::is_string_or_stringable($url) === false) {
+			throw InvalidArgument::create(1, '$url', 'string|Stringable', gettype($url));
+		}
+
+		if (is_array($headers) === false) {
+			throw InvalidArgument::create(2, '$headers', 'array', gettype($headers));
+		}
+
 		if (!is_array($data) && !is_string($data)) {
 			if ($data === null) {
 				$data = '';
-			} elseif (is_int($data) || is_float($data)) {
-				$data = (string) $data;
 			} else {
 				throw InvalidArgument::create(3, '$data', 'array|string', gettype($data));
 			}
+		}
+
+		if (is_array($options) === false) {
+			throw InvalidArgument::create(4, '$options', 'array', gettype($options));
 		}
 
 		$options['hooks']->dispatch('fsockopen.before_request');

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -8,8 +8,10 @@ use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\Http\StatusUnknown;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Hooks;
+use WpOrg\Requests\Iri;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
+use WpOrg\Requests\Tests\Fixtures\ArrayAccessibleObject;
 use WpOrg\Requests\Tests\Fixtures\TransportMock;
 use WpOrg\Requests\Tests\TestCase;
 
@@ -64,7 +66,7 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testSimpleGET() {
-		$request = Requests::get(httpbin('/get'), [], $this->getOptions());
+		$request = Requests::get(new Iri(httpbin('/get')), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -185,9 +187,62 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	/**
+	 * Tests receiving an exception when the request() method receives an invalid input type as `$url`.
+	 *
+	 * @dataProvider dataRequestInvalidUrl
+	 *
+	 * @covers \WpOrg\Requests\Transport\Curl::request
+	 * @covers \WpOrg\Requests\Transport\Fsockopen::request
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testRequestInvalidUrl($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($url) must be of type string|Stringable');
+
+		$transport = new $this->transport();
+		$transport->request($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataRequestInvalidUrl() {
+		return [
+			'boolean false'         => [false],
+			'array'                 => [[httpbin('/')]],
+			'non-stringable object' => [new stdClass('name')],
+		];
+	}
+
+	/**
+	 * Tests receiving an exception when the request() method received an invalid input type as `$headers`.
+	 *
+	 * @dataProvider dataInvalidTypeNotArray
+	 *
+	 * @covers \WpOrg\Requests\Transport\Curl::request
+	 * @covers \WpOrg\Requests\Transport\Fsockopen::request
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testRequestInvalidHeaders($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #2 ($headers) must be of type array');
+
+		$transport = new $this->transport();
+		$transport->request('', $input);
+	}
+
+	/**
 	 * Test that when a $data parameter of an incorrect type gets passed, it gets handled correctly.
 	 *
-	 * Only string/array are officially supported as accepted data types, but null, integers and floats
+	 * Only string/array are officially supported as accepted data types, but null
 	 * will also be handled (cast to string).
 	 *
 	 * This test safeguards handling of data types in response to changes in PHP 8.1.
@@ -220,26 +275,28 @@ abstract class BaseTestCase extends TestCase {
 	 */
 	public function dataIncorrectDataTypeAccepted() {
 		return [
-			'null'    => [null, ''],
-			'integer' => [12345, '12345'],
-			'float'   => [12.345, '12.345'],
+			'null' => [null, ''],
 		];
 	}
 
 	/**
-	 * Test that when a $data parameter of an unhandled incorrect type gets passed, an exception gets thrown.
+	 * Tests receiving an exception when the request() method received an invalid input type as `$data`.
 	 *
 	 * @dataProvider dataIncorrectDataTypeException
 	 *
-	 * @param mixed $data Input to be used as the $data parameter.
+	 * @covers \WpOrg\Requests\Transport\Curl::request
+	 * @covers \WpOrg\Requests\Transport\Fsockopen::request
+	 *
+	 * @param mixed $input Invalid parameter input.
 	 *
 	 * @return void
 	 */
-	public function testIncorrectDataTypeExceptionPOST($data) {
+	public function testRequestInvalidData($input) {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #3 ($data) must be of type array|string');
 
-		Requests::post(httpbin('/post'), [], $data, $this->getOptions());
+		$transport = new $this->transport();
+		$transport->request(httpbin('/post'), [], $input, $this->getOptions());
 	}
 
 	/**
@@ -250,7 +307,42 @@ abstract class BaseTestCase extends TestCase {
 	public function dataIncorrectDataTypeException() {
 		return [
 			'boolean' => [true],
+			'integer' => [12345, '12345'],
+			'float'   => [12.345, '12.345'],
 			'object'  => [new stdClass()],
+		];
+	}
+
+	/**
+	 * Tests receiving an exception when the request() method received an invalid input type as `$options`.
+	 *
+	 * @dataProvider dataInvalidTypeNotArray
+	 *
+	 * @covers \WpOrg\Requests\Transport\Curl::request
+	 * @covers \WpOrg\Requests\Transport\Fsockopen::request
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testRequestInvalidOptions($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #4 ($options) must be of type array');
+
+		$transport = new $this->transport();
+		$transport->request('/', [], [], $input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidTypeNotArray() {
+		return [
+			'null'                    => [null],
+			'boolean false'           => [false],
+			'array accessible object' => [new ArrayAccessibleObject([])],
 		];
 	}
 

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -2,6 +2,7 @@
 
 namespace WpOrg\Requests\Tests\Transport;
 
+use EmptyIterator;
 use stdClass;
 use WpOrg\Requests\Capability;
 use WpOrg\Requests\Exception;
@@ -331,6 +332,88 @@ abstract class BaseTestCase extends TestCase {
 
 		$transport = new $this->transport();
 		$transport->request('/', [], [], $input);
+	}
+
+	/**
+	 * Tests receiving an exception when the request_multiple() method received an invalid input type as `$requests`.
+	 *
+	 * @dataProvider dataRequestMultipleReturnsEmptyArrayWhenRequestsIsEmpty
+	 *
+	 * @covers \WpOrg\Requests\Transport\Curl::request_multiple
+	 * @covers \WpOrg\Requests\Transport\Fsockopen::request_multiple
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testRequestMultipleReturnsEmptyArrayWhenRequestsIsEmpty($input) {
+		$transport = new $this->transport();
+		$this->assertSame([], $transport->request_multiple($input, $this->getOptions()));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataRequestMultipleReturnsEmptyArrayWhenRequestsIsEmpty() {
+		return [
+			'null'        => [null],
+			'empty array' => [[]],
+		];
+	}
+
+	/**
+	 * Tests receiving an exception when the request_multiple() method received an invalid input type as `$requests`.
+	 *
+	 * @dataProvider dataRequestMultipleInvalidRequests
+	 *
+	 * @covers \WpOrg\Requests\Transport\Curl::request_multiple
+	 * @covers \WpOrg\Requests\Transport\Fsockopen::request_multiple
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testRequestMultipleInvalidRequests($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($requests) must be of type array|ArrayAccess&Traversable');
+
+		$transport = new $this->transport();
+		$transport->request_multiple($input, $this->getOptions());
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataRequestMultipleInvalidRequests() {
+		return [
+			'text string'                          => ['array'],
+			'iterator object without array access' => [new EmptyIterator()],
+			'array accessible object not iterable' => [new ArrayAccessibleObject([1, 2, 3])],
+		];
+	}
+
+	/**
+	 * Tests receiving an exception when the request_multiple() method received an invalid input type as `$option`.
+	 *
+	 * @dataProvider dataInvalidTypeNotArray
+	 *
+	 * @covers \WpOrg\Requests\Transport\Curl::request_multiple
+	 * @covers \WpOrg\Requests\Transport\Fsockopen::request_multiple
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testRequestMultipleInvalidOptions($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #2 ($options) must be of type array');
+
+		$transport = new $this->transport();
+		$transport->request_multiple(['notempty'], $input);
 	}
 
 	/**


### PR DESCRIPTION
### Transport\Curl/Fsockopen::request(): add input validation

This commit adds input validation to the `Curl::request()` and the `Fsockopen::request()` methods along the same lines as added to `Requests::request()`.

* The `$url` parameter is validated to allow for a string or Stringable (Iri) object.
* The `$headers` parameter is validated to allow only an array for consistency between both transport classes.
* The `$data` parameter already had (looser) input validation. This has been tightened up to only allow for the declared supported types, array and string (and null).
* The `$options` parameter is validated to allow only an array - same as in `Requests::request()`.

Includes:
* Adding perfunctory tests for the new exceptions.
* Adjusting one existing test to ensure that passing the `$url` as a stringable object is safeguarded.
* Adjusting the existing tests for the `$data` parameter validation to be in line with the new validation.

### Transport\Curl/Fsockopen::request_multiple(): add input validation

This commit adds input validation to the `Curl::request_multiple()` and the `Fsockopen::request_multiple()` methods along the same lines as added to `Requests::request_multiple()`.

* For `$requests`, arrays and iterable objects with array access should be accepted based on how the parameter is used within this class.
* The `$options` parameter is validated to allow only an array - same as in `Requests::request()`.

Includes aligning the behaviour when receiving an empty `$requests` array between the `Curl` and the `Fsockopen` classes and returning an empty array in that case.

Includes adding perfunctory tests for the new exceptions.


---

### Regarding the other `public` methods in `Curl`:

* While `public`, the `get_subrequest_handle()` and `process_response()` methods look to be intended for internal use only.
* Same goes for `stream_headers()` and `stream_body()`. Note: these methods both take a `$handle` parameter which is subsequently unused. I imagine this was to allow for overloaded methods to receive the `$handle`, but the class has become `final` now (after investigation and finding no extended classes), so these methods can no be overloaded.
    I think it may be a good idea to deprecate the public methods in a future minor in favour of `protected`/`private` replacements which only receive the parameters which are actually use.
* Lastly, there is the `test()` method for which the `$capabilities` parameter is only used after an `isset()` on the keys used, so this is safe as-is.
* Other `public` methods do not take parameters.


### Regarding the other `public` methods in `Fsockopen`:

* The `connect_error_handler()` method is an error handler and should not be called directly.
* While `public`, the `verify_certificate_from_context()` method looks to be intended for internal use only.
* Lastly, there is the `test()` method for which the `$capabilities` parameter is only used after an `isset()` on the keys used, so this is safe as-is.
