### PR TITLE
GH Actions: fix apt-get dependency hell

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -35,11 +35,15 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
 
+      - name: Ensure apt tools are in a usable state
+        run: sudo apt --fix-broken install
+
+      - name: Update apt tools
+        run: sudo apt-get update
+
       # At least one test needs a non-en_US locale to be available, so make sure it is.
       - name: Install locales
-        run: |
-          sudo apt-get update
-          sudo apt-get install locales-all
+        run: sudo apt-get install locales-all
 
       - name: Show available locales
         run: locale -a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,11 +57,15 @@ jobs:
           coverage: ${{ steps.set_cov.outputs.COV }}
           tools: cs2pr
 
+      - name: Ensure apt tools are in a usable state
+        run: sudo apt --fix-broken install
+
+      - name: Update apt tools
+        run: sudo apt-get update
+
       # At least one test needs a non-en_US locale to be available, so make sure it is.
       - name: Install locales
-        run: |
-          sudo apt-get update
-          sudo apt-get install locales-all
+        run: sudo apt-get install locales-all
 
       - name: Show available locales
         run: locale -a


### PR DESCRIPTION
The command as-it-was, is currently resulting in the following error:
```
You might want to run 'apt --fix-broken install' to correct these.
The following packages have unmet dependencies:
 libpcre3-dev : Depends: libpcre3 (= 2:8.44-2+ubuntu20.04.1+deb.sury.org+1) but 2:8.39-12build1 is to be installed
 libpcrecpp0v5 : Depends: libpcre3 (>= 2:8.41) but 2:8.39-12build1 is to be installed
 php7.2-cgi : Depends: libpcre3 (>= 2:8.41) but 2:8.39-12build1 is to be installed
 php7.2-cli : Depends: libpcre3 (>= 2:8.41) but 2:8.39-12build1 is to be installed
 php7.2-fpm : Depends: libpcre3 (>= 2:8.41) but 2:8.39-12build1 is to be installed
 php7.2-phpdbg : Depends: libpcre3 (>= 2:8.41) but 2:8.39-12build1 is to be installed
E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
```

This is most likely due to something having been changed/updated in the `ubuntu-latest` image in a way which is incompatible with our use. 

So, following the advise in the error message, I'm adding `apt --fix-broken install` to the workflows.
I'm also splitting the two commands in the "Install locales" step into separate steps to allow for easier debugging of where things actually go wrong.


----

**Context**: I was trying to test if the just released [Composer 2.2.5](https://github.com/composer/composer/releases/tag/2.2.5) would fix the issue we've been seeing with the test server failing to start, when the script started erroring out before even reaching that step. This PR doesn't fix the issue below, but it does fix the **_new_** error I saw as described above.
Also see #663
```
start-stop-daemon: unable to open pidfile '/home/runner/work/Requests/Requests//home/runner/work/Requests/Requests/vendor/requests/test-server/bin/http.pid' for writing (No such file or directory)
```