### PR TITLE
GH Actions: no longer allow failures on PHP 8.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,12 +20,8 @@ jobs:
     strategy:
       matrix:
         # Lint against the high/low versions of each PHP major.
-        php: ['5.6', '7.0', '7.4', '8.0']
+        php: ['5.6', '7.0', '7.4', '8.0', '8.1']
         experimental: [false]
-
-        include:
-          - php: '8.1'
-            experimental: true
 
     name: "Lint: PHP ${{ matrix.php }}"
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       # - coverage: Whether to run the tests with code coverage.
       # - experimental: Whether the build is "allowed to fail".
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.1']
         coverage: [false]
         experimental: [false]
 
@@ -36,11 +36,6 @@ jobs:
           - php: '8.0'
             coverage: true
             experimental: false
-
-          # Test against PHP Nightly.
-          - php: '8.1'
-            coverage: false
-            experimental: true
 
     name: "Test: PHP ${{ matrix.php }}"
 


### PR DESCRIPTION
The builds against PHP 8.1 are all green at this time and the general release is only two weeks away, so let's just keep it that way and not allow failures against PHP 8.1 anymore.

Note: I'm not adding PHP 8.2 yet at this time as IMO it is too early to start testing against that version. Let's leave that till May 2022 or something.