### PR TITLE
Autoload: introduce method `get_deprecated_classes()`.

### DIFF
--- a/examples/preload-aliases.php
+++ b/examples/preload-aliases.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * If you need to run the Requests v2.x library with another framework/CMS that still ships v1.x,
+ * use the following to preload the class aliases before the actual implementations of Requests v1.x. get loaded.
+ *
+ * Please note that mixing Requests v1.x and v2.x files is a bad idea and may have side effects.
+ * Do so at your own risk.
+ */
+
+// First, include the Requests Autoloader.
+require_once 'path/to/Requests/src/Autoload.php';
+
+// Make sure the autoloader is registered first as otherwise you may run into trouble on PHP 8.1.
+// See: https://news-web.php.net/php.internals/115549
+WpOrg\Requests\Autoload::register();
+
+// Silence deprecations.
+// Depending on when the bootstrapping is done, you may need to wrap this in a `if (!defined(...)) {}`.
+define('REQUESTS_SILENCE_PSR0_DEPRECATIONS', true);
+
+$preload = WpOrg\Requests\Autoload::get_deprecated_classes();
+// Add the base Requests class, just to be safe.
+$preload['requests'] = '\WpOrg\Requests\Requests';
+
+// Preload the class aliases for the Requests 1.x classes to ensure only Requests 2.x classes get loaded.
+foreach ($preload as $old => $new) {
+	// Make sure we don't get "Class already exists errors" from autoloading chains
+	// Think: an `implements` causing an interface to be loaded before we explicitly request it.
+	if (class_exists($old) === false && interface_exists($old) === false) {
+		WpOrg\Requests\Autoload::load($old);
+	}
+}

--- a/examples/preload-aliases.php
+++ b/examples/preload-aliases.php
@@ -25,7 +25,7 @@ $preload['requests'] = '\WpOrg\Requests\Requests';
 
 // Preload the class aliases for the Requests 1.x classes to ensure only Requests 2.x classes get loaded.
 foreach ($preload as $old => $new) {
-	// Make sure we don't get "Class already exists errors" from autoloading chains
+	// Make sure we don't get "Class already exists errors" from autoloading chains.
 	// Think: an `implements` causing an interface to be loaded before we explicitly request it.
 	if (class_exists($old) === false && interface_exists($old) === false) {
 		WpOrg\Requests\Autoload::load($old);

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -183,5 +183,14 @@ if (class_exists('WpOrg\Requests\Autoload') === false) {
 
 			return false;
 		}
+
+		/**
+		 * Get the array of deprecated Requests 1.x classes mapped to their equivalent Requests 2.x implementation.
+		 *
+		 * @return array
+		 */
+		public static function get_deprecated_classes() {
+			return self::$deprecated_classes;
+		}
 	}
 }

--- a/tests/AutoloadTest.php
+++ b/tests/AutoloadTest.php
@@ -5,6 +5,7 @@ namespace WpOrg\Requests\Tests;
 use Requests_Exception_Transport_cURL;
 use Requests_Utility_FilteredIterator;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Autoload;
 use WpOrg\Requests\Utility\FilteredIterator;
 
 final class AutoloadTest extends TestCase {
@@ -52,5 +53,12 @@ final class AutoloadTest extends TestCase {
 	 */
 	public function testConstantDeclarationDoesntInfluenceFurtherTests() {
 		$this->assertFalse(defined('REQUESTS_SILENCE_PSR0_DEPRECATIONS'));
+	}
+
+	/**
+	 * Verify that the get_deprecated_classes() method returns an array with 57 items.
+	 */
+	public function testGetDeprecatedClassesReturnsAnArrayWithCorrectAmountOfItems() {
+		$this->assertCount(57, Autoload::get_deprecated_classes());
 	}
 }


### PR DESCRIPTION
This method will return the array for the class mapping between the
legacy classes and their namespaced 2.x counterparts. The need for this
change came up while using the 2.x version of the library together
with a framework or CMS, that includes a 1.x version of Requests.

In order to prevent the framework from autoloading the 1.x classes,
they must be aliased before accessed. Through exposing the mapping
array, the classes can be aliased before being their implementations
get loaded.

See #659

<!--
Thank you for creating this pull request!

Provide a general summary of your changes in the Title above.
And please provide enough information in the description below, so that others can review your pull request (PR).
-->

## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement

## Context
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
What should be mentioned about this PR in the changelog?
-->


## Detailed Description

This adds the method `\WpOrg\Requests\Autoload::get_deprecated_classes` to access the class mapping from v1 to v2 and load the classes before `\WP_Http` gets the chance to do so.

## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added unit tests to accompany this PR.
- [x] The (new/existing) tests cover this PR 100%.
- [x] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.

## Documentation

For new features:
- [x] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!
I.e. code style complies with the project standard, the unit tests pass, code coverage has not gone down.

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make reviewing your changes easier for the maintainers.
============================================================================================
-->
