### PR TITLE
SslTest: split up test class

### DIFF
--- a/tests/Ssl/MatchDomainTest.php
+++ b/tests/Ssl/MatchDomainTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Ssl;
+
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Ssl;
+use WpOrg\Requests\Tests\Ssl\SslTestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
+
+/**
+ * @covers \WpOrg\Requests\Ssl::match_domain
+ */
+final class MatchDomainTest extends SslTestCase {
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed.
+	 *
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $input Input data.
+	 *
+	 * @return void
+	 */
+	public function testInvalidInputType($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($host) must be of type string|Stringable');
+
+		Ssl::match_domain($input, 'reference');
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputType() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
+	}
+
+	/**
+	 * Test handling of matching host and DNS names.
+	 *
+	 * @dataProvider dataMatch
+	 *
+	 * @param string $host      Host name to verify.
+	 * @param string $reference DNS name to match against.
+	 *
+	 * @return void
+	 */
+	public function testMatch($host, $reference) {
+		$this->assertTrue(Ssl::match_domain($host, $reference));
+	}
+
+	/**
+	 * Test handling of non-matching host and DNS names.
+	 *
+	 * @dataProvider dataNoMatch
+	 *
+	 * @param string $host      Host name to verify.
+	 * @param string $reference DNS name to match against.
+	 *
+	 * @return void
+	 */
+	public function testNoMatch($host, $reference) {
+		$this->assertFalse(Ssl::match_domain($host, $reference));
+	}
+}

--- a/tests/Ssl/SslTest.php
+++ b/tests/Ssl/SslTest.php
@@ -404,100 +404,6 @@ final class SslTest extends TestCase {
 	}
 
 	/**
-	 * Test correctly identifying whether a reference name is valid.
-	 *
-	 * @covers ::verify_reference_name
-	 *
-	 * @dataProvider dataVerifyReferenceName
-	 *
-	 * @param string $reference Reference name to test.
-	 * @param bool   $expected  Expected function outcome.
-	 *
-	 * @return void
-	 */
-	public function testVerifyReferenceName($reference, $expected) {
-		$this->assertSame($expected, Ssl::verify_reference_name($reference));
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function dataVerifyReferenceName() {
-		return [
-			'empty string' => [
-				'reference' => '',
-				'expected'  => false,
-			],
-			'one part, no dot' => [
-				'reference' => 'example',
-				'expected'  => true,
-			],
-			'one part, only wildcard' => [
-				'reference' => '*',
-				'expected'  => false,
-			],
-			'two parts, no wildcard' => [
-				'reference' => 'example.com',
-				'expected'  => true,
-			],
-			'two parts, wildcard in first' => [
-				'reference' => '*.com',
-				'expected'  => false,
-			],
-			'two parts, wildcard in last' => [
-				'reference' => 'example.*',
-				'expected'  => false,
-			],
-			'three parts, only dots' => [
-				'reference' => '..',
-				'expected'  => false,
-			],
-			'three parts, no wildcard' => [
-				'reference' => new StringableObject('www.example.com'),
-				'expected'  => true,
-			],
-			'three parts, no wildcard, has spaces' => [
-				'reference' => 'my dog . and . my cat',
-				'expected'  => false,
-			],
-			'three parts, wildcard in first' => [
-				'reference' => '*.example.com',
-				'expected'  => true,
-			],
-			'three parts, wildcard in second' => [
-				'reference' => 'www.*.com',
-				'expected'  => false,
-			],
-			'three parts, wildcard in third' => [
-				'reference' => 'www.example.*',
-				'expected'  => false,
-			],
-			'three parts, wildcard in first at start with other characters' => [
-				'reference' => '*ww.example.com',
-				'expected'  => false,
-			],
-			'three parts, wildcard in first at end with other characters' => [
-				'reference' => 'ww*.example.com',
-				'expected'  => false,
-			],
-			'three parts, wildcard in first and second' => [
-				'reference' => '*.*.com',
-				'expected'  => false,
-			],
-			'three parts, wildcard in second and last' => [
-				'reference' => 'www.*.*',
-				'expected'  => false,
-			],
-			'three parts, wildcard in first and last' => [
-				'reference' => '*.example.*',
-				'expected'  => false,
-			],
-		];
-	}
-
-	/**
 	 * Tests receiving an exception when an invalid input type is passed as $host.
 	 *
 	 * @dataProvider dataInvalidInputTypeStringable
@@ -540,24 +446,6 @@ final class SslTest extends TestCase {
 	 */
 	public function dataInvalidInputTypeArrayAccess() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
-	}
-
-	/**
-	 * Tests receiving an exception when an invalid input type is passed.
-	 *
-	 * @dataProvider dataInvalidInputTypeStringable
-	 *
-	 * @covers ::verify_reference_name
-	 *
-	 * @param mixed $input Input data.
-	 *
-	 * @return void
-	 */
-	public function testVerifyReferenceNameInvalidInputType($input) {
-		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($reference) must be of type string|Stringable');
-
-		Ssl::verify_reference_name($input);
 	}
 
 	/**

--- a/tests/Ssl/SslTest.php
+++ b/tests/Ssl/SslTest.php
@@ -4,14 +4,13 @@ namespace WpOrg\Requests\Tests\Ssl;
 
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Ssl;
-use WpOrg\Requests\Tests\Fixtures\StringableObject;
-use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\Ssl\SslTestCase;
 use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
  * @coversDefaultClass \WpOrg\Requests\Ssl
  */
