### PR TITLE
Tests: fix incorrect class/file name for test class

### DIFF
--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -14,7 +14,7 @@ use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 
-final class CookiesTest extends TestCase {
+final class CookieTest extends TestCase {
 	public function testBasicCookie() {
 		$cookie = new Cookie('requests-testcookie', 'testvalue');
 


### PR DESCRIPTION
The `src` class being tested is called `Cookie`, so the test class should be called `CookieTest`, not `CookiesTest`.