### PR TITLE
Cookie\JarTest: split up test class

### DIFF
--- a/tests/Cookie/Jar/ArrayAccessTest.php
+++ b/tests/Cookie/Jar/ArrayAccessTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Cookie\Jar;
+
+use WpOrg\Requests\Cookie\Jar;
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Cookie\Jar::offsetExists
+ * @covers \WpOrg\Requests\Cookie\Jar::offsetGet
+ * @covers \WpOrg\Requests\Cookie\Jar::offsetSet
+ * @covers \WpOrg\Requests\Cookie\Jar::offsetUnset
+ */
+final class ArrayAccessTest extends TestCase {
+
+	public function testJarSetter() {
+		$jar1                        = new Jar();
+		$jar1['requests-testcookie'] = 'testvalue';
+
+		$jar2 = new Jar(
+			[
+				'requests-testcookie' => 'testvalue',
+			]
+		);
+		$this->assertEquals($jar1, $jar2);
+	}
+
+	public function testJarUnsetter() {
+		$jar                        = new Jar();
+		$jar['requests-testcookie'] = 'testvalue';
+
+		$this->assertSame('testvalue', $jar['requests-testcookie']);
+
+		unset($jar['requests-testcookie']);
+		$this->assertEmpty($jar['requests-testcookie']);
+		$this->assertFalse(isset($jar['requests-testcookie']));
+	}
+
+	public function testJarAsList() {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Object is a dictionary, not a list');
+
+		$cookies   = new Jar();
+		$cookies[] = 'requests-testcookie1=testvalue1';
+	}
+}

