### PR TITLE
QA: minor whitespace fixes

### DIFF
--- a/src/Exception/Transport/Curl.php
+++ b/src/Exception/Transport/Curl.php
@@ -76,5 +76,4 @@ final class Curl extends Transport {
 	public function getReason() {
 		return $this->reason;
 	}
-
 }

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -341,6 +341,7 @@ class Requests {
 	public static function post($url, $headers = [], $data = [], $options = []) {
 		return self::request($url, $headers, $data, self::POST, $options);
 	}
+
 	/**
 	 * Send a PUT request
 	 */

--- a/tests/Fixtures/RawTransportMock.php
+++ b/tests/Fixtures/RawTransportMock.php
@@ -6,9 +6,11 @@ use WpOrg\Requests\Transport;
 
 final class RawTransportMock implements Transport {
 	public $data = '';
+
 	public function request($url, $headers = [], $data = [], $options = []) {
 		return $this->data;
 	}
+
 	public function request_multiple($requests, $options) {
 		foreach ($requests as $id => &$request) {
 			$handler       = new self();
@@ -18,6 +20,7 @@ final class RawTransportMock implements Transport {
 
 		return $requests;
 	}
+
 	public static function test($capabilities = []) {
 		return true;
 	}

--- a/tests/Fixtures/TestTransportMock.php
+++ b/tests/Fixtures/TestTransportMock.php
@@ -5,12 +5,15 @@ namespace WpOrg\Requests\Tests\Fixtures;
 use WpOrg\Requests\Transport;
 
 final class TestTransportMock implements Transport {
+
 	public function request($url, $headers = [], $data = [], $options = []) {
 		return '';
 	}
+
 	public function request_multiple($requests, $options) {
 		return [];
 	}
+
 	public static function test($capabilities = []) {
 		// Time travel is not yet supported by this transport.
 		if (isset($capabilities['time-travel']) && $capabilities['time-travel']) {

--- a/tests/HooksTest.php
+++ b/tests/HooksTest.php
@@ -120,7 +120,6 @@ class HooksTest extends TestCase {
 		$this->assertInstanceof(Closure::class, $hooks_prop['hookname'][0][0], 'Closure callback is not registered correctly');
 	}
 
-
 	/**
 	 * Verify that the return value of the dispatch method is false when no hooks are registered.
 	 *


### PR DESCRIPTION
Various minor whitespace fixes.
* One blank line between method declarations.
* No blank line at end of class.

