### PR TITLE
GH Actions/certificate update workflow: various tweaks

### DIFF
--- a/.github/workflows/update-cacert.yml
+++ b/.github/workflows/update-cacert.yml
@@ -37,14 +37,21 @@ jobs:
         id: branches
         env:
           HEAD_REF: ${{ github.head_ref }}
+          PR_NUM: ${{ github.event.pull_request.number }}
         run: |
           if [[ "${{ github.event_name }}" == 'schedule' ]]; then
             echo "::set-output name=BASE::develop"
+            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert"
           elif [[ "${{ github.event_name }}" == 'push' ]]; then
-            # Pull requests should always go to develop, even when triggered via stable.
+            # Pull requests should always go to develop, even when triggered via a push to stable.
             echo "::set-output name=BASE::develop"
-          else # = PR or manual run.
+            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert"
+          elif [[ $PR_NUM != '' ]]; then # = PR or manual (re-)run for a workflow triggered by a PR.
             echo "::set-output name=BASE::$HEAD_REF"
+            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert-$PR_NUM"
+          else # = manual run.
+            echo "::set-output name=BASE::$HEAD_REF"
+            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert-misc"
           fi
 
       - name: Checkout code
@@ -82,12 +89,12 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           base: ${{ steps.branches.outputs.BASE }}
-          branch: "feature/auto-update-cacert"
+          branch: ${{ steps.branches.outputs.PR_BRANCH }}
           delete-branch: true
           commit-message: ":lock_with_ink_pen: Update certificate bundle"
           title: ":lock_with_ink_pen: Update certificate bundle"
           body: |
-            Updated certificate bundle as of ${{ steps.get-date.outputs.DATE }}.
+            Updated certificate bundle, last verified on ${{ steps.get-date.outputs.DATE }}.
 
             Source: https://curl.se/docs/caextract.html
 


### PR DESCRIPTION
1. Create a branch with a different, unique name when the workflow is triggered via a PR to prevent a potentially already open certificate update PR (created by the cron job) from rebasing onto the PR branch.
    - When this workflow is triggered via the cron job and/or pushes to `develop`/`stable`, the branch name will be `feature/auto-update-cacert` and the branch will automatically be updated every night until the PR has been merged.
    - When this workflow is triggered via a PR which updates either the workflow or the certificate files, the branch name will be `feature/auto-update-cacert-###` where `###` is the number of the PR which triggered the workflow.
        This branch will be updated whenever the original PR which triggered the workflow run gets updated.
    - When the workflow is triggered via a manual request, the branch name will be `feature/auto-update-cacert-misc`. This should rarely happen, but is still a case which needs to be accounted for.
2. As the `create-pull-request` action runner will update the PR description of a cron job generated PR every night, the date displayed in the description is in reality the date when the certificate bundle was last checked, not the date when the certificate bundle was last changed.
    This minor textual change to the PR `body` should make that clearer.

Fingers crossed I'm using the right GH event reference, but no doubt, we'll see that soon enough once a new certificate has been published.