### PR TITLE
QA: use static closures

### DIFF
--- a/build/ghpages/update-docgen-config.php
+++ b/build/ghpages/update-docgen-config.php
@@ -19,7 +19,7 @@ use WpOrg\Requests\Autoload;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
 
-$requests_phpdoc_version_updater = function () {
+$requests_phpdoc_version_updater = static function () {
 	// Include Requests.
 	$project_root = dirname(__DIR__, 2);
 	require_once $project_root . '/src/Autoload.php';

--- a/tests/AutoloadTest.php
+++ b/tests/AutoloadTest.php
@@ -42,7 +42,7 @@ final class AutoloadTest extends TestCase {
 	public function testAutoloadOfOldRequestsClassDoesNotThrowAFatalForFinalClass() {
 		define('REQUESTS_SILENCE_PSR0_DEPRECATIONS', true);
 
-		$this->assertInstanceOf(FilteredIterator::class, new Requests_utility_filteredIterator([], function() {}));
+		$this->assertInstanceOf(FilteredIterator::class, new Requests_utility_filteredIterator([], static function() {}));
 	}
 
 	/**

--- a/tests/HooksTest.php
+++ b/tests/HooksTest.php
@@ -107,7 +107,7 @@ class HooksTest extends TestCase {
 	public function testRegisterClosureCallback() {
 		$this->hooks->register(
 			'hookname',
-			function($param) {
+			static function($param) {
 				return true;
 			}
 		);
@@ -254,48 +254,48 @@ class HooksTest extends TestCase {
 		// Register multiple callbacks for the same hook with a variation of priorities.
 		$this->hooks->register(
 			'hook_a',
-			function(&$text) {
+			static function(&$text) {
 				$text .= "no prio 0\n";
 			}
 		);
 		$this->hooks->register(
 			'hook_a',
-			function(&$text) {
+			static function(&$text) {
 				$text .= "prio 10-1\n";
 			},
 			10
 		);
 		$this->hooks->register(
 			'hook_a',
-			function(&$text) {
+			static function(&$text) {
 				$text .= "prio -3\n";
 			},
 			-3
 		);
 		$this->hooks->register(
 			'hook_a',
-			function(&$text) {
+			static function(&$text) {
 				$text .= "prio 5\n";
 			},
 			5
 		);
 		$this->hooks->register(
 			'hook_a',
-			function(&$text) {
+			static function(&$text) {
 				$text .= "prio 2-1\n";
 			},
 			2
 		);
 		$this->hooks->register(
 			'hook_a',
-			function(&$text) {
+			static function(&$text) {
 				$text .= "prio 2-2\n";
 			},
 			2
 		);
 		$this->hooks->register(
 			'hook_a',
-			function(&$text) {
+			static function(&$text) {
 				$text .= "prio 10-2\n";
 			},
 			10

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -49,7 +49,7 @@ if (defined('__PHPUNIT_PHAR__')) {
 	 * in a non-Composer context.
 	 */
 	spl_autoload_register(
-		function ($class_name) {
+		static function ($class_name) {
 			// Only try & load our own classes.
 			if (stripos($class_name, 'WpOrg\\Requests\\Tests\\') !== 0) {
 				return false;


### PR DESCRIPTION
Any closure not using `$this` can be made static, which AFAIK has performance benefits.