### PR TITLE
GH Actions: secure the website update workflow

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -33,9 +33,11 @@ jobs:
       # to have access to the latest version of the workflow/scripts.
       - name: Determine branch to use
         id: base_branch
+        env:
+          REF: ${{ github.ref }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo '::set-output name=BRANCH::${{ github.ref }}'
+            echo "::set-output name=BRANCH::$REF"
           else
             echo '::set-output name=BRANCH::stable'
           fi
@@ -86,16 +88,19 @@ jobs:
       # always be based on the latest release.
       - name: Determine PR title prefix, body and more
         id: get_pr_info
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo '::set-output name=REF::${{ github.ref_name }}'
+            echo "::set-output name=REF::$REF_NAME"
             echo '::set-output name=PR_TITLE_PREFIX::[TEST | DO NOT MERGE] '
             echo '::set-output name=PR_BODY::Test run for the website update after changes to the automated scripts.'
             echo '::set-output name=DRAFT::true'
           else
-            echo '::set-output name=REF::${{ github.event.release.tag_name }}'
+            echo "::set-output name=REF::$TAG_NAME"
             echo '::set-output name=PR_TITLE_PREFIX::'
-            echo '::set-output name=PR_BODY::Website update after the release of Requests ${{ github.event.release.tag_name }}.'
+            echo "::set-output name=PR_BODY::Website update after the release of Requests $TAG_NAME."
             echo '::set-output name=DRAFT::false'
           fi
 
@@ -122,9 +127,11 @@ jobs:
 
       # The commit should contain all changes in the API directory, both tracked and untracked!
       - name: Commit the API docs separately
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
           git config user.name 'GitHub Action'
-          git config user.email '${{ github.actor }}@users.noreply.github.com'
+          git config user.email "$ACTOR@users.noreply.github.com"
           git add -A ./api-2.x/
           git commit --allow-empty --message="GH Pages: update API docs for Requests ${{ steps.get_pr_info.outputs.REF }}"
 


### PR DESCRIPTION
The website update workflow (re-)uses (limited) information retrieved from the original commit which triggered the workflow, such as the branch name/tag name and the committer.

This type of data should always be regarded as **untrusted** input and when these `github....` variables are used directly within the `run` context, they can lead to script injection and unintended execution of commands.

To mitigate the risk of these type of script injection attacks, untrusted data is first set as a step-specific interim environment variable and only after that the environment variable (not the github variables directly) is used in the `run` context.

This complies with the current best practices regarding defending against these type of attacks as per January 2022.
For more information, see:
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions