### PR TITLE
Tests: expand type verification tests

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -237,4 +237,9 @@
 		<exclude-pattern>/tests/*\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Method declarations in test classes can use camelCase for compatibility with PHPUnit and consistency. -->
+	<rule ref="WordPress.NamingConventions.ValidFunctionName">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/tests/Auth/Basic/BasicTest.php
+++ b/tests/Auth/Basic/BasicTest.php
@@ -8,6 +8,7 @@ use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * @covers \WpOrg\Requests\Auth\Basic
@@ -237,10 +238,7 @@ final class BasicTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidInputType() {
-		return [
-			'boolean false'         => [false],
-			'authentication string' => ['user:psw'],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_ARRAY);
 	}
 
 	/**

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -2,16 +2,13 @@
 
 namespace WpOrg\Requests\Tests\Cookie;
 
-use DateTime;
-use EmptyIterator;
 use WpOrg\Requests\Cookie;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response\Headers;
-use WpOrg\Requests\Tests\Fixtures\ArrayAccessibleObject;
-use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 
 final class CookieTest extends TestCase {
@@ -639,11 +636,7 @@ final class CookieTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidStringInput() {
-		return [
-			'null'              => [null],
-			'float'             => [1.1],
-			'stringable object' => [new StringableObject('name')],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
 	/**
@@ -670,12 +663,8 @@ final class CookieTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidAttributes() {
-		return [
-			'null'                                 => [null],
-			'text string'                          => ['array'],
-			'iterator object without array access' => [new EmptyIterator()],
-			'array accessible object not iterable' => [new ArrayAccessibleObject([1, 2, 3])],
-		];
+		$except = array_intersect(TypeProviderHelper::GROUP_ITERABLE, TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
+		return TypeProviderHelper::getAllExcept($except);
 	}
 
 	/**
@@ -702,11 +691,7 @@ final class CookieTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidFlags() {
-		return [
-			'null'                    => [null],
-			'integer'                 => [101],
-			'array accessible object' => [new ArrayAccessibleObject([])],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 
 	/**
@@ -733,11 +718,7 @@ final class CookieTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidReferenceTime() {
-		return [
-			'float'           => [1.1],
-			'string'          => ['now'],
-			'DateTime object' => [new DateTime('now')],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_INT);
 	}
 
 	/**

--- a/tests/Cookie/Jar/JarTest.php
+++ b/tests/Cookie/Jar/JarTest.php
@@ -8,6 +8,7 @@ use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * @covers \WpOrg\Requests\Cookie\Jar
@@ -111,12 +112,25 @@ final class JarTest extends TestCase {
 	/**
 	 * Tests receiving an exception when an invalid input type is passed to the class constructor.
 	 *
+	 * @dataProvider dataConstructorInvalidInputType
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
 	 * @return void
 	 */
