### PR TITLE
Docs: various improvements [2]

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -36,8 +36,8 @@ class Cookie {
 	/**
 	 * Cookie attributes
 	 *
-	 * Valid keys are (currently) path, domain, expires, max-age, secure and
-	 * httponly.
+	 * Valid keys are `'path'`, `'domain'`, `'expires'`, `'max-age'`, `'secure'` and
+	 * `'httponly'`.
 	 *
 	 * @var \WpOrg\Requests\Utility\CaseInsensitiveDictionary|array Array-like object
 	 */
@@ -46,8 +46,7 @@ class Cookie {
 	/**
 	 * Cookie flags
 	 *
-	 * Valid keys are (currently) creation, last-access, persistent and
-	 * host-only.
+	 * Valid keys are `'creation'`, `'last-access'`, `'persistent'` and `'host-only'`.
 	 *
 	 * @var array
 	 */
@@ -70,8 +69,8 @@ class Cookie {
 	 * @param string                                                  $value          The value for the cookie.
 	 * @param array|\WpOrg\Requests\Utility\CaseInsensitiveDictionary $attributes Associative array of attribute data
 	 * @param array                                                   $flags          The flags for the cookie.
-	 *                                                                                Valid keys are (currently) creation,
-	 *                                                                                last-access, persistent and host-only.
+	 *                                                                                Valid keys are `'creation'`, `'last-access'`,
+	 *                                                                                `'persistent'` and `'host-only'`.
 	 * @param int|null                                                $reference_time Reference time for relative calculations.
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $name argument is not a string.

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -66,11 +66,13 @@ class Cookie {
 	/**
 	 * Create a new cookie object
 	 *
-	 * @param string $name
-	 * @param string $value
+	 * @param string                                                  $name           The name of the cookie.
+	 * @param string                                                  $value          The value for the cookie.
 	 * @param array|\WpOrg\Requests\Utility\CaseInsensitiveDictionary $attributes Associative array of attribute data
-	 * @param array $flags
-	 * @param int|null $reference_time
+	 * @param array                                                   $flags          The flags for the cookie.
+	 *                                                                                Valid keys are (currently) creation,
+	 *                                                                                last-access, persistent and host-only.
+	 * @param int|null                                                $reference_time Reference time for relative calculations.
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $name argument is not a string.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $value argument is not a string.

--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -50,6 +50,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	 * Normalise cookie data into a \WpOrg\Requests\Cookie
 	 *
 	 * @param string|\WpOrg\Requests\Cookie $cookie
+	 * @param string                        $key    Optional. The name for this cookie.
 	 * @return \WpOrg\Requests\Cookie
 	 */
 	public function normalize_cookie($cookie, $key = '') {

--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -49,7 +49,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Normalise cookie data into a \WpOrg\Requests\Cookie
 	 *
-	 * @param string|\WpOrg\Requests\Cookie $cookie
+	 * @param string|\WpOrg\Requests\Cookie $cookie Cookie header value, possibly pre-parsed (object).
 	 * @param string                        $key    Optional. The name for this cookie.
 	 * @return \WpOrg\Requests\Cookie
 	 */
@@ -107,7 +107,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Unset the given header
 	 *
-	 * @param string $offset
+	 * @param string $offset The key for the item to unset.
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetUnset($offset) {
@@ -172,7 +172,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Parse all cookies from a response and attach them to the response
 	 *
-	 * @param \WpOrg\Requests\Response $response
+	 * @param \WpOrg\Requests\Response $response Response as received.
 	 */
 	public function before_redirect_check(Response $response) {
 		$url = $response->url;

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -137,7 +137,7 @@ class IdnaEncoder {
 	 *
 	 * @internal (Testing found regex was the fastest implementation)
 	 *
-	 * @param string $text
+	 * @param string $text Text to examine.
 	 * @return bool Is the text string ASCII-only?
 	 */
 	protected static function is_ascii($text) {
@@ -148,7 +148,7 @@ class IdnaEncoder {
 	 * Prepare a text string for use as an IDNA name
 	 *
 	 * @todo Implement this based on RFC 3491 and the newer 5891
-	 * @param string $text
+	 * @param string $text Text to prepare.
 	 * @return string Prepared string
 	 */
 	protected static function nameprep($text) {
@@ -160,7 +160,7 @@ class IdnaEncoder {
 	 *
 	 * Based on \WpOrg\Requests\Iri::replace_invalid_with_pct_encoding()
 	 *
-	 * @param string $input
+	 * @param string $input Text to convert.
 	 * @return array Unicode code points
 	 *
 	 * @throws \WpOrg\Requests\Exception Invalid UTF-8 codepoint (`idna.invalidcodepoint`)

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -27,7 +27,7 @@ class Headers extends CaseInsensitiveDictionary {
 	 * Avoid using this where commas may be used unquoted in values, such as
 	 * Set-Cookie headers.
 	 *
-	 * @param string $offset
+	 * @param string $offset Name of the header to retrieve.
 	 * @return string|null Header value
 	 */
 	public function offsetGet($offset) {
@@ -69,7 +69,7 @@ class Headers extends CaseInsensitiveDictionary {
 	/**
 	 * Get all values for a given header
 	 *
-	 * @param string $offset
+	 * @param string $offset Name of the header to retrieve.
 	 * @return array|null Header values
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not valid as an array key.

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -467,7 +467,7 @@ final class Curl implements Transport {
 	 * @param string $response Response data from the body
 	 * @param array $options Request options
 	 * @return string|false HTTP response data including headers. False if non-blocking.
-	 * @throws \WpOrg\Requests\Exception
+	 * @throws \WpOrg\Requests\Exception If the request resulted in a cURL error.
 	 */
 	public function process_response($response, $options) {
 		if ($options['blocking'] === false) {

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -564,7 +564,7 @@ final class Curl implements Transport {
 	/**
 	 * Format a URL given GET data
 	 *
-	 * @param string $url
+	 * @param string       $url  Original URL.
 	 * @param array|object $data Data to build query using, see {@link https://www.php.net/http_build_query}
 	 * @return string URL with data
 	 */

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -406,7 +406,7 @@ final class Fsockopen implements Transport {
 	/**
 	 * Format a URL given GET data
 	 *
-	 * @param array $url_parts
+	 * @param array        $url_parts Array of URL parts as received from {@link https://www.php.net/parse_url}
 	 * @param array|object $data Data to build query using, see {@link https://www.php.net/http_build_query}
 	 * @return string URL with data
 	 */

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -51,6 +51,11 @@ final class Fsockopen implements Transport {
 	 */
 	private $max_bytes = false;
 
+	/**
+	 * Cache for received connection errors.
+	 *
+	 * @var string
+	 */
 	private $connect_error = '';
 
 	/**

--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -95,7 +95,7 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Unset the given header
 	 *
-	 * @param string $offset
+	 * @param string $offset The key for the item to unset.
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetUnset($offset) {

--- a/src/Utility/FilteredIterator.php
+++ b/src/Utility/FilteredIterator.php
@@ -46,14 +46,25 @@ final class FilteredIterator extends ArrayIterator {
 	}
 
 	/**
-	 * @inheritDoc
+	 * Prevent unserialization of the object for security reasons.
 	 *
 	 * @phpcs:disable PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__unserializeFound
+	 *
+	 * @param array $data Restored array of data originally serialized.
+	 *
+	 * @return void
 	 */
 	#[ReturnTypeWillChange]
 	public function __unserialize($data) {}
 	// phpcs:enable
 
+	/**
+	 * Perform reinitialization tasks.
+	 *
+	 * Prevents a callback from being injected during unserialization of an object.
+	 *
+	 * @return void
+	 */
 	public function __wakeup() {
 		unset($this->callback);
 	}
@@ -75,7 +86,11 @@ final class FilteredIterator extends ArrayIterator {
 	}
 
 	/**
-	 * @inheritDoc
+	 * Prevent creating a PHP value from a stored representation of the object for security reasons.
+	 *
+	 * @param string $data The serialized string.
+	 *
+	 * @return void
 	 */
 	#[ReturnTypeWillChange]
 	public function unserialize($data) {}

--- a/src/Utility/FilteredIterator.php
+++ b/src/Utility/FilteredIterator.php
@@ -28,7 +28,7 @@ final class FilteredIterator extends ArrayIterator {
 	/**
 	 * Create a new iterator
 	 *
-	 * @param array $data
+	 * @param array    $data     The array or object to be iterated on.
 	 * @param callable $callback Callback to be called on each value
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $data argument is not iterable.

--- a/tests/Requests/ChunkedEncodingTest.php
+++ b/tests/Requests/ChunkedEncodingTest.php
@@ -17,7 +17,8 @@ final class ChunkedDecodingTest extends TestCase {
 	 *
 	 * @dataProvider dataChunked
 	 *
-	 * @param string $body Not really chunked response body.
+	 * @param string $body     Not really chunked response body.
+	 * @param string $expected Expected chunked data.
 	 *
 	 * @return void
 	 */

--- a/tests/SslTest.php
+++ b/tests/SslTest.php
@@ -245,6 +245,12 @@ final class SslTest extends TestCase {
 	/**
 	 * Test helper to mock a certificate.
 	 *
+	 * @param string      $dnsname  DNS name to match against.
+	 * @param bool|string $with_san Optional. How to generate the fake certificate.
+	 *                              - false:  plain, CN only;
+	 *                              - true:   CN + subjectAltName, alt set to same as CN;
+	 *                              - string: CN + subjectAltName, alt set to string value.
+	 *
 	 * @return array
 	 */
 	private function fakeCertificate($dnsname, $with_san = true) {


### PR DESCRIPTION
Next PR in a series of documentation style & completeness improvements started with #685

By no means claiming completeness, but this is at least another step forward.

* Add missing parameter tags
* Add missing param comments
* Add missing property docblock
* Add missing `@throws` comment
* Add missing function docblocks
    Notably, remove a couple of `@inheritDoc`s for methods where the PHP native methods which are being overloaded don't have a notable docblock, so there is nothing to inherit.