### PR TITLE
`curl.after_send` hook: pass the `$handle` as parameter

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -80,7 +80,7 @@ Available Hooks
 
     Run events after sending the request, but before interpreting the response.
 
-    Parameters: -
+    Parameters: `cURL resource|CurlHandle &$handle`
 
 * **`curl.after_request`**
 

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -204,7 +204,7 @@ final class Curl implements Transport {
 		curl_exec($this->handle);
 		$response = $this->response_data;
 
-		$options['hooks']->dispatch('curl.after_send', []);
+		$options['hooks']->dispatch('curl.after_send', [&$this->handle]);
 
 		if (curl_errno($this->handle) === CURLE_WRITE_ERROR || curl_errno($this->handle) === CURLE_BAD_CONTENT_ENCODING) {
 			// Reset encoding and try again


### PR DESCRIPTION
Fixes #220