-	public function testConstructorInvalidInputType() {
+	public function testConstructorInvalidInputType($input) {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #1 ($cookies) must be of type array');
 
-		new Jar('string');
+		new Jar($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataConstructorInvalidInputType() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 }

--- a/tests/Hooks/HooksTest.php
+++ b/tests/Hooks/HooksTest.php
@@ -6,9 +6,8 @@ use Closure;
 use stdClass;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Hooks;
-use WpOrg\Requests\Tests\Fixtures\ArrayAccessibleObject;
-use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * @coversDefaultClass \WpOrg\Requests\Hooks
@@ -349,11 +348,7 @@ class HooksTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidHookname() {
-		return [
-			'null'              => [null],
-			'float'             => [1.1],
-			'stringable object' => [new StringableObject('value')],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
 	/**
@@ -413,11 +408,7 @@ class HooksTest extends TestCase {
 	 * @return array
 	 */
 	public function dataRegisterInvalidPriority() {
-		return [
-			'null'             => [null],
-			'float'            => [1.1],
-			'string "123 abc"' => ['123 abc'],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, ['numeric string']);
 	}
 
 	/**
@@ -444,13 +435,7 @@ class HooksTest extends TestCase {
 	 * @return array
 	 */
 	public function dataDispatchInvalidParameters() {
-		return [
-			'null'                            => [null],
-			'bool false'                      => [false],
-			'float'                           => [1.1],
-			'string'                          => ['param'],
-			'object implementing ArrayAccess' => [new ArrayAccessibleObject()],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 
 	/**

--- a/tests/IdnaEncoder/IdnaEncoderTest.php
+++ b/tests/IdnaEncoder/IdnaEncoderTest.php
@@ -7,6 +7,7 @@ use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\IdnaEncoder;
 use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * @covers \WpOrg\Requests\IdnaEncoder
@@ -205,12 +206,7 @@ final class IdnaEncoderTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidInputType() {
-		return [
-			'null'          => [null],
-			'boolean false' => [false],
-			'integer'       => [12345],
-			'array'         => [[1, 2, 3]],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
 	public function testASCIITooLong() {

--- a/tests/Ipv6/Ipv6Test.php
+++ b/tests/Ipv6/Ipv6Test.php
@@ -6,6 +6,7 @@ use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Ipv6;
 use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * Test for the Ipv6 class.
@@ -128,11 +129,6 @@ final class Ipv6Test extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidInputType() {
-		return [
-			'null'          => [null],
-			'boolean false' => [false],
-			'integer'       => [12345],
-			'array'         => [[1, 2, 3]],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 }

--- a/tests/Iri/IriTest.php
+++ b/tests/Iri/IriTest.php
@@ -42,11 +42,11 @@
 
 namespace WpOrg\Requests\Tests\Iri;
 
-use stdClass;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 final class IriTest extends TestCase
 {
@@ -452,10 +452,6 @@ final class IriTest extends TestCase
 	 * @return array
 	 */
 	public function dataConstructorInvalidInput() {
-		return array(
-			'boolean false'         => array(false),
-			'float'                 => array(1.1),
-			'non-stringable object' => array(new stdClass('value')),
-		);
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_STRINGABLE);
 	}
 }

--- a/tests/Port/PortTest.php
+++ b/tests/Port/PortTest.php
@@ -6,6 +6,7 @@ use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Port;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * @covers \WpOrg\Requests\Port::get
@@ -70,10 +71,7 @@ final class PortTest extends TestCase {
 	 * @return array
 	 */
 	public function dataGetPortThrowsExceptionOnInvalidInputType() {
-		return [
-			'null'                => [null],
-			'integer port number' => [443],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
 	/**

--- a/tests/Proxy/Http/HttpTest.php
+++ b/tests/Proxy/Http/HttpTest.php
@@ -9,6 +9,7 @@ use WpOrg\Requests\Proxy\Http;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 use WpOrg\Requests\Transport\Fsockopen;
 
 final class HttpTest extends TestCase {
@@ -185,11 +186,30 @@ final class HttpTest extends TestCase {
 	 * Tests receiving an exception when an invalid input type is passed to the Proxy\Http constructor.
 	 *
 	 * @covers \WpOrg\Requests\Proxy\Http::__construct
+	 *
+	 * @dataProvider dataConstructorInvalidParameterType
+	 *
+	 * @param mixed $input Input to pass to the function.
+	 *
+	 * @return void
 	 */
-	public function testConstructorInvalidParameterType() {
+	public function testConstructorInvalidParameterType($input) {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #1 ($args) must be of type array|string|null');
 
-		new Http(false);
+		new Http($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataConstructorInvalidParameterType() {
+		return TypeProviderHelper::getAllExcept(
+			TypeProviderHelper::GROUP_NULL,
+			TypeProviderHelper::GROUP_STRING,
+			TypeProviderHelper::GROUP_ARRAY
+		);
 	}
 }

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -4,8 +4,8 @@ namespace WpOrg\Requests\Tests\Requests;
 
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Requests;
-use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 final class DecompressionTest extends TestCase {
 
@@ -233,9 +233,6 @@ final class DecompressionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidInputType() {
-		return [
-			'null'              => [null],
-			'stringable object' => [new StringableObject('value')],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 }

--- a/tests/Requests/RequestsTest.php
+++ b/tests/Requests/RequestsTest.php
@@ -3,21 +3,19 @@
 namespace WpOrg\Requests\Tests\Requests;
 
 use ArrayIterator;
-use EmptyIterator;
 use ReflectionProperty;
-use stdClass;
 use WpOrg\Requests\Capability;
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response\Headers;
-use WpOrg\Requests\Tests\Fixtures\ArrayAccessibleObject;
 use WpOrg\Requests\Tests\Fixtures\RawTransportMock;
 use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\Fixtures\TestTransportMock;
 use WpOrg\Requests\Tests\Fixtures\TransportMock;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 final class RequestsTest extends TestCase {
 
@@ -45,11 +43,7 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataRequestInvalidUrl() {
-		return [
-			'null'                  => [null],
-			'array'                 => [[httpbin('/')]],
-			'non-stringable object' => [new stdClass('name')],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
 	/**
@@ -76,10 +70,7 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidTypeNotString() {
-		return [
-			'null'              => [null],
-			'stringable object' => [new StringableObject('type')],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
 	/**
@@ -124,12 +115,8 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataRequestMultipleInvalidRequests() {
-		return [
-			'null'                                 => [null],
-			'text string'                          => ['array'],
-			'iterator object without array access' => [new EmptyIterator()],
-			'array accessible object not iterable' => [new ArrayAccessibleObject([1, 2, 3])],
-		];
+		$except = array_intersect(TypeProviderHelper::GROUP_ITERABLE, TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
+		return TypeProviderHelper::getAllExcept($except);
 	}
 
 	/**
@@ -156,10 +143,7 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidTypeNotArray() {
-		return [
-			'null'                    => [null],
-			'array accessible object' => [new ArrayAccessibleObject([])],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 
 	public function testInvalidProtocol() {
@@ -403,10 +387,7 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataSetCertificatePathInvalidData() {
-		return [
-			'null'                  => [null],
-			'non-stringable object' => [new stdClass('value')],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_BOOL, TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
 	/**
@@ -467,9 +448,6 @@ final class RequestsTest extends TestCase {
 	 * @return array
 	 */
 	public function dataFlattenInvalidData() {
-		return [
-			'null'                                 => [null],
-			'array accessible object not iterable' => [new ArrayAccessibleObject([1, 2, 3])],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ITERABLE);
 	}
 }

--- a/tests/Response/Headers/HeadersTest.php
+++ b/tests/Response/Headers/HeadersTest.php
@@ -2,11 +2,11 @@
 
 namespace WpOrg\Requests\Tests\Response\Headers;
 
-use stdClass;
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Response\Headers;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * @coversDefaultClass \WpOrg\Requests\Response\Headers
@@ -245,10 +245,7 @@ final class HeadersTest extends TestCase {
 	 * @return array
 	 */
 	public function dataGetValuesInvalidOffset() {
-		return [
-			'null'          => [null],
-			'boolean false' => [false],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING, TypeProviderHelper::GROUP_INT);
 	}
 
 	/**
@@ -342,10 +339,6 @@ final class HeadersTest extends TestCase {
 	 * @return array
 	 */
 	public function dataFlattenInvalidValue() {
-		return [
-			'null'          => [null],
-			'boolean false' => [false],
-			'plain object'  => [new stdClass()],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING, TypeProviderHelper::GROUP_ARRAY);
 	}
 }

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -2,14 +2,12 @@
 
 namespace WpOrg\Requests\Tests\Session;
 
-use EmptyIterator;
-use stdClass;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Session;
-use WpOrg\Requests\Tests\Fixtures\ArrayAccessibleObject;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 final class SessionTest extends TestCase {
 	public function testURLResolution() {
@@ -282,11 +280,7 @@ final class SessionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidUrl() {
-		return [
-			'boolean false'         => [false],
-			'array'                 => [[httpbin('/')]],
-			'non-stringable object' => [new stdClass('name')],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
 	/**
@@ -368,12 +362,8 @@ final class SessionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataRequestMultipleInvalidRequests() {
-		return [
-			'null'                                 => [null],
-			'text string'                          => ['array'],
-			'iterator object without array access' => [new EmptyIterator()],
-			'array accessible object not iterable' => [new ArrayAccessibleObject([1, 2, 3])],
-		];
+		$except = array_intersect(TypeProviderHelper::GROUP_ITERABLE, TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
+		return TypeProviderHelper::getAllExcept($except);
 	}
 
 	/**
@@ -401,10 +391,6 @@ final class SessionTest extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidTypeNotArray() {
-		return [
-			'null'                    => [null],
-			'boolean false'           => [false],
-			'array accessible object' => [new ArrayAccessibleObject([])],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 }

--- a/tests/Ssl/SslTest.php
+++ b/tests/Ssl/SslTest.php
@@ -2,11 +2,11 @@
 
 namespace WpOrg\Requests\Tests\Ssl;
 
-use stdClass;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Ssl;
 use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * @coversDefaultClass \WpOrg\Requests\Ssl
@@ -500,7 +500,7 @@ final class SslTest extends TestCase {
 	/**
 	 * Tests receiving an exception when an invalid input type is passed as $host.
 	 *
-	 * @dataProvider dataInvalidInputType
+	 * @dataProvider dataInvalidInputTypeStringable
 	 *
 	 * @covers ::verify_certificate
 	 *
@@ -518,7 +518,7 @@ final class SslTest extends TestCase {
 	/**
 	 * Tests receiving an exception when an invalid input type is passed as $cert.
 	 *
-	 * @dataProvider dataInvalidInputType
+	 * @dataProvider dataInvalidInputTypeArrayAccess
 	 *
 	 * @covers ::verify_certificate
 	 *
@@ -534,9 +534,18 @@ final class SslTest extends TestCase {
 	}
 
 	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputTypeArrayAccess() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
+	}
+
+	/**
 	 * Tests receiving an exception when an invalid input type is passed.
 	 *
-	 * @dataProvider dataInvalidInputType
+	 * @dataProvider dataInvalidInputTypeStringable
 	 *
 	 * @covers ::verify_reference_name
 	 *
@@ -554,7 +563,7 @@ final class SslTest extends TestCase {
 	/**
 	 * Tests receiving an exception when an invalid input type is passed.
 	 *
-	 * @dataProvider dataInvalidInputType
+	 * @dataProvider dataInvalidInputTypeStringable
 	 *
 	 * @covers ::match_domain
 	 *
@@ -562,7 +571,7 @@ final class SslTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function testInvalidInputType($input) {
+	public function testMatchDomainInvalidInputType($input) {
 		$this->expectException(InvalidArgument::class);
 		$this->expectExceptionMessage('Argument #1 ($host) must be of type string|Stringable');
 
@@ -574,10 +583,7 @@ final class SslTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputType() {
-		return [
-			'null'         => [null],
-			'plain object' => [new stdClass()],
-		];
+	public function dataInvalidInputTypeStringable() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,9 +3,20 @@
 namespace WpOrg\Requests\Tests;
 
 use WpOrg\Requests\Requests;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase as Polyfill_TestCase;
 
 abstract class TestCase extends Polyfill_TestCase {
+
+	/**
+	 * Clean up after the tests.
+	 *
+	 * As most test classes will use the TypeProviderHelper for one or more tests,
+	 * we may as well always call the clean up function just to be on the safe side.
+	 */
+	public static function tear_down_after_test() {
+		TypeProviderHelper::cleanUp();
+	}
 
 	/**
 	 * Data provider for use in tests which need to be run against all default supported transports.

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -2,7 +2,6 @@
 
 namespace WpOrg\Requests\Tests\Transport;
 
-use EmptyIterator;
 use stdClass;
 use WpOrg\Requests\Capability;
 use WpOrg\Requests\Exception;
@@ -12,9 +11,9 @@ use WpOrg\Requests\Hooks;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
-use WpOrg\Requests\Tests\Fixtures\ArrayAccessibleObject;
 use WpOrg\Requests\Tests\Fixtures\TransportMock;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 
 abstract class BaseTestCase extends TestCase {
 
@@ -213,11 +212,7 @@ abstract class BaseTestCase extends TestCase {
 	 * @return array
 	 */
 	public function dataRequestInvalidUrl() {
-		return [
-			'boolean false'         => [false],
-			'array'                 => [[httpbin('/')]],
-			'non-stringable object' => [new stdClass('name')],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
 	/**
@@ -306,12 +301,11 @@ abstract class BaseTestCase extends TestCase {
 	 * @return array
 	 */
 	public function dataIncorrectDataTypeException() {
-		return [
-			'boolean' => [true],
-			'integer' => [12345, '12345'],
-			'float'   => [12.345, '12.345'],
-			'object'  => [new stdClass()],
-		];
+		return TypeProviderHelper::getAllExcept(
+			TypeProviderHelper::GROUP_NULL,
+			TypeProviderHelper::GROUP_STRING,
+			TypeProviderHelper::GROUP_ARRAY
+		);
 	}
 
 	/**
@@ -357,10 +351,7 @@ abstract class BaseTestCase extends TestCase {
 	 * @return array
 	 */
 	public function dataRequestMultipleReturnsEmptyArrayWhenRequestsIsEmpty() {
-		return [
-			'null'        => [null],
-			'empty array' => [[]],
-		];
+		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_EMPTY);
 	}
 
 	/**
@@ -389,11 +380,8 @@ abstract class BaseTestCase extends TestCase {
 	 * @return array
 	 */
 	public function dataRequestMultipleInvalidRequests() {
-		return [
-			'text string'                          => ['array'],
-			'iterator object without array access' => [new EmptyIterator()],
-			'array accessible object not iterable' => [new ArrayAccessibleObject([1, 2, 3])],
-		];
+		$except = array_intersect(TypeProviderHelper::GROUP_ITERABLE, TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
+		return TypeProviderHelper::getAllExcept($except, TypeProviderHelper::GROUP_EMPTY);
 	}
 
 	/**
@@ -422,11 +410,7 @@ abstract class BaseTestCase extends TestCase {
 	 * @return array
 	 */
 	public function dataInvalidTypeNotArray() {
-		return [
-			'null'                    => [null],
-			'boolean false'           => [false],
-			'array accessible object' => [new ArrayAccessibleObject([])],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 
 	public function testFormPost() {

--- a/tests/TypeProviderHelper.php
+++ b/tests/TypeProviderHelper.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace WpOrg\Requests\Tests;
+
+use ArrayIterator;
+use EmptyIterator;
+use stdClass;
+use WpOrg\Requests\Tests\Fixtures\ArrayAccessibleObject;
+use WpOrg\Requests\Tests\Fixtures\StringableObject;
+
+/**
+ * Helper class to provide an exhaustive list of types to test type safety.
+ */
+final class TypeProviderHelper {
+
+	/**
+	 * Keys of all type entries representing null.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_NULL = ['null'];
+
+	/**
+	 * Keys of all type entries representing a boolean.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_BOOL = [
+		'boolean false',
+		'boolean true',
+	];
+
+	/**
+	 * Keys of all type entries representing an integer.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_INT = [
+		'integer 0',
+		'negative integer',
+		'positive integer',
+	];
+
+	/**
+	 * Keys of all type entries representing a float.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_FLOAT = [
+		'float 0.0',
+		'negative float',
+		'positive float',
+	];
+
+	/**
+	 * Keys of all type entries representing an integer or float.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_INT_FLOAT = [
+		'integer 0',
+		'negative integer',
+		'positive integer',
+		'float 0.0',
+		'negative float',
+		'positive float',
+	];
+
+	/**
+	 * Keys of all type entries representing a string.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_STRING = [
+		'empty string',
+		'numeric string',
+		'textual string',
+		'textual string starting with numbers',
+	];
+
+	/**
+	 * Keys of all type entries which are stringable.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_STRINGABLE = [
+		'empty string',
+		'numeric string',
+		'textual string',
+		'textual string starting with numbers',
+		'Stringable object',
+	];
+
+	/**
+	 * Keys of all type entries representing an array.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_ARRAY = [
+		'empty array',
+		'array with values, no keys',
+		'array with values, string keys',
+	];
+
+	/**
+	 * Keys of all type entries which are iterable.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_ITERABLE = [
+		'empty array',
+		'array with values, no keys',
+		'array with values, string keys',
+		'ArrayIterator object',
+		'Iterator object, no array access',
+	];
+
+	/**
+	 * Keys of all type entries which have array access.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_ARRAY_ACCESSIBLE = [
+		'empty array',
+		'array with values, no keys',
+		'array with values, string keys',
+		'ArrayIterator object',
+		'ArrayAccess object',
+	];
+
+	/**
+	 * Keys of all type entries representing an object.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_OBJECT = [
+		'plain object',
+		'Stringable object',
+		'ArrayIterator object',
+		'ArrayAccess object',
+		'Iterator object, no array access',
+	];
+
+	/**
+	 * Keys of all type entries representing a resource.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_RESOURCE = [
+		'resource (open file handle)',
+		'resource (closed file handle)',
+	];
+
+	/**
+	 * Keys of all type entries which are considered empty.
+	 *
+	 * @var string[]
+	 */
+	const GROUP_EMPTY = [
+		'null',
+		'boolean false',
+		'integer 0',
+		'float 0.0',
+		'empty string',
+		'empty array',
+	];
+
+	/**
+	 * File handle to local memory (open resource).
+	 *
+	 * @var resource
+	 */
+	private static $memory_handle_open;
+
+	/**
+	 * File handle to local memory (closed resource).
+	 *
+	 * @var resource
+	 */
+	private static $memory_handle_closed;
+
+	/**
+	 * Clean up after the tests.
+	 *
+	 * This method should be called in the `tear_down_after_class()` of any test class
+	 * using these helper functions.
+	 *
+	 * @return void
+	 */
+	public static function cleanUp() {
+		if (isset(self::$memory_handle_open)) {
+			fclose(self::$memory_handle_open);
+			unset(self::$memory_handle_open);
+		}
+	}
+
+	/**
+	 * Retrieve an array in data provider format with a selection of all typical PHP data types
+	 * *except* the named types specified in the $except parameter.
+	 *
+	 * @param string[] ...$except One or more arrays containing the names of the types to exclude.
+	 *                            Typically, one or more of the predefined "groups" (see the constants)
+	 *                            would be used here.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function getAllExcept(array ...$except) {
+		$except = array_flip(array_merge(...$except));
+
+		return array_diff_key(self::getAll(), $except);
+	}
+
+	/**
+	 * Retrieve an array in data provider format with a selection of typical PHP data types.
+	 *
+	 * @param string[] ...$selection One or more arrays containing the names of the types to include.
+	 *                               Typically, one or more of the predefined "groups" (see the constants)
+	 *                               would be used here.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function getSelection(array ...$selection) {
+		$selection = array_flip(array_merge(...$selection));
+
+		return array_intersect_key(self::getAll(), $selection);
+	}
+
+	/**
+	 * Retrieve an array in data provider format with all typical PHP data types.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function getAll() {
+		if (isset(self::$memory_handle_open) === false) {
+			self::$memory_handle_open = fopen('php://memory', 'r+');
+		}
+
+		if (isset(self::$memory_handle_closed) === false) {
+			self::$memory_handle_closed = fopen('php://memory', 'r+');
+			fclose(self::$memory_handle_closed);
+		}
+
+		return [
+			'null' => [
+				'input' => null,
+			],
+			'boolean false' => [
+				'input' => false,
+			],
+			'boolean true' => [
+				'input' => true,
+			],
+			'integer 0' => [
+				'input' => 0,
+			],
+			'negative integer' => [
+				'input' => -123,
+			],
+			'positive integer' => [
+				'input' => 786687,
+			],
+			'float 0.0' => [
+				'input' => 0.0,
+			],
+			'negative float' => [
+				'input' => 5.600e-3,
+			],
+			'positive float' => [
+				'input' => 124.7,
+			],
+			'empty string' => [
+				'input' => '',
+			],
+			'numeric string' => [
+				'input' => '123',
+			],
+			'textual string' => [
+				'input' => 'foobar',
+			],
+			'textual string starting with numbers' => [
+				'input' => '123 My Street',
+			],
+			'empty array' => [
+				'input' => [],
+			],
+			'array with values, no keys' => [
+				'input' => [1, 2, 3],
+			],
+			'array with values, string keys' => [
+				'input' => ['a' => 1, 'b' => 2],
+			],
+			'plain object' => [
+				'input' => new stdClass(),
+			],
+			'Stringable object' => [
+				'input' => new StringableObject('value'),
+			],
+			'ArrayIterator object' => [
+				'input' => new ArrayIterator([1, 2, 3]),
+			],
+			'ArrayAccess object' => [
+				'input' => new ArrayAccessibleObject(),
+			],
+			'Iterator object, no array access' => [
+				'input' => new EmptyIterator(),
+			],
+			'resource (open file handle)' => [
+				'input' => self::$memory_handle_open,
+			],
+			'resource (closed file handle)' => [
+				'input' => self::$memory_handle_closed,
+			],
+		];
+	}
+}

--- a/tests/Utility/FilteredIterator/FilteredIteratorTest.php
+++ b/tests/Utility/FilteredIterator/FilteredIteratorTest.php
@@ -7,8 +7,8 @@ use ReflectionClass;
 use ReflectionObject;
 use stdClass;
 use WpOrg\Requests\Exception\InvalidArgument;
-use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 use WpOrg\Requests\Utility\FilteredIterator;
 
 /**
@@ -92,10 +92,7 @@ final class FilteredIteratorTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorValidData() {
-		return [
-			'array'           => [[1, 2, 3]],
-			'iterable object' => [new ArrayIterator([1, 2, 3])],
-		];
+		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_ITERABLE);
 	}
 
 	/**
@@ -122,11 +119,7 @@ final class FilteredIteratorTest extends TestCase {
 	 * @return array
 	 */
 	public function dataConstructorInvalidData() {
-		return [
-			'null'              => [null],
-			'float'             => [1.1],
-			'stringable object' => [new StringableObject('value')],
-		];
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ITERABLE);
 	}
 
 	/**

--- a/tests/Utility/InputValidator/InputValidatorTest.php
+++ b/tests/Utility/InputValidator/InputValidatorTest.php
@@ -2,11 +2,8 @@
 
 namespace WpOrg\Requests\Tests\Utility\InputValidator;
 
-use ArrayIterator;
-use stdClass;
-use WpOrg\Requests\Tests\Fixtures\ArrayAccessibleObject;
-use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 use WpOrg\Requests\Utility\InputValidator;
 
 /**
@@ -22,13 +19,6 @@ final class InputValidatorTest extends TestCase {
 	private static $curl_handle;
 
 	/**
-	 * Directory handle.
-	 *
-	 * @var resource
-	 */
-	private static $dir_handle;
-
-	/**
 	 * Clean up after the tests.
 	 */
 	public static function tear_down_after_test() {
@@ -36,361 +26,300 @@ final class InputValidatorTest extends TestCase {
 			curl_close(self::$curl_handle);
 		}
 
-		if (isset(self::$dir_handle)) {
-			closedir(self::$dir_handle);
-		}
+		parent::tear_down_after_test();
 	}
 
 	/**
-	 * Test that a received input parameter is correctly identified as string or "stringable".
+	 * Test that a received input parameter is correctly identified as a valid string or "stringable".
 	 *
-	 * @dataProvider dataInput
+	 * @dataProvider dataIsStringOrStringableValid
 	 *
 	 * @covers ::is_string_or_stringable
 	 *
-	 * @param mixed $input    Input parameter to verify.
-	 * @param array $expected Expected output for the respective functions.
+	 * @param mixed $input Input parameter to verify.
 	 *
 	 * @return void
 	 */
-	public function testIsStringOrStringable($input, $expected) {
-		$this->assertSame($expected['is_string_or_stringable'], InputValidator::is_string_or_stringable($input));
+	public function testIsStringOrStringableValid($input) {
+		$this->assertTrue(InputValidator::is_string_or_stringable($input));
 	}
 
 	/**
-	 * Test whether a received input parameter is correctly identified as usable as a numeric (integer) array key.
+	 * Data Provider.
 	 *
-	 * @dataProvider dataInput
+	 * @return array
+	 */
+	public function dataIsStringOrStringableValid() {
+		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_STRINGABLE);
+	}
+
+	/**
+	 * Test that a received input parameter is correctly identified as NOT valid as a string or "stringable".
 	 *
-	 * @covers ::is_numeric_array_key
+	 * @dataProvider dataIsStringOrStringableInvalid
 	 *
-	 * @param mixed $input    Input parameter to verify.
-	 * @param array $expected Expected output for the respective functions.
+	 * @covers ::is_string_or_stringable
+	 *
+	 * @param mixed $input Input parameter to verify.
 	 *
 	 * @return void
 	 */
-	public function testIsNumericArrayKey($input, $expected) {
-		$this->assertSame($expected['is_numeric_array_key'], InputValidator::is_numeric_array_key($input));
+	public function testIsStringOrStringableInvalid($input) {
+		$this->assertFalse(InputValidator::is_string_or_stringable($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataIsStringOrStringableInvalid() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
+	}
+
+	/**
+	 * Test whether a received input parameter is correctly identified as usable as a valid numeric (integer) array key.
+	 *
+	 * @dataProvider dataIsNumericArrayKeyValid
+	 *
+	 * @covers ::is_numeric_array_key
+	 *
+	 * @param mixed $input Input parameter to verify.
+	 *
+	 * @return void
+	 */
+	public function testIsNumericArrayKeyValid($input) {
+		$this->assertTrue(InputValidator::is_numeric_array_key($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataIsNumericArrayKeyValid() {
+		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_INT, ['numeric string']);
+	}
+
+	/**
+	 * Test whether a received input parameter is correctly identified as NOT valid as a numeric (integer) array key.
+	 *
+	 * @dataProvider dataIsNumericArrayKeyInvalid
+	 *
+	 * @covers ::is_numeric_array_key
+	 *
+	 * @param mixed $input Input parameter to verify.
+	 *
+	 * @return void
+	 */
+	public function testIsNumericArrayKeyInvalid($input) {
+		$this->assertFalse(InputValidator::is_numeric_array_key($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataIsNumericArrayKeyInvalid() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, ['numeric string']);
 	}
 
 	/**
 	 * Test whether a received input parameter is correctly identified as "stringable".
 	 *
-	 * @dataProvider dataInput
+	 * @dataProvider dataIsStringableObjectValid
 	 *
 	 * @covers ::is_stringable_object
 	 *
-	 * @param mixed $input    Input parameter to verify.
-	 * @param array $expected Expected output for the respective functions.
+	 * @param mixed $input Input parameter to verify.
 	 *
 	 * @return void
 	 */
-	public function testIsStringableObject($input, $expected) {
-		$this->assertSame($expected['is_stringable_object'], InputValidator::is_stringable_object($input));
+	public function testIsStringableObjectValid($input) {
+		$this->assertTrue(InputValidator::is_stringable_object($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataIsStringableObjectValid() {
+		return TypeProviderHelper::getSelection(['Stringable object']);
+	}
+
+	/**
+	 * Test whether a received input parameter is correctly identified as NOT "stringable".
+	 *
+	 * @dataProvider dataIsStringableObjectInvalid
+	 *
+	 * @covers ::is_stringable_object
+	 *
+	 * @param mixed $input Input parameter to verify.
+	 *
+	 * @return void
+	 */
+	public function testIsStringableObjectInvalid($input) {
+		$this->assertFalse(InputValidator::is_stringable_object($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataIsStringableObjectInvalid() {
+		return TypeProviderHelper::getAllExcept(['Stringable object']);
 	}
 
 	/**
 	 * Test whether a received input parameter is correctly identified as "accessible as array".
 	 *
-	 * @dataProvider dataInput
+	 * @dataProvider dataHasArrayAccessValid
 	 *
 	 * @covers ::has_array_access
 	 *
-	 * @param mixed $input    Input parameter to verify.
-	 * @param array $expected Expected output for the respective functions.
+	 * @param mixed $input Input parameter to verify.
 	 *
 	 * @return void
 	 */
-	public function testHasArrayAccess($input, $expected) {
-		$this->assertSame($expected['has_array_access'], InputValidator::has_array_access($input));
+	public function testHasArrayAccessValid($input) {
+		$this->assertTrue(InputValidator::has_array_access($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataHasArrayAccessValid() {
+		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
+	}
+
+	/**
+	 * Test whether a received input parameter is correctly identified as NOT "accessible as array".
+	 *
+	 * @dataProvider dataHasArrayAccessInvalid
+	 *
+	 * @covers ::has_array_access
+	 *
+	 * @param mixed $input Input parameter to verify.
+	 *
+	 * @return void
+	 */
+	public function testHasArrayAccessInvalid($input) {
+		$this->assertFalse(InputValidator::has_array_access($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataHasArrayAccessInvalid() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
 	}
 
 	/**
 	 * Test whether a received input parameter is correctly identified as "iterable".
 	 *
-	 * @dataProvider dataInput
+	 * @dataProvider dataIsIterableValid
 	 *
 	 * @covers ::is_iterable
 	 *
-	 * @param mixed $input    Input parameter to verify.
-	 * @param array $expected Expected output for the respective functions.
+	 * @param mixed $input Input parameter to verify.
 	 *
 	 * @return void
 	 */
-	public function testIsIterable($input, $expected) {
-		$this->assertSame($expected['is_iterable'], InputValidator::is_iterable($input));
+	public function testIsIterableValid($input) {
+		$this->assertTrue(InputValidator::is_iterable($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataIsIterableValid() {
+		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_ITERABLE);
+	}
+
+	/**
+	 * Test whether a received input parameter is correctly identified as NOT "iterable".
+	 *
+	 * @dataProvider dataIsIterableInvalid
+	 *
+	 * @covers ::is_iterable
+	 *
+	 * @param mixed $input Input parameter to verify.
+	 *
+	 * @return void
+	 */
+	public function testIsIterableInvalid($input) {
+		$this->assertFalse(InputValidator::is_iterable($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataIsIterableInvalid() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ITERABLE);
 	}
 
 	/**
 	 * Test whether a received input parameter is correctly identified as a Curl handle.
 	 *
-	 * @dataProvider dataInput
+	 * @dataProvider dataIsCurlHandleValid
 	 *
 	 * @covers ::is_curl_handle
 	 *
-	 * @param mixed $input    Input parameter to verify.
-	 * @param array $expected Expected output for the respective functions.
+	 * @param mixed $input Input parameter to verify.
 	 *
 	 * @return void
 	 */
-	public function testIsCurlHandle($input, $expected) {
-		$this->assertSame($expected['is_curl_handle'], InputValidator::is_curl_handle($input));
+	public function testIsCurlHandleValid($input) {
+		$this->assertTrue(InputValidator::is_curl_handle($input));
 	}
 
 	/**
-	 * Data provider.
+	 * Data Provider.
 	 *
 	 * @return array
 	 */
-	public function dataInput() {
-		if (isset(self::$curl_handle, self::$dir_handle) === false) {
+	public function dataIsCurlHandleValid() {
+		if (isset(self::$curl_handle) === false) {
 			self::$curl_handle = curl_init('http://httpbin.org/anything');
-			self::$dir_handle  = opendir(__DIR__);
 		}
 
 		return [
-			'null' => [
-				'input'    => null,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'boolean false' => [
-				'input'    => false,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'boolean true' => [
-				'input'    => true,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'integer 0' => [
-				'input'    => 0,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => true,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'negative integer' => [
-				'input'    => -123,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => true,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'positive integer' => [
-				'input'    => 786687,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => true,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'float 0.0' => [
-				'input'    => 0.0,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'negative float' => [
-				'input'    => 5.600e-3,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'positive float' => [
-				'input'    => 124.7,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'empty string' => [
-				'input'    => '',
-				'expected' => [
-					'is_string_or_stringable' => true,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'string "123"' => [
-				'input'    => '123',
-				'expected' => [
-					'is_string_or_stringable' => true,
-					'is_numeric_array_key'    => true,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'string "foobar"' => [
-				'input'    => 'foobar',
-				'expected' => [
-					'is_string_or_stringable' => true,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'string "123 My Street"' => [
-				'input'    => '123 My Street',
-				'expected' => [
-					'is_string_or_stringable' => true,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'empty array' => [
-				'input'    => [],
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => true,
-					'is_iterable'             => true,
-					'is_curl_handle'          => false,
-				],
-			],
-			'array with three items, no keys' => [
-				'input'    => [1, 2, 3],
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => true,
-					'is_iterable'             => true,
-					'is_curl_handle'          => false,
-				],
-			],
-			'array with two items, with keys' => [
-				'input'    => ['a' => 1, 'b' => 2],
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => true,
-					'is_iterable'             => true,
-					'is_curl_handle'          => false,
-				],
-			],
-			'plain object' => [
-				'input'    => new stdClass(),
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'object with __toString method' => [
-				'input'    => new StringableObject('value'),
-				'expected' => [
-					'is_string_or_stringable' => true,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => true,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'object implementing ArrayIterator' => [
-				'input'    => new ArrayIterator([1, 2, 3]),
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => true,
-					'is_iterable'             => true,
-					'is_curl_handle'          => false,
-				],
-			],
-			'object implementing ArrayAccess' => [
-				'input'    => new ArrayAccessibleObject(),
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => true,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
-			'Curl handle (resource or object depending on PHP version)' => [
-				'input'    => self::$curl_handle,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => true,
-				],
-			],
-			'Directory handle (resource)' => [
-				'input'    => self::$dir_handle,
-				'expected' => [
-					'is_string_or_stringable' => false,
-					'is_numeric_array_key'    => false,
-					'is_stringable_object'    => false,
-					'has_array_access'        => false,
-					'is_iterable'             => false,
-					'is_curl_handle'          => false,
-				],
-			],
+			'Curl handle (resource or object depending on PHP version)' => [self::$curl_handle],
 		];
+	}
+
+	/**
+	 * Test whether a received input parameter is correctly identified as a Curl handle.
+	 *
+	 * @dataProvider dataIsCurlHandleInvalid
+	 *
+	 * @covers ::is_curl_handle
+	 *
+	 * @param mixed $input Input parameter to verify.
+	 *
+	 * @return void
+	 */
+	public function testIsCurlHandleInvalid($input) {
+		$this->assertFalse(InputValidator::is_curl_handle($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataIsCurlHandleInvalid() {
+		return TypeProviderHelper::getAll();
 	}
 }


### PR DESCRIPTION
This PR is a follow-up on the PRs created to address #593.

At the time, it was discussed in a call that it would be better to always test against all types which would generate an exception, but with the pressure to release version 2.0.0, this wasn't implemented at that time.

This PR addresses this remark now.


### Tests: add new TypeProviderHelper class

... which can be used as a data provider for all tests which need to test against a variation of different types of data.

Typical groups of keys are defined as class constants for use as selectors.

As a resource is created for the test cases, the `clean_up()` method needs to be called after the tests using data from the TypeProviderHelper have run.
As the majority of the test classes will use the TypeProviderHelper for one or more tests, we may as well generically call this clean up method from the base `TestCase`.

Includes adding an exception for the use of camelCase method names to the PHPCS ruleset.
The `WordPress.NamingConventions.ValidFunctionName` sniff already doesn't trigger on the use of camelCase in the test classes themselves (as they extend another class), so let's blanket ignore the snake_case method name rule for all files in the `tests` directory.
Note: if so preferred, I could add a sniff to enforce using camelCase in the tests directory, though I'd need to see if I can find one which could make an exception for the snake_case fixture methods.

### InputValidatorTest: refactor to use the TypeProviderHelper

This removes the original data provider in favour of having a "valid" and "invalid" test function for each function with a dedicated data provider for each.

The refactor is nearly 1-on-1: all previously tested cases are still tested, with the one exception being that a curl handle is not included in the "default" data provided via the TypeProviderHelper.

### Tests: implement use of the new TypeProviderHelper class

.. in all the data providers related to tests which check for input types.

The benefit of this refactor is that if/when additional test cases are added to the `TypeProviderHelper`, these tests will automatically also be tested against those new test cases.