### PR TITLE
Hooks: priority should be respected

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -86,6 +86,8 @@ class Hooks implements HookManager {
 			$parameters = array_values($parameters);
 		}
 
+		ksort($this->hooks[$hook]);
+
 		foreach ($this->hooks[$hook] as $priority => $hooked) {
 			foreach ($hooked as $callback) {
 				$callback(...$parameters);


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement

## Detailed Description

The `$priority` parameter in the `register()` method is intended to allow for prioritizing the order in which callbacks are run, however, this priority was effectively not used, so callbacks would be run in the order different priorities were _registered_, not ordered _by_ the priorities.

This commit fixes this + adds a unit test to safeguard the fix.

I've elected to add the sorting to the `dispatch()` method, rather than the `register()` method for performance reasons.
Sorting arrays can be expensive and this way, only the subarrays of those hooks which are actually being run will be sorted, instead of sorting the subarray every time a new callback is registered, whether the hook on which the callback is registered will be called or not.

Fixes #452



## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added unit tests to accompany this PR.
- [x] The (new/existing) tests cover this PR 100%.
- [x] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.
