### PR TITLE
Try to fix GitHub Actions

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -33,6 +33,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          tools: composer:2.2.4
           coverage: none
 
       # At least one test needs a non-en_US locale to be available, so make sure it is.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -33,7 +33,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:2.2.4
+          tools: composer:2.1.14
           coverage: none
 
       # At least one test needs a non-en_US locale to be available, so make sure it is.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
           coverage: ${{ steps.set_cov.outputs.COV }}
-          tools: cs2pr,composer:2.2.4
+          tools: cs2pr,composer:2.1.14
 
       # At least one test needs a non-en_US locale to be available, so make sure it is.
       - name: Install locales

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
           coverage: ${{ steps.set_cov.outputs.COV }}
-          tools: cs2pr
+          tools: cs2pr,composer:2.2.4
 
       # At least one test needs a non-en_US locale to be available, so make sure it is.
       - name: Install locales


### PR DESCRIPTION
## Pull Request Type

- [X] I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [ ] New feature
- [X] Code quality improvement

## Detailed Description

The issue in https://github.com/WordPress/Requests/runs/4614423459?check_suite_focus=true might be related to https://github.com/composer/composer/issues/10389, which was fixed/released in https://github.com/composer/composer/releases/tag/2.2.4.

Unfortunately I could not get the tests to run locally, but the error message disappeared after downgrading to Composer 2.1.14.

I am actually trying to work on https://github.com/WordPress/Requests/issues/475 and maybe add a Dockerfile and a shell script to the repository to make it easier to run the tests locally.

## Quality assurance

- [ ] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [ ] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!
I.e. code style complies with the project standard, the unit tests pass, code coverage has not gone down.

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make reviewing your changes easier for the maintainers.
============================================================================================
-->
