### PR TITLE
Composer: allow the PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "A HTTP library written in PHP, for human beings.",
   "homepage": "https://requests.ryanmccue.info/",
   "license": "ISC",
+  "type": "library",
   "keywords": [
     "http",
     "idna",
@@ -39,6 +40,11 @@
     "php": ">=5.6",
     "ext-json": "*"
   },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  },
   "require-dev": {
     "requests/test-server": "dev-main",
     "squizlabs/php_codesniffer": "^3.6",
@@ -50,7 +56,6 @@
     "yoast/phpunit-polyfills": "^1.0.0",
     "roave/security-advisories": "dev-latest"
   },
-  "type": "library",
   "autoload": {
     "psr-4": {
       "WpOrg\\Requests\\": "src/"


### PR DESCRIPTION
The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution