### PR TITLE
Docs: full review of Hook documentation

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -16,45 +16,116 @@ Available Hooks
 
     Alter the request before it is sent to the transport.
 
-    Parameters: `string &$url`, `array &$headers`, `array|string &$data`,
+    Parameters: `string &$url`, `array &$headers`, `array|null &$data`,
     `string &$type`, `array &$options`
+
+* **`request.progress`**
+
+    Run events based on how much body data has been received up to this point for the current request.
+
+    Parameters: `string $data`, `int $response_bytes`, `int|bool $response_byte_limit`
 
 * **`requests.before_parse`**
 
     Alter the raw HTTP response before parsing.
 
-    Parameters: `string &$response`
+    Parameters: `string &$response`, `string $url`, `array $headers`,
+    `array|null $data`, `string $type`, `array $options`
+
+* **`requests.before_redirect_check`**
+
+    Alter the response object before a potential redirect is detected and acted on.
+
+    Parameters: `WpOrg\Requests\Response &$return`, `array $req_headers`,
+    `array $req_data`, `array $options`
+
+* **`requests.before_redirect`**
+
+    Alter the request arguments before a redirect is acted upon.
+
+    Parameters: `string &$location`, `array &$req_headers`, `array &$req_data`,
+    `array &$options`, `WpOrg\Requests\Response $return`
 
 * **`requests.after_request`**
 
     Alter the response object before it is returned to the user.
 
-    Parameters: `WpOrg\Requests\Response &$return`
+    Parameters: `WpOrg\Requests\Response &$return`, `array &$req_headers`,
+    `array &$req_data`, `array &$options`
+
+* **`multiple.request.complete`**
+
+    Alter the response for an individual request in a multi-request.
+
+    Parameters: `WpOrg\Requests\Response &$response`, `string|int $id`
+
+    Do not register this hook directly.
+    To use this hook, pass a callback via `$options['complete']` when calling
+    `WpOrg\Requests\Requests\request_multiple()`.
 
 * **`curl.before_request`**
 
     Set cURL options before the transport sets any (note that Requests may
     override these).
 
-    Parameters: `cURL resource|CurlHandle &$fp`
+    Parameters: `cURL resource|CurlHandle &$handle`
 
 * **`curl.before_send`**
 
     Set cURL options just before the request is actually sent via `curl_exec()`.
 
-    Parameters: `cURL resource|CurlHandle &$fp`
+    Parameters: `cURL resource|CurlHandle &$handle`
+
+* **`curl.after_send`**
+
+    Run events after sending the request, but before interpreting the response.
+
+    Parameters: -
 
 * **`curl.after_request`**
 
     Alter the raw HTTP response before returning for parsing.
 
-    Parameters: `string &$response, array &$info`
+    Parameters: `string &$headers`, `[array &$info]`
 
-    `$info` contains the associated array as defined in the return value for [curl_getinfo()](https://www.php.net/curl-getinfo#refsect1-function.curl-getinfo-returnvalues).
+    The optional `$info` parameter contains the associated array as defined in
+    the return value for [curl_getinfo()](https://www.php.net/curl-getinfo#refsect1-function.curl-getinfo-returnvalues).
+
+This optional parameter will be present when a blocking request was made (`$options['blocking' = true`) and will not be present when a non-blocking request was made (`$options['blocking' = false`). The callback signature needs to be adapted accordingly.
+
+* **`curl.before_multi_add`**
+
+    Set cURL options before adding the request to a cURL multi handle.
+
+    Parameters: `cURL resource|CurlHandle &$subhandle`
+
+* **`curl.before_multi_exec`**
+
+    Set cURL options before executing a cURL multi handle request.
+
+    Parameters: `cURL resource|CurlMultiHandle &$multihandle`
+
+* **`curl.after_multi_exec`**
+
+    Run events before a cURL multi handle is closed.
+
+    Parameters: `cURL resource|CurlMultiHandle &$multihandle`
 
 * **`fsockopen.before_request`**
 
     Run events before the transport does anything.
+
+* **`fsockopen.remote_socket`**
+
+    Alter the remote socket.
+
+    Parameters: `string &$remote_socket`
+
+* **`fsockopen.remote_host_path`**
+
+    Alter the remote host path.
+
+    Parameters: `string &$path`, `string $url`
 
 * **`fsockopen.after_headers`**
 
@@ -70,16 +141,20 @@ Available Hooks
 
 * **`fsockopen.after_send`**
 
-   Run events after writing the data to the socket.
+    Run events after writing the data to the socket.
+
+    Parameters: `string $out`
 
 * **`fsockopen.after_request`**
 
     Alter the raw HTTP response before returning for parsing.
 
-    Parameters: `string &$response, array &$info`
+    Parameters: `string &$headers`, `[array &$info]`
 
-    `$info` contains the associated array as defined in the return value for [stream_get_meta_data()](https://www.php.net/stream-get-meta-data#refsect1-function.stream-get-meta-data-returnvalues).
+    The optional `$info` parameter contains the associated array as defined
+    in the return value for [stream_get_meta_data()](https://www.php.net/stream-get-meta-data#refsect1-function.stream-get-meta-data-returnvalues).
 
+This optional parameter will be present when a blocking request was made (`$options['blocking' = true`) and will not be present when a non-blocking request was made (`$options['blocking' = false`). The callback signature needs to be adapted accordingly.
 
 
 Registering Hooks


### PR DESCRIPTION
Inspired by issue #220, I've:
* Verified that all hooks listed in the documentation still exist in the codebase.
* Verified the parameters for all hooks listed in the docs with the actual parameters in the hook calls in the codebase.
* Verified that all hooks in the codebase are listed in the Hooks documentation page, with the exception of the `transport.internal....` hooks.

Note:
* The hook descriptions for the added hooks can probably use further improvement. I wasn't always sure how best to describe the hook event.
* The ordering of this list looks to be a loose "requests hooks, curl hooks, fsockopen hooks and those in the order they are called" order.
    With some of the additional hooks, it wasn't always clear where to place them within this loose order, so suggestions to improve the order are welcome.

Also note that the naming of the `request.progress` hook seems inconsistent. I do understand why the hook uses `request` instead of `requests`, but this may be something to revisit at a later point in time.