### PR TITLE
Refine docs for `curl.before_send`

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -72,7 +72,7 @@ Available Hooks
 
 * **`curl.before_send`**
 
-    Set cURL options just before the request is actually sent via `curl_exec()`.
+    Set cURL options before the request is actually sent via `curl_exec()`.
 
     Parameters: `cURL resource|CurlHandle &$handle`
 


### PR DESCRIPTION
Change "just before" to "before". It is more inline with the doc for
`fsockopen.before_send` and more correct.