### PR TITLE
GH Actions: version update for various action runners

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set coverage variable
         id: set_cov

--- a/.github/workflows/update-cacert.yml
+++ b/.github/workflows/update-cacert.yml
@@ -48,10 +48,10 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Restore etags cache for certificate files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: certificates/etag-*.txt
           key: curl-etag-${{ hashFiles('certificates/cacert.pem') }}-${{ hashFiles('certificates/cacert.pem.sha256') }}

--- a/.github/workflows/update-cacert.yml
+++ b/.github/workflows/update-cacert.yml
@@ -79,7 +79,7 @@ jobs:
         run: echo "::set-output name=DATE::$(/bin/date -u "+%F")"
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           base: ${{ steps.branches.outputs.BASE }}
           branch: "feature/auto-update-cacert"

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -159,7 +159,7 @@ jobs:
         run: git status -vv --untracked=all
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           base: gh-pages
           branch: feature/auto-ghpages-update-${{ steps.get_pr_info.outputs.REF }}


### PR DESCRIPTION
### GH Actions: version update for actions/cache

The update doesn't actually contain any changed functionality, it's mostly just a change of the Node version used by the action itself (from Node 12 to Node 16).

Also saw that I missed updating the `actions/checkout` for this new workflow and in some other places. Ref: #691

Refs:
* https://github.com/actions/cache/releases/

### 🆕 GH Actions: version update for peter-evans/create-pull-request

The update contain minimal changed functionality, it's mostly just a change of the Node version used by the action itself (from Node 12 to Node 16).

There is one breaking change regarding the `add-paths` key, but as that's not used in our workflows this doesn't affect us.

Refs:
* https://github.com/peter-evans/create-pull-request/releases/