### PR TITLE
GH Actions: version update for various predefined actions (`gh-pages` branch)

### DIFF
--- a/.github/workflows/test-ghpages.yml
+++ b/.github/workflows/test-ghpages.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
A number of predefined actions have had major release, which warrant an update to the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 14 to Node 16).

Refs:
* https://github.com/actions/checkout/releases