### PR TITLE
GH Actions: show deprecations when linting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
   },
   "scripts": {
     "lint": [
-      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . --show-deprecated -e php --exclude vendor --exclude .git"
     ],
     "checkcs": [
       "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"


### PR DESCRIPTION
While rare, there are some deprecations which PHP can show when a file is being linted.
By default these are ignored by PHP-Parallel-Lint.

Apparently though, there is an option to show them (wasn't documented until recently), so let's turn that option on.