### PR TITLE
Proxy\HttpTest: split constructor specific tests to dedicated test class

### DIFF
--- a/tests/Proxy/Http/ConstructorTest.php
+++ b/tests/Proxy/Http/ConstructorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Proxy\Http;
+
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Proxy\Http;
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
+
+/**
+ * @covers \WpOrg\Requests\Proxy\Http::__construct
+ */
+final class ConstructorTest extends TestCase {
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed to the Proxy\Http constructor.
+	 *
+	 * @dataProvider dataInvalidParameterType
+	 *
+	 * @param mixed $input Input to pass to the function.
+	 *
+	 * @return void
+	 */
+	public function testInvalidParameterType($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($args) must be of type array|string|null');
+
+		new Http($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidParameterType() {
+		return TypeProviderHelper::getAllExcept(
+			TypeProviderHelper::GROUP_NULL,
+			TypeProviderHelper::GROUP_STRING,
+			TypeProviderHelper::GROUP_ARRAY
+		);
+	}
+}

--- a/tests/Proxy/Http/HttpTest.php
+++ b/tests/Proxy/Http/HttpTest.php
@@ -4,12 +4,10 @@ namespace WpOrg\Requests\Tests\Proxy\Http;
 
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\ArgumentCount;
-use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Proxy\Http;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\TestCase;
-use WpOrg\Requests\Tests\TypeProviderHelper;
 use WpOrg\Requests\Transport\Fsockopen;
 
 final class HttpTest extends TestCase {
@@ -180,36 +178,5 @@ final class HttpTest extends TestCase {
 			$this->assertEmpty($result['args']);
 			$this->assertSame('http', $result['headers']['x-requests-proxy']);
 		}
-	}
-
-	/**
-	 * Tests receiving an exception when an invalid input type is passed to the Proxy\Http constructor.
-	 *
-	 * @covers \WpOrg\Requests\Proxy\Http::__construct
-	 *
-	 * @dataProvider dataConstructorInvalidParameterType
-	 *
-	 * @param mixed $input Input to pass to the function.
-	 *
-	 * @return void
-	 */
-	public function testConstructorInvalidParameterType($input) {
-		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($args) must be of type array|string|null');
-
-		new Http($input);
-	}
-
-	/**
-	 * Data Provider.
-	 *
-	 * @return array
-	 */
-	public function dataConstructorInvalidParameterType() {
-		return TypeProviderHelper::getAllExcept(
-			TypeProviderHelper::GROUP_NULL,
-			TypeProviderHelper::GROUP_STRING,
-			TypeProviderHelper::GROUP_ARRAY
-		);
 	}
 }


### PR DESCRIPTION
The other tests in the `HttpTest` class are integration tests, not unit tests, so should remain in the generic class test class (and still need review per issue #497 anyway).

Related to #648