### PR TITLE
Revert "Skip alternate port test while portquiz has issues"

### DIFF
--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -1076,8 +1076,6 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testAlternatePort() {
-		$this->markTestSkipped('The portquiz.net service is having technical issues.');
-
 		try {
 			$request = Requests::get('http://portquiz.net:8080/', [], $this->getOptions());
 		} catch (Exception $e) {


### PR DESCRIPTION
This reverts commit 75b1eb04728348d7dd81bd4a3a82cbc84f286fd5.

Looks like the portquiz server test is passing again, so let's re-enable the test!

Fixes #639