### PR TITLE
Docs: various improvements

### DIFF
--- a/build/ghpages/UpdateMarkdown.php
+++ b/build/ghpages/UpdateMarkdown.php
@@ -325,7 +325,7 @@ title: %s
 	 * @param string $contents File contents to write.
 	 * @param string $type     Type of file to use in error message.
 	 *
-	 * @return string
+	 * @return void
 	 *
 	 * @throws \RuntimeException When the target directory could not be created.
 	 * @throws \RuntimeException When the file could not be written to the target directory.

--- a/src/Capability.php
+++ b/src/Capability.php
@@ -28,7 +28,7 @@ interface Capability {
 	 *
 	 * Note: this does not automatically mean that the capability will be supported for your chosen transport!
 	 *
-	 * @var array<string>
+	 * @var string[]
 	 */
 	const ALL = [
 		self::SSL,

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -133,7 +133,7 @@ class Cookie {
 	 * Checks the age against $this->reference_time to determine if the cookie
 	 * is expired.
 	 *
-	 * @return boolean True if expired, false if time is valid.
+	 * @return bool True if expired, false if time is valid.
 	 */
 	public function is_expired() {
 		// RFC6265, s. 4.1.2.2:
@@ -157,7 +157,7 @@ class Cookie {
 	 * Check if a cookie is valid for a given URI
 	 *
 	 * @param \WpOrg\Requests\Iri $uri URI to check
-	 * @return boolean Whether the cookie is valid for the given URI
+	 * @return bool Whether the cookie is valid for the given URI
 	 */
 	public function uri_matches(Iri $uri) {
 		if (!$this->domain_matches($uri->host)) {
@@ -175,7 +175,7 @@ class Cookie {
 	 * Check if a cookie is valid for a given domain
 	 *
 	 * @param string $domain Domain to check
-	 * @return boolean Whether the cookie is valid for the given domain
+	 * @return bool Whether the cookie is valid for the given domain
 	 */
 	public function domain_matches($domain) {
 		if (is_string($domain) === false) {
@@ -228,7 +228,7 @@ class Cookie {
 	 * From the path-match check in RFC 6265 section 5.1.4
 	 *
 	 * @param string $request_path Path to check
-	 * @return boolean Whether the cookie is valid for the given path
+	 * @return bool Whether the cookie is valid for the given path
 	 */
 	public function path_matches($request_path) {
 		if (empty($request_path)) {
@@ -274,7 +274,7 @@ class Cookie {
 	/**
 	 * Normalize cookie and attributes
 	 *
-	 * @return boolean Whether the cookie was successfully normalized
+	 * @return bool Whether the cookie was successfully normalized
 	 */
 	public function normalize() {
 		foreach ($this->attributes as $key => $value) {
@@ -299,7 +299,7 @@ class Cookie {
 	 * Handles parsing individual attributes from the cookie values.
 	 *
 	 * @param string $name Attribute name
-	 * @param string|boolean $value Attribute value (string value, or true if empty/flag)
+	 * @param string|bool $value Attribute value (string value, or true if empty/flag)
 	 * @return mixed Value if available, or null if the attribute value is invalid (and should be skipped)
 	 */
 	protected function normalize_attribute($name, $value) {

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -299,7 +299,7 @@ class Cookie {
 	 * Handles parsing individual attributes from the cookie values.
 	 *
 	 * @param string $name Attribute name
-	 * @param string|bool $value Attribute value (string value, or true if empty/flag)
+	 * @param string|int|bool $value Attribute value (string/integer value, or true if empty/flag)
 	 * @return mixed Value if available, or null if the attribute value is invalid (and should be skipped)
 	 */
 	protected function normalize_attribute($name, $value) {

--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -64,7 +64,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	 * Check if the given item exists
 	 *
 	 * @param string $offset Item key
-	 * @return boolean Does the item exist?
+	 * @return bool Does the item exist?
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetExists($offset) {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -35,7 +35,7 @@ class Exception extends PHPException {
 	 * @param string $message Exception message
 	 * @param string $type Exception type
 	 * @param mixed $data Associated data
-	 * @param integer $code Exception numerical code, if applicable
+	 * @param int $code Exception numerical code, if applicable
 	 */
 	public function __construct($message, $type, $data = null, $code = 0) {
 		parent::__construct($message, $code);

--- a/src/Exception/Http.php
+++ b/src/Exception/Http.php
@@ -19,7 +19,7 @@ class Http extends Exception {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 0;
 

--- a/src/Exception/Http/Status304.php
+++ b/src/Exception/Http/Status304.php
@@ -18,7 +18,7 @@ final class Status304 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 304;
 

--- a/src/Exception/Http/Status305.php
+++ b/src/Exception/Http/Status305.php
@@ -18,7 +18,7 @@ final class Status305 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 305;
 

--- a/src/Exception/Http/Status306.php
+++ b/src/Exception/Http/Status306.php
@@ -18,7 +18,7 @@ final class Status306 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 306;
 

--- a/src/Exception/Http/Status400.php
+++ b/src/Exception/Http/Status400.php
@@ -18,7 +18,7 @@ final class Status400 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 400;
 

--- a/src/Exception/Http/Status401.php
+++ b/src/Exception/Http/Status401.php
@@ -18,7 +18,7 @@ final class Status401 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 401;
 

--- a/src/Exception/Http/Status402.php
+++ b/src/Exception/Http/Status402.php
@@ -18,7 +18,7 @@ final class Status402 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 402;
 

--- a/src/Exception/Http/Status403.php
+++ b/src/Exception/Http/Status403.php
@@ -18,7 +18,7 @@ final class Status403 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 403;
 

--- a/src/Exception/Http/Status404.php
+++ b/src/Exception/Http/Status404.php
@@ -18,7 +18,7 @@ final class Status404 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 404;
 

--- a/src/Exception/Http/Status405.php
+++ b/src/Exception/Http/Status405.php
@@ -18,7 +18,7 @@ final class Status405 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 405;
 

--- a/src/Exception/Http/Status406.php
+++ b/src/Exception/Http/Status406.php
@@ -18,7 +18,7 @@ final class Status406 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 406;
 

--- a/src/Exception/Http/Status407.php
+++ b/src/Exception/Http/Status407.php
@@ -18,7 +18,7 @@ final class Status407 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 407;
 

--- a/src/Exception/Http/Status408.php
+++ b/src/Exception/Http/Status408.php
@@ -18,7 +18,7 @@ final class Status408 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 408;
 

--- a/src/Exception/Http/Status409.php
+++ b/src/Exception/Http/Status409.php
@@ -18,7 +18,7 @@ final class Status409 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 409;
 

--- a/src/Exception/Http/Status410.php
+++ b/src/Exception/Http/Status410.php
@@ -18,7 +18,7 @@ final class Status410 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 410;
 

--- a/src/Exception/Http/Status411.php
+++ b/src/Exception/Http/Status411.php
@@ -18,7 +18,7 @@ final class Status411 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 411;
 

--- a/src/Exception/Http/Status412.php
+++ b/src/Exception/Http/Status412.php
@@ -18,7 +18,7 @@ final class Status412 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 412;
 

--- a/src/Exception/Http/Status413.php
+++ b/src/Exception/Http/Status413.php
@@ -18,7 +18,7 @@ final class Status413 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 413;
 

--- a/src/Exception/Http/Status414.php
+++ b/src/Exception/Http/Status414.php
@@ -18,7 +18,7 @@ final class Status414 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 414;
 

--- a/src/Exception/Http/Status415.php
+++ b/src/Exception/Http/Status415.php
@@ -18,7 +18,7 @@ final class Status415 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 415;
 

--- a/src/Exception/Http/Status416.php
+++ b/src/Exception/Http/Status416.php
@@ -18,7 +18,7 @@ final class Status416 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 416;
 

--- a/src/Exception/Http/Status417.php
+++ b/src/Exception/Http/Status417.php
@@ -18,7 +18,7 @@ final class Status417 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 417;
 

--- a/src/Exception/Http/Status418.php
+++ b/src/Exception/Http/Status418.php
@@ -22,7 +22,7 @@ final class Status418 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 418;
 

--- a/src/Exception/Http/Status428.php
+++ b/src/Exception/Http/Status428.php
@@ -22,7 +22,7 @@ final class Status428 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 428;
 

--- a/src/Exception/Http/Status429.php
+++ b/src/Exception/Http/Status429.php
@@ -22,7 +22,7 @@ final class Status429 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 429;
 

--- a/src/Exception/Http/Status431.php
+++ b/src/Exception/Http/Status431.php
@@ -22,7 +22,7 @@ final class Status431 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 431;
 

--- a/src/Exception/Http/Status500.php
+++ b/src/Exception/Http/Status500.php
@@ -18,7 +18,7 @@ final class Status500 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 500;
 

--- a/src/Exception/Http/Status501.php
+++ b/src/Exception/Http/Status501.php
@@ -18,7 +18,7 @@ final class Status501 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 501;
 

--- a/src/Exception/Http/Status502.php
+++ b/src/Exception/Http/Status502.php
@@ -18,7 +18,7 @@ final class Status502 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 502;
 

--- a/src/Exception/Http/Status503.php
+++ b/src/Exception/Http/Status503.php
@@ -18,7 +18,7 @@ final class Status503 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 503;
 

--- a/src/Exception/Http/Status504.php
+++ b/src/Exception/Http/Status504.php
@@ -18,7 +18,7 @@ final class Status504 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 504;
 

--- a/src/Exception/Http/Status505.php
+++ b/src/Exception/Http/Status505.php
@@ -18,7 +18,7 @@ final class Status505 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 505;
 

--- a/src/Exception/Http/Status511.php
+++ b/src/Exception/Http/Status511.php
@@ -22,7 +22,7 @@ final class Status511 extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = 511;
 

--- a/src/Exception/Http/StatusUnknown.php
+++ b/src/Exception/Http/StatusUnknown.php
@@ -19,7 +19,7 @@ final class StatusUnknown extends Http {
 	/**
 	 * HTTP status code
 	 *
-	 * @var integer|bool Code if available, false if an error occurred
+	 * @var int|bool Code if available, false if an error occurred
 	 */
 	protected $code = 0;
 

--- a/src/Exception/Transport/Curl.php
+++ b/src/Exception/Transport/Curl.php
@@ -23,7 +23,7 @@ final class Curl extends Transport {
 	/**
 	 * cURL error code
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	protected $code = -1;
 

--- a/src/HookManager.php
+++ b/src/HookManager.php
@@ -27,7 +27,7 @@ interface HookManager {
 	 *
 	 * @param string $hook Hook name
 	 * @param array $parameters Parameters to pass to callbacks
-	 * @return boolean Successfulness
+	 * @return bool Successfulness
 	 */
 	public function dispatch($hook, $parameters = []);
 }

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -63,7 +63,7 @@ class Hooks implements HookManager {
 	 *
 	 * @param string $hook Hook name
 	 * @param array $parameters Parameters to pass to callbacks
-	 * @return boolean Successfulness
+	 * @return bool Successfulness
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $hook argument is not a string.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $parameters argument is not an array.
 	 */

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -333,7 +333,8 @@ class IdnaEncoder {
 						$output .= self::digit_to_char($digit);
 						// let q = (q - t) div (base - t)
 						$q = floor(($q - $t) / (self::BOOTSTRAP_BASE - $t));
-					} // end
+					}
+
 					// output the code point for digit q
 					$output .= self::digit_to_char($q);
 					// let bias = adapt(delta, h + 1, test h equals b?)
@@ -342,12 +343,13 @@ class IdnaEncoder {
 					$delta = 0;
 					// increment h
 					$h++;
-				} // end
-			} // end
+				}
+			}
+
 			// increment delta and n
 			$delta++;
 			$n++;
-		} // end
+		}
 
 		return $output;
 	}
@@ -403,7 +405,8 @@ class IdnaEncoder {
 			$delta = floor($delta / (self::BOOTSTRAP_BASE - self::BOOTSTRAP_TMIN));
 			// let k = k + base
 			$k += self::BOOTSTRAP_BASE;
-		} // end
+		}
+
 		// return k + (((base - tmin + 1) * delta) div (delta + skew))
 		return $k + floor(((self::BOOTSTRAP_BASE - self::BOOTSTRAP_TMIN + 1) * $delta) / ($delta + self::BOOTSTRAP_SKEW));
 	}

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -381,7 +381,7 @@ class IdnaEncoder {
 	 * @param int $delta
 	 * @param int $numpoints
 	 * @param bool $firsttime
-	 * @return int New bias
+	 * @return int|float New bias
 	 *
 	 * function adapt(delta,numpoints,firsttime):
 	 */

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -54,7 +54,7 @@ class IdnaEncoder {
 	/**
 	 * Encode a hostname using Punycode
 	 *
-	 * @param string|Stringable $hostname Hostname
+	 * @param string|\Stringable $hostname Hostname
 	 * @return string Punycode-encoded hostname
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string or a stringable object.
 	 */

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -382,8 +382,6 @@ class IdnaEncoder {
 	 * @param int $numpoints
 	 * @param bool $firsttime
 	 * @return int|float New bias
-	 *
-	 * function adapt(delta,numpoints,firsttime):
 	 */
 	protected static function adapt($delta, $numpoints, $firsttime) {
 		// if firsttime then let delta = delta div damp

--- a/src/Ipv6.php
+++ b/src/Ipv6.php
@@ -35,7 +35,7 @@ final class Ipv6 {
 	 * @copyright 2003-2005 The PHP Group
 	 * @license https://opensource.org/licenses/bsd-license.php
 	 *
-	 * @param string|Stringable $ip An IPv6 address
+	 * @param string|\Stringable $ip An IPv6 address
 	 * @return string The uncompressed IPv6 address
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string or a stringable object.

--- a/src/Iri.php
+++ b/src/Iri.php
@@ -246,7 +246,7 @@ class Iri {
 	/**
 	 * Create a new IRI object, from a specified string
 	 *
-	 * @param string|Stringable|null $iri
+	 * @param string|\Stringable|null $iri
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $iri argument is not a string, Stringable or null.
 	 */

--- a/src/Proxy/Http.php
+++ b/src/Proxy/Http.php
@@ -48,7 +48,7 @@ final class Http implements Proxy {
 	/**
 	 * Do we need to authenticate? (ie username & password have been provided)
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	public $use_authentication;
 

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -642,12 +642,14 @@ class Requests {
 	/**
 	 * Set the default values
 	 *
+	 * The $options parameter is updated with the results.
+	 *
 	 * @param string $url URL to request
 	 * @param array $headers Extra headers to send with the request
 	 * @param array|null $data Data to send either as a query string for GET/HEAD requests, or in the body for POST requests
 	 * @param string $type HTTP request type
 	 * @param array $options Options for the request
-	 * @return void $options is updated with the results
+	 * @return void
 	 *
 	 * @throws \WpOrg\Requests\Exception When the $url is not an http(s) URL.
 	 */
@@ -824,9 +826,11 @@ class Requests {
 	 * Internal use only. Converts a raw HTTP response to a \WpOrg\Requests\Response
 	 * while still executing a multiple request.
 	 *
+	 * `$response` is either set to a \WpOrg\Requests\Response instance, or a \WpOrg\Requests\Exception object
+	 *
 	 * @param string $response Full response text including headers and body (will be overwritten with Response instance)
 	 * @param array $request Request data as passed into {@see \WpOrg\Requests\Requests::request_multiple()}
-	 * @return void `$response` is either set to a \WpOrg\Requests\Response instance, or a \WpOrg\Requests\Exception object
+	 * @return void
 	 */
 	public static function parse_multiple(&$response, $request) {
 		try {

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -95,7 +95,7 @@ class Requests {
 	/**
 	 * Default size of buffer size to read streams
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	const BUFFER_SIZE = 1160;
 
@@ -386,22 +386,22 @@ class Requests {
 	 * - `useragent`: Useragent to send to the server
 	 *    (string, default: php-requests/$version)
 	 * - `follow_redirects`: Should we follow 3xx redirects?
-	 *    (boolean, default: true)
+	 *    (bool, default: true)
 	 * - `redirects`: How many times should we redirect before erroring?
-	 *    (integer, default: 10)
+	 *    (int, default: 10)
 	 * - `blocking`: Should we block processing on this request?
-	 *    (boolean, default: true)
+	 *    (bool, default: true)
 	 * - `filename`: File to stream the body to instead.
-	 *    (string|boolean, default: false)
+	 *    (string|bool, default: false)
 	 * - `auth`: Authentication handler or array of user/password details to use
 	 *    for Basic authentication
-	 *    (\WpOrg\Requests\Auth|array|boolean, default: false)
+	 *    (\WpOrg\Requests\Auth|array|bool, default: false)
 	 * - `proxy`: Proxy details to use for proxy by-passing and authentication
-	 *    (\WpOrg\Requests\Proxy|array|string|boolean, default: false)
+	 *    (\WpOrg\Requests\Proxy|array|string|bool, default: false)
 	 * - `max_bytes`: Limit for the response body size.
-	 *    (integer|boolean, default: false)
+	 *    (int|bool, default: false)
 	 * - `idn`: Enable IDN parsing
-	 *    (boolean, default: true)
+	 *    (bool, default: true)
 	 * - `transport`: Custom transport. Either a class name, or a
 	 *    transport object. Defaults to the first working transport from
 	 *    {@see \WpOrg\Requests\Requests::getTransport()}
@@ -412,9 +412,9 @@ class Requests {
 	 *    certificate file as a string. (Using true uses the system-wide root
 	 *    certificate store instead, but this may have different behaviour
 	 *    across transports.)
-	 *    (string|boolean, default: certificates/cacert.pem)
+	 *    (string|bool, default: certificates/cacert.pem)
 	 * - `verifyname`: Should we verify the common name in the SSL certificate?
-	 *    (boolean, default: true)
+	 *    (bool, default: true)
 	 * - `data_format`: How should we send the `$data` parameter?
 	 *    (string, one of 'query' or 'body', default: 'query' for
 	 *    HEAD/GET/DELETE, 'body' for POST/PUT/OPTIONS/PATCH)
@@ -601,7 +601,7 @@ class Requests {
 	 * Get the default options
 	 *
 	 * @see \WpOrg\Requests\Requests::request() for values returned by this method
-	 * @param boolean $multirequest Is this a multirequest?
+	 * @param bool $multirequest Is this a multirequest?
 	 * @return array Default option values
 	 */
 	protected static function get_default_options($multirequest = false) {

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -419,7 +419,7 @@ class Requests {
 	 *    (string, one of 'query' or 'body', default: 'query' for
 	 *    HEAD/GET/DELETE, 'body' for POST/PUT/OPTIONS/PATCH)
 	 *
-	 * @param string|Stringable $url URL to request
+	 * @param string|\Stringable $url URL to request
 	 * @param array $headers Extra headers to send with the request
 	 * @param array|null $data Data to send either as a query string for GET/HEAD requests, or in the body for POST requests
 	 * @param string $type HTTP request type (use Requests constants)
@@ -627,7 +627,7 @@ class Requests {
 	/**
 	 * Set default certificate path.
 	 *
-	 * @param string|Stringable|bool $path Certificate path, pointing to a PEM file.
+	 * @param string|\Stringable|bool $path Certificate path, pointing to a PEM file.
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $url argument is not a string, Stringable or boolean.
 	 */

--- a/src/Response.php
+++ b/src/Response.php
@@ -137,16 +137,16 @@ class Response {
 	 *
 	 * @link https://php.net/json-decode
 	 *
-	 * @param ?bool $associative Optional. When `true`, JSON objects will be returned as associative arrays;
-	 *                           When `false`, JSON objects will be returned as objects.
-	 *                           When `null`, JSON objects will be returned as associative arrays
-	 *                           or objects depending on whether `JSON_OBJECT_AS_ARRAY` is set in the flags.
-	 *                           Defaults to `true` (in contrast to the PHP native default of `null`).
-	 * @param int   $depth       Optional. Maximum nesting depth of the structure being decoded.
-	 *                           Defaults to `512`.
-	 * @param int   $options     Optional. Bitmask of JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE,
-	 *                           JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR.
-	 *                           Defaults to `0` (no options set).
+	 * @param bool|null $associative Optional. When `true`, JSON objects will be returned as associative arrays;
+	 *                               When `false`, JSON objects will be returned as objects.
+	 *                               When `null`, JSON objects will be returned as associative arrays
+	 *                               or objects depending on whether `JSON_OBJECT_AS_ARRAY` is set in the flags.
+	 *                               Defaults to `true` (in contrast to the PHP native default of `null`).
+	 * @param int       $depth       Optional. Maximum nesting depth of the structure being decoded.
+	 *                               Defaults to `512`.
+	 * @param int       $options     Optional. Bitmask of JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE,
+	 *                               JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR.
+	 *                               Defaults to `0` (no options set).
 	 *
 	 * @return array
 	 *

--- a/src/Response.php
+++ b/src/Response.php
@@ -47,28 +47,28 @@ class Response {
 	/**
 	 * Status code, false if non-blocking
 	 *
-	 * @var integer|boolean
+	 * @var int|bool
 	 */
 	public $status_code = false;
 
 	/**
 	 * Protocol version, false if non-blocking
 	 *
-	 * @var float|boolean
+	 * @var float|bool
 	 */
 	public $protocol_version = false;
 
 	/**
 	 * Whether the request succeeded or not
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	public $success = false;
 
 	/**
 	 * Number of redirects the request used
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	public $redirects = 0;
 
@@ -104,7 +104,7 @@ class Response {
 	/**
 	 * Is the response a redirect?
 	 *
-	 * @return boolean True if redirect (3xx status), false if not.
+	 * @return bool True if redirect (3xx status), false if not.
 	 */
 	public function is_redirect() {
 		$code = $this->status_code;
@@ -114,7 +114,7 @@ class Response {
 	/**
 	 * Throws an exception if the request was not successful
 	 *
-	 * @param boolean $allow_redirects Set to false to throw on a 3xx as well
+	 * @param bool $allow_redirects Set to false to throw on a 3xx as well
 	 *
 	 * @throws \WpOrg\Requests\Exception If `$allow_redirects` is false, and code is 3xx (`response.no_redirects`)
 	 * @throws \WpOrg\Requests\Exception\Http On non-successful status code. Exception class corresponds to "Status" + code (e.g. {@see \WpOrg\Requests\Exception\Http\Status404})

--- a/src/Session.php
+++ b/src/Session.php
@@ -66,7 +66,7 @@ class Session {
 	/**
 	 * Create a new session
 	 *
-	 * @param string|Stringable|null $url Base URL for requests
+	 * @param string|\Stringable|null $url Base URL for requests
 	 * @param array $headers Default headers for requests
 	 * @param array $data Default data for requests
 	 * @param array $options Default options for requests

--- a/src/Session.php
+++ b/src/Session.php
@@ -269,7 +269,7 @@ class Session {
 	 * Merge a request's data with the default data
 	 *
 	 * @param array $request Request data (same form as {@see \WpOrg\Requests\Session::request_multiple()})
-	 * @param boolean $merge_options Should we merge options as well?
+	 * @param bool $merge_options Should we merge options as well?
 	 * @return array Request data
 	 */
 	protected function merge_request($request, $merge_options = true) {

--- a/src/Ssl.php
+++ b/src/Ssl.php
@@ -26,7 +26,7 @@ final class Ssl {
 	 *
 	 * @link https://tools.ietf.org/html/rfc2818#section-3.1 RFC2818, Section 3.1
 	 *
-	 * @param string|Stringable $host Host name to verify against
+	 * @param string|\Stringable $host Host name to verify against
 	 * @param array $cert Certificate data from openssl_x509_parse()
 	 * @return bool
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $host argument is not a string or a stringable object.
@@ -91,7 +91,7 @@ final class Ssl {
 	 * character to be the full first component; that is, with the exclusion of
 	 * the third rule.
 	 *
-	 * @param string|Stringable $reference Reference dNSName
+	 * @param string|\Stringable $reference Reference dNSName
 	 * @return boolean Is the name valid?
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string or a stringable object.
 	 */
@@ -144,8 +144,8 @@ final class Ssl {
 	/**
 	 * Match a hostname against a dNSName reference
 	 *
-	 * @param string|Stringable $host Requested host
-	 * @param string|Stringable $reference dNSName to match against
+	 * @param string|\Stringable $host Requested host
+	 * @param string|\Stringable $reference dNSName to match against
 	 * @return boolean Does the domain match?
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When either of the passed arguments is not a string or a stringable object.
 	 */

--- a/src/Ssl.php
+++ b/src/Ssl.php
@@ -92,7 +92,7 @@ final class Ssl {
 	 * the third rule.
 	 *
 	 * @param string|\Stringable $reference Reference dNSName
-	 * @return boolean Is the name valid?
+	 * @return bool Is the name valid?
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not a string or a stringable object.
 	 */
 	public static function verify_reference_name($reference) {
@@ -146,7 +146,7 @@ final class Ssl {
 	 *
 	 * @param string|\Stringable $host Requested host
 	 * @param string|\Stringable $reference dNSName to match against
-	 * @return boolean Does the domain match?
+	 * @return bool Does the domain match?
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When either of the passed arguments is not a string or a stringable object.
 	 */
 	public static function match_domain($host, $reference) {

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -71,7 +71,7 @@ final class Curl implements Transport {
 	/**
 	 * Have we finished the headers yet?
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	private $done_headers = false;
 
@@ -501,7 +501,7 @@ final class Curl implements Transport {
 	 *
 	 * @param resource|\CurlHandle $handle cURL handle
 	 * @param string $headers Header string
-	 * @return integer Length of provided header
+	 * @return int Length of provided header
 	 */
 	public function stream_headers($handle, $headers) {
 		// Why do we do this? cURL will send both the final response and any
@@ -528,7 +528,7 @@ final class Curl implements Transport {
 	 *
 	 * @param resource|\CurlHandle $handle cURL handle
 	 * @param string $data Body data
-	 * @return integer Length of provided data
+	 * @return int Length of provided data
 	 */
 	public function stream_body($handle, $data) {
 		$this->hooks->dispatch('request.progress', [$data, $this->response_bytes, $this->response_byte_limit]);

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -133,7 +133,7 @@ final class Curl implements Transport {
 	/**
 	 * Perform a request
 	 *
-	 * @param string|Stringable $url URL to request
+	 * @param string|\Stringable $url URL to request
 	 * @param array $headers Associative array of request headers
 	 * @param string|array $data Data to send either as the POST body, or as parameters in the URL for a GET/HEAD
 	 * @param array $options Request options, see {@see \WpOrg\Requests\Requests::response()} for documentation

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -26,7 +26,7 @@ final class Fsockopen implements Transport {
 	/**
 	 * Second to microsecond conversion
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	const SECOND_IN_MICROSECONDS = 1000000;
 

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -56,7 +56,7 @@ final class Fsockopen implements Transport {
 	/**
 	 * Perform a request
 	 *
-	 * @param string|Stringable $url URL to request
+	 * @param string|\Stringable $url URL to request
 	 * @param array $headers Associative array of request headers
 	 * @param string|array $data Data to send either as the POST body, or as parameters in the URL for a GET/HEAD
 	 * @param array $options Request options, see {@see \WpOrg\Requests\Requests::response()} for documentation

--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -41,7 +41,7 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	 * Check if the given item exists
 	 *
 	 * @param string $offset Item key
-	 * @return boolean Does the item exist?
+	 * @return bool Does the item exist?
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetExists($offset) {

--- a/src/Utility/FilteredIterator.php
+++ b/src/Utility/FilteredIterator.php
@@ -46,7 +46,7 @@ final class FilteredIterator extends ArrayIterator {
 	}
 
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 *
 	 * @phpcs:disable PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__unserializeFound
 	 */
@@ -75,7 +75,7 @@ final class FilteredIterator extends ArrayIterator {
 	}
 
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 */
 	#[ReturnTypeWillChange]
 	public function unserialize($data) {}

--- a/tests/HooksTest.php
+++ b/tests/HooksTest.php
@@ -18,7 +18,7 @@ class HooksTest extends TestCase {
 	/**
 	 * Object under test.
 	 *
-	 * @var \Requests\Hooks
+	 * @var \WpOrg\Requests\Hooks
 	 */
 	public $hooks;
 

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -85,8 +85,8 @@ final class HeadersTest extends TestCase {
 	 *
 	 * @dataProvider dataOffsetSetDoesNotTryToLowercaseNonStringKeys
 	 *
-	 * @param mixed      $key         Key to set.
-	 * @param string|int $request_key Key to retrieve if different.
+	 * @param mixed           $key         Key to set.
+	 * @param string|int|null $request_key Key to retrieve if different.
 	 *
 	 * @return void
 	 */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ abstract class TestCase extends Polyfill_TestCase {
 	/**
 	 * Data provider for use in tests which need to be run against all default supported transports.
 	 *
-	 * @var array
+	 * @return array
 	 */
 	public function transportProvider() {
 		$data = [];


### PR DESCRIPTION
### Docs: use FQNs in param types

As the `Stringable` class is not imported via a `use` statement, let's make it explicit that the global/PHP native class is intended.

### Docs: consistently use short form type keywords

### Docs: various fixes to param/return types

* `IdnaEncoder:adapt()`: as `floor()` is used in the `return` and `floor()` will return an integer compatible float, the `float` type should be included in the return type.
* `Cookie::normalize_attribute()`: the code within the function checks for various cases whether the value is an integer, so `int` appears to be a valid input type.
* `Capability`: improve format of type specification
* `Response::decode_body()`: a nullable type should indicated with `|null` in the docs.

### Docs: fix incorrect tagname

### Docs: fix incorrect tag case

### Docs: remove redundant comment

### Docs: remove redundant // end comments

### Docs: minor comment placement tweaks

A `void` return type should not have a description. Moving the description of what the function updates to the "long description" instead.