### PR TITLE
Skip alternate port test while portquiz has issues

### DIFF
--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -1077,6 +1077,8 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testAlternatePort() {
+		$this->markTestSkipped('The portquiz.net service is having technical issues.');
+
 		try {
 			$request = Requests::get('http://portquiz.net:8080/', [], $this->getOptions());
 		}


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement

## Context

Skip alternate port test while required service has technical issues.

## Detailed Description

The portquiz.net service that we are using to test the use of alternate ports is currently always returning `80` as the detected port, regardless of what port you actually did the request with.

We contacted the author via email to see if this is something that can be fixed.

In the mean time, this PR skips the particular test, as the failure is due to external circumstances.

An issue was opened to re-enable the test at a later point: #639 



## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.