### PR TITLE
IriTest: split constructor specific tests to dedicated test class

### DIFF
--- a/tests/Iri/ConstructorTest.php
+++ b/tests/Iri/ConstructorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Iri;
+
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Iri;
+use WpOrg\Requests\Tests\Fixtures\StringableObject;
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
+
+/**
+ * @covers \WpOrg\Requests\Iri::__construct
+ */
+final class ConstructorTest extends TestCase {
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed to the constructor.
+	 *
+	 * @dataProvider dataInvalidInput
+	 *
+	 * @param mixed $iri Invalid input.
+	 *
+	 * @return void
+	 */
+	public function testInvalidInput($iri) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($iri) must be of type string|Stringable|null');
+
+		new Iri($iri);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInput() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_STRINGABLE);
+	}
+
+	/**
+	 * Safeguard that the constructor can accept Stringable objects as $iri.
+	 *
+	 * @return void
+	 */
+	public function testAcceptsStringableIri() {
+		$this->assertInstanceOf(Iri::class, new Iri(new StringableObject('https://example.com/')));
+	}
+}

--- a/tests/Iri/IriTest.php
+++ b/tests/Iri/IriTest.php
@@ -42,11 +42,8 @@
 
 namespace WpOrg\Requests\Tests\Iri;
 
-use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Iri;
-use WpOrg\Requests\Tests\Fixtures\StringableObject;
 use WpOrg\Requests\Tests\TestCase;
-use WpOrg\Requests\Tests\TypeProviderHelper;
 
 final class IriTest extends TestCase
 {
@@ -415,43 +412,5 @@ final class IriTest extends TestCase
 		$iri->port = 'example';
 
 		$this->assertNull($iri->port);
-	}
-
-	/**
-	 * Safeguard that the constructor can accept Stringable objects as $iri.
-	 *
-	 * @covers \WpOrg\Requests\Iri::__construct
-	 *
-	 * @return void
-	 */
-	public function testConstructorAcceptsStringableIri() {
-		$this->assertInstanceOf(Iri::class, new Iri(new StringableObject('https://example.com/')));
-	}
-
-	/**
-	 * Tests receiving an exception when an invalid input type is passed to the constructor.
-	 *
-	 * @dataProvider dataConstructorInvalidInput
-	 *
-	 * @covers \WpOrg\Requests\Iri::__construct
-	 *
-	 * @param mixed $iri Invalid input.
-	 *
-	 * @return void
-	 */
-	public function testConstructorInvalidInput($iri) {
-		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($iri) must be of type string|Stringable|null');
-
-		new Iri($iri);
-	}
-
-	/**
-	 * Data Provider.
-	 *
-	 * @return array
-	 */
-	public function dataConstructorInvalidInput() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_STRINGABLE);
 	}
 }


### PR DESCRIPTION
Splitting up the rest of the test class will be done when the full test class will be reviewed for stability and code coverage. (Per #497)

Related to #648