### PR TITLE
`*.after_request` hook: always pass `$info`

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -86,12 +86,14 @@ Available Hooks
 
     Alter the raw HTTP response before returning for parsing.
 
-    Parameters: `string &$headers`, `[array &$info]`
+    Parameters: `string &$headers`, `array &$info`
 
-    The optional `$info` parameter contains the associated array as defined in
+    The `$info` parameter contains the associated array as defined in
     the return value for [curl_getinfo()](https://www.php.net/curl-getinfo#refsect1-function.curl-getinfo-returnvalues).
 
-This optional parameter will be present when a blocking request was made (`$options['blocking' = true`) and will not be present when a non-blocking request was made (`$options['blocking' = false`). The callback signature needs to be adapted accordingly.
+    When a non-blocking request was made (`$options['blocking'] = false`), both the `$headers` string as well as the `$info` array will be empty.
+
+    Prior to Requests 2.1.0, the `$info` parameter was omitted for non-blocking requests.
 
 * **`curl.before_multi_add`**
 
@@ -149,12 +151,14 @@ This optional parameter will be present when a blocking request was made (`$opti
 
     Alter the raw HTTP response before returning for parsing.
 
-    Parameters: `string &$headers`, `[array &$info]`
+    Parameters: `string &$headers`, `array &$info`
 
     The optional `$info` parameter contains the associated array as defined
     in the return value for [stream_get_meta_data()](https://www.php.net/stream-get-meta-data#refsect1-function.stream-get-meta-data-returnvalues).
 
-This optional parameter will be present when a blocking request was made (`$options['blocking' = true`) and will not be present when a non-blocking request was made (`$options['blocking' = false`). The callback signature needs to be adapted accordingly.
+    When a non-blocking request was made (`$options['blocking'] = false`), both the `$headers` string as well as the `$info` array will be empty.
+
+    Prior to Requests 2.1.0, the `$info` parameter was omitted for non-blocking requests.
 
 
 Registering Hooks

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -470,7 +470,8 @@ final class Curl implements Transport {
 	public function process_response($response, $options) {
 		if ($options['blocking'] === false) {
 			$fake_headers = '';
-			$options['hooks']->dispatch('curl.after_request', [&$fake_headers]);
+			$fake_info    = [];
+			$options['hooks']->dispatch('curl.after_request', [&$fake_headers, &$fake_info]);
 			return false;
 		}
 

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -254,7 +254,8 @@ final class Fsockopen implements Transport {
 		if (!$options['blocking']) {
 			fclose($socket);
 			$fake_headers = '';
-			$options['hooks']->dispatch('fsockopen.after_request', [&$fake_headers]);
+			$fake_info    = [];
+			$options['hooks']->dispatch('fsockopen.after_request', [&$fake_headers, &$fake_info]);
 			return '';
 		}
 


### PR DESCRIPTION
Callbacks hooked into the `[curl|fsockopen].after_request` hook would previously only receive the `$info` parameter for blocking requests. For non-blocking requests, the parameter would be omitted.

This made creating callbacks a little awkward, especially with both parameters being passed by reference.

This PR changes this to:
* Always pass the `$info` parameter by reference. When the request is non-blocking, this will just be a plain empty array.
* Update the hook documentation to reflect this change.

Note: this _could_ be considered a breaking change, so discussion may be warranted on whether this change can go into a minor or needs to wait for a major release.

Fixes #321