-final class SslTest extends TestCase {
+final class SslTest extends SslTestCase {
 
 	/**
 	 * Test handling of matching host and DNS names.
@@ -49,28 +48,6 @@ final class SslTest extends TestCase {
 	public function testMatchViaCertificate($host, $reference, $with_san = true) {
 		$certificate = $this->fakeCertificate($reference, $with_san);
 		$this->assertTrue(Ssl::verify_certificate($host, $certificate));
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function dataMatch() {
-		return [
-			'top-level domain (stringable object)' => [
-				'host'      => new StringableObject('example.com'),
-				'reference' => new StringableObject('example.com'),
-			],
-			'subdomain' => [
-				'host'      => 'test.example.com',
-				'reference' => 'test.example.com',
-			],
-			'subdomain with wildcard reference' => [
-				'host'      => 'test.example.com',
-				'reference' => '*.example.com',
-			],
-		];
 	}
 
 	/**
@@ -147,67 +124,6 @@ final class SslTest extends TestCase {
 	}
 
 	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function dataNoMatch() {
-		return [
-			// Check that we need at least 3 components
-			'not a domain; wildcard reference' => [
-				'host'      => 'com',
-				'reference' => '*',
-			],
-			'domain name; wildcard on TLD as reference' => [
-				'host'      => 'example.com',
-				'reference' => '*.com',
-			],
-
-			// Check that double wildcards don't work
-			'domain name; double wildcard in reference' => [
-				'host'      => 'abc.def.example.com',
-				'reference' => '*.*.example.com',
-			],
-
-			// Check that we only match with the correct number of components
-			'four-level domain; three-level reference' => [
-				'host'      => 'abc.def.example.com',
-				'reference' => 'def.example.com',
-			],
-			'four-level domain; three-level wildcard reference' => [
-				'host'      => 'abc.def.example.com',
-				'reference' => '*.example.com',
-			],
-
-			// Check that the wildcard only works as the full first component
-			'four-level domain; four-level reference, but wildcard not stand-alone' => [
-				'host'      => 'abc.def.example.com',
-				'reference' => 'a*.def.example.com',
-			],
-
-			// Check that wildcards are not allowed for IPs
-			'IP address; wildcard in refence (start)' => [
-				'host'      => '192.168.0.1',
-				'reference' => '*.168.0.1',
-			],
-			'IP address; wildcard in refence (end)' => [
-				'host'      => '192.168.0.1',
-				'reference' => '192.168.0.*',
-			],
-
-			// IP vs named address.
-			'IP address vs named address' => [
-				'host'      => '192.168.0.1',
-				'reference' => '*.example.com',
-			],
-			'Named address vs IP address' => [
-				'host'      => 'example.com',
-				'reference' => '192.168.0.1',
-			],
-		];
-	}
-
-	/**
 	 * Data provider for additional test cases specific to the Ssl::verify_certificate() method.
 	 *
 	 * @return array
@@ -240,38 +156,6 @@ final class SslTest extends TestCase {
 				'with_san'  => 'DNS: example.com, DNS: example.org, DNS: example.info',
 			],
 		];
-	}
-
-	/**
-	 * Test helper to mock a certificate.
-	 *
-	 * @param string      $dnsname  DNS name to match against.
-	 * @param bool|string $with_san Optional. How to generate the fake certificate.
-	 *                              - false:  plain, CN only;
-	 *                              - true:   CN + subjectAltName, alt set to same as CN;
-	 *                              - string: CN + subjectAltName, alt set to string value.
-	 *
-	 * @return array
-	 */
-	private function fakeCertificate($dnsname, $with_san = true) {
-		$certificate = [
-			'subject' => [
-				'CN' => $dnsname,
-			],
-		];
-
-		if ($with_san !== false) {
-			// If SAN is set to true, default it to the dNSName
-			if ($with_san === true) {
-				$with_san = 'DNS: ' . $dnsname;
-			}
-
-			$certificate['extensions'] = [
-				'subjectAltName' => $with_san,
-			];
-		}
-
-		return $certificate;
 	}
 
 	/**

--- a/tests/Ssl/SslTest.php
+++ b/tests/Ssl/SslTest.php
@@ -13,22 +13,6 @@ use WpOrg\Requests\Tests\TypeProviderHelper;
 final class SslTest extends SslTestCase {
 
 	/**
-	 * Test handling of matching host and DNS names.
-	 *
-	 * @dataProvider dataMatch
-	 *
-	 * @covers ::match_domain
-	 *
-	 * @param string $host      Host name to verify.
-	 * @param string $reference DNS name to match against.
-	 *
-	 * @return void
-	 */
-	public function testMatch($host, $reference) {
-		$this->assertTrue(Ssl::match_domain($host, $reference));
-	}
-
-	/**
 	 * Test handling of matching host and DNS names based on certificate.
 	 *
 	 * @dataProvider dataMatch
@@ -83,22 +67,6 @@ final class SslTest extends SslTestCase {
 				'with_san'  => 'example.com, example.net',
 			],
 		];
-	}
-
-	/**
-	 * Test handling of non-matching host and DNS names.
-	 *
-	 * @dataProvider dataNoMatch
-	 *
-	 * @covers ::match_domain
-	 *
-	 * @param string $host      Host name to verify.
-	 * @param string $reference DNS name to match against.
-	 *
-	 * @return void
-	 */
-	public function testNoMatch($host, $reference) {
-		$this->assertFalse(Ssl::match_domain($host, $reference));
 	}
 
 	/**
@@ -330,24 +298,6 @@ final class SslTest extends SslTestCase {
 	 */
 	public function dataInvalidInputTypeArrayAccess() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
-	}
-
-	/**
-	 * Tests receiving an exception when an invalid input type is passed.
-	 *
-	 * @dataProvider dataInvalidInputTypeStringable
-	 *
-	 * @covers ::match_domain
-	 *
-	 * @param mixed $input Input data.
-	 *
-	 * @return void
-	 */
-	public function testMatchDomainInvalidInputType($input) {
-		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($host) must be of type string|Stringable');
-
-		Ssl::match_domain($input, 'reference');
 	}
 
 	/**

--- a/tests/Ssl/SslTestCase.php
+++ b/tests/Ssl/SslTestCase.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Ssl;
+
+use WpOrg\Requests\Tests\Fixtures\StringableObject;
+use WpOrg\Requests\Tests\TestCase;
+
+abstract class SslTestCase extends TestCase {
+
+	/**
+	 * Test helper to mock a certificate.
+	 *
+	 * @param string      $dnsname  DNS name to match against.
+	 * @param bool|string $with_san Optional. How to generate the fake certificate.
+	 *                              - false:  plain, CN only;
+	 *                              - true:   CN + subjectAltName, alt set to same as CN;
+	 *                              - string: CN + subjectAltName, alt set to string value.
+	 *
+	 * @return array
+	 */
+	protected function fakeCertificate($dnsname, $with_san = true) {
+		$certificate = [
+			'subject' => [
+				'CN' => $dnsname,
+			],
+		];
+
+		if ($with_san !== false) {
+			// If SAN is set to true, default it to the dNSName
+			if ($with_san === true) {
+				$with_san = 'DNS: ' . $dnsname;
+			}
+
+			$certificate['extensions'] = [
+				'subjectAltName' => $with_san,
+			];
+		}
+
+		return $certificate;
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataMatch() {
+		return [
+			'top-level domain (stringable object)' => [
+				'host'      => new StringableObject('example.com'),
+				'reference' => new StringableObject('example.com'),
+			],
+			'subdomain' => [
+				'host'      => 'test.example.com',
+				'reference' => 'test.example.com',
+			],
+			'subdomain with wildcard reference' => [
+				'host'      => 'test.example.com',
+				'reference' => '*.example.com',
+			],
+		];
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataNoMatch() {
+		return [
+			// Check that we need at least 3 components
+			'not a domain; wildcard reference' => [
+				'host'      => 'com',
+				'reference' => '*',
+			],
+			'domain name; wildcard on TLD as reference' => [
+				'host'      => 'example.com',
+				'reference' => '*.com',
+			],
+
+			// Check that double wildcards don't work
+			'domain name; double wildcard in reference' => [
+				'host'      => 'abc.def.example.com',
+				'reference' => '*.*.example.com',
+			],
+
+			// Check that we only match with the correct number of components
+			'four-level domain; three-level reference' => [
+				'host'      => 'abc.def.example.com',
+				'reference' => 'def.example.com',
+			],
+			'four-level domain; three-level wildcard reference' => [
+				'host'      => 'abc.def.example.com',
+				'reference' => '*.example.com',
+			],
+
+			// Check that the wildcard only works as the full first component
+			'four-level domain; four-level reference, but wildcard not stand-alone' => [
+				'host'      => 'abc.def.example.com',
+				'reference' => 'a*.def.example.com',
+			],
+
+			// Check that wildcards are not allowed for IPs
+			'IP address; wildcard in refence (start)' => [
+				'host'      => '192.168.0.1',
+				'reference' => '*.168.0.1',
+			],
+			'IP address; wildcard in refence (end)' => [
+				'host'      => '192.168.0.1',
+				'reference' => '192.168.0.*',
+			],
+
+			// IP vs named address.
+			'IP address vs named address' => [
+				'host'      => '192.168.0.1',
+				'reference' => '*.example.com',
+			],
+			'Named address vs IP address' => [
+				'host'      => 'example.com',
+				'reference' => '192.168.0.1',
+			],
+		];
+	}
+}

--- a/tests/Ssl/SslTestCase.php
+++ b/tests/Ssl/SslTestCase.php
@@ -26,7 +26,7 @@ abstract class SslTestCase extends TestCase {
 		];
 
 		if ($with_san !== false) {
-			// If SAN is set to true, default it to the dNSName
+			// If SAN is set to true, default it to the dNSName.
 			if ($with_san === true) {
 				$with_san = 'DNS: ' . $dnsname;
 			}
@@ -68,7 +68,7 @@ abstract class SslTestCase extends TestCase {
 	 */
 	public function dataNoMatch() {
 		return [
-			// Check that we need at least 3 components
+			// Check that we need at least 3 components.
 			'not a domain; wildcard reference' => [
 				'host'      => 'com',
 				'reference' => '*',
@@ -78,13 +78,13 @@ abstract class SslTestCase extends TestCase {
 				'reference' => '*.com',
 			],
 
-			// Check that double wildcards don't work
+			// Check that double wildcards don't work.
 			'domain name; double wildcard in reference' => [
 				'host'      => 'abc.def.example.com',
 				'reference' => '*.*.example.com',
 			],
 
-			// Check that we only match with the correct number of components
+			// Check that we only match with the correct number of components.
 			'four-level domain; three-level reference' => [
 				'host'      => 'abc.def.example.com',
 				'reference' => 'def.example.com',
@@ -94,18 +94,18 @@ abstract class SslTestCase extends TestCase {
 				'reference' => '*.example.com',
 			],
 
-			// Check that the wildcard only works as the full first component
+			// Check that the wildcard only works as the full first component.
 			'four-level domain; four-level reference, but wildcard not stand-alone' => [
 				'host'      => 'abc.def.example.com',
 				'reference' => 'a*.def.example.com',
 			],
 
-			// Check that wildcards are not allowed for IPs
-			'IP address; wildcard in refence (start)' => [
+			// Check that wildcards are not allowed for IPs.
+			'IP address; wildcard in reference (start)' => [
 				'host'      => '192.168.0.1',
 				'reference' => '*.168.0.1',
 			],
-			'IP address; wildcard in refence (end)' => [
+			'IP address; wildcard in reference (end)' => [
 				'host'      => '192.168.0.1',
 				'reference' => '192.168.0.*',
 			],

--- a/tests/Ssl/VerifyCertificateTest.php
+++ b/tests/Ssl/VerifyCertificateTest.php
@@ -8,17 +8,65 @@ use WpOrg\Requests\Tests\Ssl\SslTestCase;
 use WpOrg\Requests\Tests\TypeProviderHelper;
 
 /**
- * @coversDefaultClass \WpOrg\Requests\Ssl
+ * @covers \WpOrg\Requests\Ssl::verify_certificate
  */
-final class SslTest extends SslTestCase {
+final class VerifyCertificateTest extends SslTestCase {
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed as $host.
+	 *
+	 * @dataProvider dataInvalidInputHost
+	 *
+	 * @param mixed $input Input data.
+	 *
+	 * @return void
+	 */
+	public function testInvalidInputHost($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($host) must be of type string|Stringable');
+
+		Ssl::verify_certificate($input, []);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputHost() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
+	}
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed as $cert.
+	 *
+	 * @dataProvider dataInvalidInputCert
+	 *
+	 * @param mixed $input Input data.
+	 *
+	 * @return void
+	 */
+	public function testInvalidInputCert($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #2 ($cert) must be of type array|ArrayAccess');
+
+		Ssl::verify_certificate('host', $input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputCert() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
+	}
 
 	/**
 	 * Test handling of matching host and DNS names based on certificate.
 	 *
 	 * @dataProvider dataMatch
 	 * @dataProvider dataMatchViaCertificate
-	 *
-	 * @covers ::verify_certificate
 	 *
 	 * @param string      $host      Host name to verify.
 	 * @param string      $reference DNS name to match against.
@@ -74,8 +122,6 @@ final class SslTest extends SslTestCase {
 	 *
 	 * @dataProvider dataNoMatch
 	 * @dataProvider dataNoMatchViaCertificate
-	 *
-	 * @covers ::verify_certificate
 	 *
 	 * @param string      $host      Host name to verify.
 	 * @param string      $reference DNS name to match against.
@@ -133,8 +179,6 @@ final class SslTest extends SslTestCase {
 	 * the value of the CN field.
 	 *
 	 * @link https://tools.ietf.org/html/rfc2818#section-3.1
-	 *
-	 * @covers ::verify_certificate
 	 */
 	public function testIgnoreCNWithSAN() {
 		$certificate = $this->fakeCertificate('example.net', 'DNS: example.com');
@@ -146,7 +190,7 @@ final class SslTest extends SslTestCase {
 	/**
 	 * Test handling of non-compliant certificates.
 	 *
-	 * @dataProvider dataVerifyCertificateWithInvalidCertificates
+	 * @dataProvider dataWithInvalidCertificates
 	 *
 	 * @param string $host        Host name to verify.
 	 * @param array  $certificate A (faked) certificate to verify against.
@@ -154,7 +198,7 @@ final class SslTest extends SslTestCase {
 	 *
 	 * @return void
 	 */
-	public function testVerifyCertificateWithInvalidCertificates($host, $certificate, $expected) {
+	public function testWithInvalidCertificates($host, $certificate, $expected) {
 		$this->assertSame($expected, Ssl::verify_certificate($host, $certificate));
 	}
 
@@ -163,7 +207,7 @@ final class SslTest extends SslTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataVerifyCertificateWithInvalidCertificates() {
+	public function dataWithInvalidCertificates() {
 		return [
 			'empty array' => [
 				'host'        => 'example.com',
@@ -253,59 +297,5 @@ final class SslTest extends SslTestCase {
 				'expected'    => false,
 			],
 		];
-	}
-
-	/**
-	 * Tests receiving an exception when an invalid input type is passed as $host.
-	 *
-	 * @dataProvider dataInvalidInputTypeStringable
-	 *
-	 * @covers ::verify_certificate
-	 *
-	 * @param mixed $input Input data.
-	 *
-	 * @return void
-	 */
-	public function testVerifyCertificateInvalidInputHost($input) {
-		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($host) must be of type string|Stringable');
-
-		Ssl::verify_certificate($input, []);
-	}
-
-	/**
-	 * Tests receiving an exception when an invalid input type is passed as $cert.
-	 *
-	 * @dataProvider dataInvalidInputTypeArrayAccess
-	 *
-	 * @covers ::verify_certificate
-	 *
-	 * @param mixed $input Input data.
-	 *
-	 * @return void
-	 */
-	public function testVerifyCertificateInvalidInputCert($input) {
-		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #2 ($cert) must be of type array|ArrayAccess');
-
-		Ssl::verify_certificate('host', $input);
-	}
-
-	/**
-	 * Data Provider.
-	 *
-	 * @return array
-	 */
-	public function dataInvalidInputTypeArrayAccess() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
-	}
-
-	/**
-	 * Data Provider.
-	 *
-	 * @return array
-	 */
-	public function dataInvalidInputTypeStringable() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 }

--- a/tests/Ssl/VerifyReferenceNameTest.php
+++ b/tests/Ssl/VerifyReferenceNameTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Ssl;
+
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Ssl;
+use WpOrg\Requests\Tests\Fixtures\StringableObject;
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
+
+/**
+ * @covers \WpOrg\Requests\Ssl::verify_reference_name
+ */
+final class VerifyReferenceNameTest extends TestCase {
+
+	/**
+	 * Tests receiving an exception when an invalid input type is passed.
+	 *
+	 * @dataProvider dataInvalidInputType
+	 *
+	 * @param mixed $input Input data.
+	 *
+	 * @return void
+	 */
+	public function testInvalidInputType($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #1 ($reference) must be of type string|Stringable');
+
+		Ssl::verify_reference_name($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInputType() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
+	}
+
+	/**
+	 * Test correctly identifying whether a reference name is valid.
+	 *
+	 * @dataProvider dataVerifyReferenceName
+	 *
+	 * @param string $reference Reference name to test.
+	 * @param bool   $expected  Expected function outcome.
+	 *
+	 * @return void
+	 */
+	public function testVerifyReferenceName($reference, $expected) {
+		$this->assertSame($expected, Ssl::verify_reference_name($reference));
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataVerifyReferenceName() {
+		return [
+			'empty string' => [
+				'reference' => '',
+				'expected'  => false,
+			],
+			'one part, no dot' => [
+				'reference' => 'example',
+				'expected'  => true,
+			],
+			'one part, only wildcard' => [
+				'reference' => '*',
+				'expected'  => false,
+			],
+			'two parts, no wildcard' => [
+				'reference' => 'example.com',
+				'expected'  => true,
+			],
+			'two parts, wildcard in first' => [
+				'reference' => '*.com',
+				'expected'  => false,
+			],
+			'two parts, wildcard in last' => [
+				'reference' => 'example.*',
+				'expected'  => false,
+			],
+			'three parts, only dots' => [
+				'reference' => '..',
+				'expected'  => false,
+			],
+			'three parts, no wildcard' => [
+				'reference' => new StringableObject('www.example.com'),
+				'expected'  => true,
+			],
+			'three parts, no wildcard, has spaces' => [
+				'reference' => 'my dog . and . my cat',
+				'expected'  => false,
+			],
+			'three parts, wildcard in first' => [
+				'reference' => '*.example.com',
+				'expected'  => true,
+			],
+			'three parts, wildcard in second' => [
+				'reference' => 'www.*.com',
+				'expected'  => false,
+			],
+			'three parts, wildcard in third' => [
+				'reference' => 'www.example.*',
+				'expected'  => false,
+			],
+			'three parts, wildcard in first at start with other characters' => [
+				'reference' => '*ww.example.com',
+				'expected'  => false,
+			],
+			'three parts, wildcard in first at end with other characters' => [
+				'reference' => 'ww*.example.com',
+				'expected'  => false,
+			],
+			'three parts, wildcard in first and second' => [
+				'reference' => '*.*.com',
+				'expected'  => false,
+			],
+			'three parts, wildcard in second and last' => [
+				'reference' => 'www.*.*',
+				'expected'  => false,
+			],
+			'three parts, wildcard in first and last' => [
+				'reference' => '*.example.*',
+				'expected'  => false,
+			],
+		];
+	}
+}


### PR DESCRIPTION
### SslTest: split verify_reference_name() specific tests to dedicated test class

### Tests: introduce an SslTestCase class

... containing various methods which are used by tests for multiple different methods.

### SslTest: split match_domain() specific tests to dedicated test class

### SslTest: rename to VerifyCertificateTest

... as the remaining tests relate directly to the `verify_certificate()` method.

Including re-ordering the methods in the class to follow the order of the code in the method under test.


Related to #648