### PR TITLE
Auth\BasicTest: split up the test class

### DIFF
--- a/tests/Auth/Basic/BasicTest.php
+++ b/tests/Auth/Basic/BasicTest.php
@@ -269,17 +269,4 @@ final class BasicTest extends TestCase {
 			'array with extra element'    => [['user', 'psw', 'port']],
 		];
 	}
-
-	/**
-	 * Helper function to skip select tests when the transport under test is not available.
-	 *
-	 * @param string $transport Transport to use.
-	 *
-	 * @return void
-	 */
-	public function skipWhenTransportNotAvailable($transport) {
-		if (!$transport::test()) {
-			$this->markTestSkipped('Transport "' . $transport . '" is not available');
-		}
-	}
 }

--- a/tests/Auth/Basic/BasicTest.php
+++ b/tests/Auth/Basic/BasicTest.php
@@ -3,12 +3,9 @@
 namespace WpOrg\Requests\Tests\Auth\Basic;
 
 use WpOrg\Requests\Auth\Basic;
-use WpOrg\Requests\Exception\ArgumentCount;
-use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\TestCase;
-use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * @covers \WpOrg\Requests\Auth\Basic
@@ -214,59 +211,5 @@ final class BasicTest extends TestCase {
 			'Property "data" not available in decoded response'
 		);
 		$this->assertSame('test', $result->data, 'Unexpected data value encountered');
-	}
-
-	/**
-	 * Tests receiving an exception when an invalid input type is passed.
-	 *
-	 * @dataProvider dataInvalidInputType
-	 *
-	 * @param mixed $input Input data.
-	 *
-	 * @return void
-	 */
-	public function testInvalidInputType($input) {
-		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($args) must be of type array|null');
-
-		new Basic($input);
-	}
-
-	/**
-	 * Data Provider.
-	 *
-	 * @return array
-	 */
-	public function dataInvalidInputType() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_ARRAY);
-	}
-
-	/**
-	 * Verify that an exception is thrown when the class is instantiated with an invalid number of arguments.
-	 *
-	 * @dataProvider dataInvalidArgumentCount
-	 *
-	 * @param mixed $input Input data.
-	 *
-	 * @return void
-	 */
-	public function testInvalidArgumentCount($input) {
-		$this->expectException(ArgumentCount::class);
-		$this->expectExceptionMessage('WpOrg\Requests\Auth\Basic::__construct() expects an array with exactly two elements');
-
-		new Basic($input);
-	}
-
-	/**
-	 * Data Provider.
-	 *
-	 * @return array
-	 */
-	public function dataInvalidArgumentCount() {
-		return [
-			'empty array'                 => [[]],
-			'array with only one element' => [['user']],
-			'array with extra element'    => [['user', 'psw', 'port']],
-		];
 	}
 }

--- a/tests/Auth/Basic/ConstructorTest.php
+++ b/tests/Auth/Basic/ConstructorTest.php
@@ -66,4 +66,28 @@ final class ConstructorTest extends TestCase {
 			'array with extra element'    => [['user', 'psw', 'port']],
 		];
 	}
+
+	/**
+	 * Tests valid instantiation of the class with a user and password.
+	 *
+	 * @return void
+	 */
+	public function testInstantiateWithValidInput() {
+		$instance = new Basic(['user', 'psw']);
+
+		$this->assertSame('user', $instance->user);
+		$this->assertSame('psw', $instance->pass);
+	}
+
+	/**
+	 * Tests valid instantiation of the class with passing any parameters.
+	 *
+	 * @return void
+	 */
+	public function testInstantiateWithNoInput() {
+		$instance = new Basic();
+
+		$this->assertNull($instance->user);
+		$this->assertNull($instance->pass);
+	}
 }

--- a/tests/Auth/Basic/ConstructorTest.php
+++ b/tests/Auth/Basic/ConstructorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Auth\Basic;
+
+use WpOrg\Requests\Auth\Basic;
+use WpOrg\Requests\Exception\ArgumentCount;
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
+
+/**
+ * @covers \WpOrg\Requests\Auth\Basic::__construct
+ */
+final class ConstructorTest extends TestCase {
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed.
+	 *
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $input Input data.
+	 *
+	 * @return void
+	 */
+	public function testInvalidInputType($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($args) must be of type array|null');
+
+		new Basic($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputType() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_ARRAY);
+	}
+
+	/**
+	 * Verify that an exception is thrown when the class is instantiated with an invalid number of arguments.
+	 *
+	 * @dataProvider dataInvalidArgumentCount
+	 *
+	 * @param mixed $input Input data.
+	 *
+	 * @return void
+	 */
+	public function testInvalidArgumentCount($input) {
+		$this->expectException(ArgumentCount::class);
+		$this->expectExceptionMessage('WpOrg\Requests\Auth\Basic::__construct() expects an array with exactly two elements');
+
+		new Basic($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidArgumentCount() {
+		return [
+			'empty array'                 => [[]],
+			'array with only one element' => [['user']],
+			'array with extra element'    => [['user', 'psw', 'port']],
+		];
+	}
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,6 +19,19 @@ abstract class TestCase extends Polyfill_TestCase {
 	}
 
 	/**
+	 * Helper function to skip select tests when the transport under test is not available.
+	 *
+	 * @param string $transport Fully qualified class name for the transport to verify.
+	 *
+	 * @return void
+	 */
+	public function skipWhenTransportNotAvailable($transport) {
+		if (!$transport::test()) {
+			$this->markTestSkipped('Transport "' . $transport . '" is not available');
+		}
+	}
+
+	/**
 	 * Data provider for use in tests which need to be run against all default supported transports.
 	 *
 	 * @return array


### PR DESCRIPTION
### Auth\BasicTest: move helper function to base TestCase

... as this helper may be useful in other test classes as well.

### Auth\BasicTest: split constructor specific tests to dedicated test class

The other tests in the `BasicTest` class are integration tests, not unit tests, so should remain in the generic class test class.

### Auth\Basic\ConstructorTest: add two extra tests specifically for the constructor

... to make the `Auth\Basic\ConstructorTest` feature complete and independent of the integration tests.

Related to #648