--- a/tests/Cookie/Jar/ConstructorTest.php
+++ b/tests/Cookie/Jar/ConstructorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Cookie\Jar;
+
+use WpOrg\Requests\Cookie\Jar;
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
+
+/**
+ * @covers \WpOrg\Requests\Cookie\Jar::__construct
+ */
+final class ConstructorTest extends TestCase {
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed to the class constructor.
+	 *
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testInvalidInputType($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($cookies) must be of type array');
+
+		new Jar($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputType() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
+	}
+}

--- a/tests/Cookie/Jar/ConstructorTest.php
+++ b/tests/Cookie/Jar/ConstructorTest.php
@@ -2,6 +2,7 @@
 
 namespace WpOrg\Requests\Tests\Cookie\Jar;
 
+use ReflectionObject;
 use WpOrg\Requests\Cookie\Jar;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Tests\TestCase;
@@ -35,5 +36,35 @@ final class ConstructorTest extends TestCase {
 	 */
 	public function dataInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
+	}
+
+	/**
+	 * Tests that valid data is accepted by the constructor and the property gets set.
+	 *
+	 * @dataProvider dataValidInputType
+	 *
+	 * @param mixed $input Valid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testValidInputType($input) {
+		$obj = new Jar($input);
+
+		$reflection = new ReflectionObject($obj);
+		$property   = $reflection->getProperty('cookies');
+		$property->setAccessible(true);
+		$property_value = $property->getValue($obj);
+		$property->setAccessible(false);
+
+		$this->assertSame($input, $property_value, 'Cookies property has not been set to expected value');
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataValidInputType() {
+		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_ARRAY);
 	}
 }

--- a/tests/Cookie/Jar/GetIteratorTest.php
+++ b/tests/Cookie/Jar/GetIteratorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Cookie\Jar;
+
+use WpOrg\Requests\Cookie\Jar;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Cookie\Jar::getIterator
+ */
+final class GetIteratorTest extends TestCase {
+
+	public function testJarIterator() {
+		$cookies = [
+			'requests-testcookie1' => 'testvalue1',
+			'requests-testcookie2' => 'testvalue2',
+		];
+		$jar     = new Jar($cookies);
+
+		foreach ($jar as $key => $value) {
+			$this->assertSame($cookies[$key], $value);
+		}
+	}
+}

--- a/tests/Cookie/Jar/JarTest.php
+++ b/tests/Cookie/Jar/JarTest.php
@@ -4,7 +4,6 @@ namespace WpOrg\Requests\Tests\Cookie\Jar;
 
 use WpOrg\Requests\Cookie;
 use WpOrg\Requests\Cookie\Jar;
-use WpOrg\Requests\Exception;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
 
@@ -12,36 +11,6 @@ use WpOrg\Requests\Tests\TestCase;
  * @covers \WpOrg\Requests\Cookie\Jar
  */
 final class JarTest extends TestCase {
-
-	public function testCookieJarSetter() {
-		$jar1                        = new Jar();
-		$jar1['requests-testcookie'] = 'testvalue';
-
-		$jar2 = new Jar(
-			[
-				'requests-testcookie' => 'testvalue',
-			]
-		);
-		$this->assertEquals($jar1, $jar2);
-	}
-
-	public function testCookieJarUnsetter() {
-		$jar                        = new Jar();
-		$jar['requests-testcookie'] = 'testvalue';
-
-		$this->assertSame('testvalue', $jar['requests-testcookie']);
-
-		unset($jar['requests-testcookie']);
-		$this->assertEmpty($jar['requests-testcookie']);
-		$this->assertFalse(isset($jar['requests-testcookie']));
-	}
-
-	public function testCookieJarAsList() {
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Object is a dictionary, not a list');
-		$cookies   = new Jar();
-		$cookies[] = 'requests-testcookie1=testvalue1';
-	}
 
 	public function testCookieJarIterator() {
 		$cookies = [

--- a/tests/Cookie/Jar/JarTest.php
+++ b/tests/Cookie/Jar/JarTest.php
@@ -12,18 +12,6 @@ use WpOrg\Requests\Tests\TestCase;
  */
 final class JarTest extends TestCase {
 
-	public function testCookieJarIterator() {
-		$cookies = [
-			'requests-testcookie1' => 'testvalue1',
-			'requests-testcookie2' => 'testvalue2',
-		];
-		$jar     = new Jar($cookies);
-
-		foreach ($jar as $key => $value) {
-			$this->assertSame($cookies[$key], $value);
-		}
-	}
-
 	public function testSendingCookieWithJar() {
 		$cookies = new Jar(
 			[

--- a/tests/Cookie/Jar/JarTest.php
+++ b/tests/Cookie/Jar/JarTest.php
@@ -8,7 +8,12 @@ use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
 
 /**
- * @covers \WpOrg\Requests\Cookie\Jar
+ * Integration tests for the Jar class.
+ *
+ * @covers \WpOrg\Requests\Cookie\Jar::normalize_cookie
+ * @covers \WpOrg\Requests\Cookie\Jar::register
+ * @covers \WpOrg\Requests\Cookie\Jar::before_request
+ * @covers \WpOrg\Requests\Cookie\Jar::before_redirect_check
  */
 final class JarTest extends TestCase {
 
@@ -52,6 +57,13 @@ final class JarTest extends TestCase {
 		$this->assertSame('testvalue', $data['requests-testcookie']);
 	}
 
+	/**
+	 * Test helper.
+	 *
+	 * @param \WpOrg\Requests\Cookie\Jar $cookies Cookies.
+	 *
+	 * @return array
+	 */
 	private function setCookieRequest($cookies) {
 		$options  = [
 			'cookies' => $cookies,

--- a/tests/Cookie/Jar/JarTest.php
+++ b/tests/Cookie/Jar/JarTest.php
@@ -5,10 +5,8 @@ namespace WpOrg\Requests\Tests\Cookie\Jar;
 use WpOrg\Requests\Cookie;
 use WpOrg\Requests\Cookie\Jar;
 use WpOrg\Requests\Exception;
-use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TestCase;
-use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * @covers \WpOrg\Requests\Cookie\Jar
@@ -107,30 +105,5 @@ final class JarTest extends TestCase {
 		$this->assertIsArray($data);
 		$this->assertArrayHasKey('cookies', $data);
 		return $data['cookies'];
-	}
-
-	/**
-	 * Tests receiving an exception when an invalid input type is passed to the class constructor.
-	 *
-	 * @dataProvider dataConstructorInvalidInputType
-	 *
-	 * @param mixed $input Invalid parameter input.
-	 *
-	 * @return void
-	 */
-	public function testConstructorInvalidInputType($input) {
-		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($cookies) must be of type array');
-
-		new Jar($input);
-	}
-
-	/**
-	 * Data Provider.
-	 *
-	 * @return array
-	 */
-	public function dataConstructorInvalidInputType() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 }


### PR DESCRIPTION
### Cookie\JarTest: split constructor specific tests to dedicated test class

### Cookie\Jar\ConstructorTest: add extra test specifically for the constructor

... to make the `Cookie\Jar\ConstructorTest` feature complete and independent of the other tests for this class.

### Cookie\JarTest: split array access specific tests to dedicated test class

### Cookie\JarTest: split getIterator() specific tests to dedicated test class

### Cookie\JarTest: improve documentation of the remaining tests

Includes making the `@covers` tag more specific.


Related to #648