### PR TITLE
Utility\CaseInsensitiveDictionaryTest: split up test class

### DIFF
--- a/tests/Utility/CaseInsensitiveDictionary/ArrayAccessTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/ArrayAccessTest.php
@@ -9,7 +9,7 @@ use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 /**
  * @coversDefaultClass \WpOrg\Requests\Utility\CaseInsensitiveDictionary
  */
-class CaseInsensitiveDictionaryTest extends TestCase {
+class ArrayAccessTest extends TestCase {
 
 	/**
 	 * Base data set for array access tests.
@@ -62,6 +62,21 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	];
 
 	/**
+	 * Test trying to create an array entry without a key.
+	 *
+	 * @covers ::offsetSet
+	 *
+	 * @return void
+	 */
+	public function testOffsetSetWithoutKey() {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Object is a dictionary, not a list');
+
+		$dictionary   = new CaseInsensitiveDictionary();
+		$dictionary[] = 'value';
+	}
+
+	/**
 	 * Test array access for entries which exist.
 	 *
 	 * @covers ::offsetExists
@@ -69,14 +84,14 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	 * @covers ::offsetSet
 	 * @covers ::offsetUnset
 	 *
-	 * @dataProvider dataArrayAccessForValidEntries
+	 * @dataProvider dataAccessValidEntries
 	 *
 	 * @param mixed  $key   Item key.
 	 * @param string $value Unused for this test. Item value.
 	 *
 	 * @return void
 	 */
-	public function testArrayAccessForValidEntries($key, $value) {
+	public function testAccessValidEntries($key, $value) {
 		// Initial set up.
 		$dictionary = new CaseInsensitiveDictionary(self::DATASET);
 
@@ -101,7 +116,7 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataArrayAccessForValidEntries() {
+	public function dataAccessValidEntries() {
 		$data = [];
 
 		foreach (self::DATASET_REVERSED as $key => $value) {
@@ -122,7 +137,7 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	/**
 	 * Test array access for an entry which (initially) doesn't exist.
 	 *
-	 * @dataProvider dataArrayAccessForInvalidEntry
+	 * @dataProvider dataAccessInvalidEntry
 	 *
 	 * @covers ::offsetExists
 	 * @covers ::offsetGet
@@ -133,7 +148,7 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function testArrayAccessForInvalidEntry($key) {
+	public function testAccessInvalidEntry($key) {
 		// Initial set up.
 		$dictionary = new CaseInsensitiveDictionary(self::DATASET);
 
@@ -156,25 +171,10 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataArrayAccessForInvalidEntry() {
+	public function dataAccessInvalidEntry() {
 		return [
 			'string key'  => ['Non-existant entry'],
 			'integer key' => [25],
 		];
-	}
-
-	/**
-	 * Test trying to create an array entry without a key.
-	 *
-	 * @covers ::offsetSet
-	 *
-	 * @return void
-	 */
-	public function testOffsetSetWithoutKey() {
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Object is a dictionary, not a list');
-
-		$dictionary   = new CaseInsensitiveDictionary();
-		$dictionary[] = 'value';
 	}
 }

--- a/tests/Utility/CaseInsensitiveDictionary/CaseInsensitiveDictionaryTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/CaseInsensitiveDictionaryTest.php
@@ -62,20 +62,6 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	];
 
 	/**
-	 * Test setting up a dictionary without entries.
-	 *
-	 * @covers ::__construct
-	 *
-	 * @return void
-	 */
-	public function testInitialDictionaryIsEmptyArray() {
-		$dictionary = new CaseInsensitiveDictionary();
-
-		$this->assertIsIterable($dictionary, 'Empty dictionary is not iterable');
-		$this->assertCount(0, $dictionary, 'Empty dictionary has a count not equal to 0');
-	}
-
-	/**
 	 * Test array access for entries which exist.
 	 *
 	 * @covers ::__construct

--- a/tests/Utility/CaseInsensitiveDictionary/CaseInsensitiveDictionaryTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/CaseInsensitiveDictionaryTest.php
@@ -64,7 +64,6 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 	/**
 	 * Test array access for entries which exist.
 	 *
-	 * @covers ::__construct
 	 * @covers ::offsetExists
 	 * @covers ::offsetGet
 	 * @covers ::offsetSet

--- a/tests/Utility/CaseInsensitiveDictionary/CaseInsensitiveDictionaryTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/CaseInsensitiveDictionaryTest.php
@@ -192,24 +192,4 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 		$dictionary   = new CaseInsensitiveDictionary();
 		$dictionary[] = 'value';
 	}
-
-	/**
-	 * Test iterating over a dictionary.
-	 *
-	 * @covers ::getIterator
-	 *
-	 * @return void
-	 */
-	public function testGetIterator() {
-		// Initial set up.
-		$dictionary = new CaseInsensitiveDictionary(self::DATASET);
-
-		$this->assertCount(8, $dictionary, 'Dictionary is not countable');
-
-		// If foreach() works and actually enters the loop, we're good.
-		foreach ($dictionary as $key => $value) {
-			$this->assertTrue(true, 'Dictionary is not iterable');
-			break;
-		}
-	}
 }

--- a/tests/Utility/CaseInsensitiveDictionary/CaseInsensitiveDictionaryTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/CaseInsensitiveDictionaryTest.php
@@ -212,29 +212,4 @@ class CaseInsensitiveDictionaryTest extends TestCase {
 			break;
 		}
 	}
-
-	/**
-	 * Test retrieving all data as recorded in the dictionary.
-	 *
-	 * Take note of the key changes!
-	 *
-	 * @covers ::getAll
-	 *
-	 * @return void
-	 */
-	public function testGetAll() {
-		$expected = [
-			'upper case'  => 'Uppercase key',
-			'proper case' => 'First char in caps in key',
-			'lower case'  => 'Lowercase key',
-			''            => 'Null key will be converted to empty string',
-			0             => 'false key will become integer 0 key',
-			1             => 'true key will become integer 1 key',
-			5             => 'Float key will be converted to integer key (cut off)',
-			100           => 'Explicit integer numeric key',
-		];
-
-		$dictionary = new CaseInsensitiveDictionary(self::DATASET);
-		$this->assertSame($expected, $dictionary->getAll());
-	}
 }

--- a/tests/Utility/CaseInsensitiveDictionary/ConstructorTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/ConstructorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary;
+
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
+
+/**
+ * @covers \WpOrg\Requests\Utility\CaseInsensitiveDictionary::__construct
+ */
+class ConstructorTest extends TestCase {
+
+	/**
+	 * Test setting up a dictionary without entries.
+	 *
+	 * @return void
+	 */
+	public function testInitialDictionaryIsEmptyArray() {
+		$dictionary = new CaseInsensitiveDictionary();
+
+		$this->assertIsIterable($dictionary, 'Empty dictionary is not iterable');
+		$this->assertCount(0, $dictionary, 'Empty dictionary has a count not equal to 0');
+	}
+}

--- a/tests/Utility/CaseInsensitiveDictionary/ConstructorTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/ConstructorTest.php
@@ -3,6 +3,7 @@
 namespace WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary;
 
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary\CaseInsensitiveDictionaryTest;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 
 /**
@@ -20,5 +21,22 @@ class ConstructorTest extends TestCase {
 
 		$this->assertIsIterable($dictionary, 'Empty dictionary is not iterable');
 		$this->assertCount(0, $dictionary, 'Empty dictionary has a count not equal to 0');
+	}
+
+	/**
+	 * Test setting up a dictionary with entries.
+	 *
+	 * @return void
+	 */
+	public function testInitialDictionaryHasEntries() {
+		$dictionary = new CaseInsensitiveDictionary(CaseInsensitiveDictionaryTest::DATASET);
+		$property   = $this->getPropertyValue($dictionary, 'data');
+
+		$this->assertIsArray($property, 'Dictionary is not an array');
+		$this->assertCount(
+			count(CaseInsensitiveDictionaryTest::DATASET),
+			$property,
+			'Entry count for initial dictionary does not match expectation'
+		);
 	}
 }

--- a/tests/Utility/CaseInsensitiveDictionary/ConstructorTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/ConstructorTest.php
@@ -3,7 +3,7 @@
 namespace WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary;
 
 use WpOrg\Requests\Tests\TestCase;
-use WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary\CaseInsensitiveDictionaryTest;
+use WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary\ArrayAccessTest;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 
 /**
@@ -29,12 +29,12 @@ class ConstructorTest extends TestCase {
 	 * @return void
 	 */
 	public function testInitialDictionaryHasEntries() {
-		$dictionary = new CaseInsensitiveDictionary(CaseInsensitiveDictionaryTest::DATASET);
+		$dictionary = new CaseInsensitiveDictionary(ArrayAccessTest::DATASET);
 		$property   = $this->getPropertyValue($dictionary, 'data');
 
 		$this->assertIsArray($property, 'Dictionary is not an array');
 		$this->assertCount(
-			count(CaseInsensitiveDictionaryTest::DATASET),
+			count(ArrayAccessTest::DATASET),
 			$property,
 			'Entry count for initial dictionary does not match expectation'
 		);

--- a/tests/Utility/CaseInsensitiveDictionary/GetAllTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/GetAllTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary;
+
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
+
+/**
+ * @covers \WpOrg\Requests\Utility\CaseInsensitiveDictionary::getAll
+ */
+class GetAllTest extends TestCase {
+
+	/**
+	 * Base data set for array access tests.
+	 *
+	 * @var array
+	 */
+	const DATASET = [
+		'UPPER CASE'  => 'Uppercase key',
+		'Proper Case' => 'First char in caps in key',
+		'lower case'  => 'Lowercase key',
+		null          => 'Null key will be converted to empty string',
+		false         => 'false key will become integer 0 key',
+		true          => 'true key will become integer 1 key',
+		5.0           => 'Float key will be converted to integer key (cut off)',
+		100           => 'Explicit integer numeric key',
+	];
+
+	/**
+	 * Test retrieving all data as recorded in the dictionary.
+	 *
+	 * Take note of the key changes!
+	 *
+	 * @return void
+	 */
+	public function testGetAll() {
+		$expected = [
+			'upper case'  => 'Uppercase key',
+			'proper case' => 'First char in caps in key',
+			'lower case'  => 'Lowercase key',
+			''            => 'Null key will be converted to empty string',
+			0             => 'false key will become integer 0 key',
+			1             => 'true key will become integer 1 key',
+			5             => 'Float key will be converted to integer key (cut off)',
+			100           => 'Explicit integer numeric key',
+		];
+
+		$dictionary = new CaseInsensitiveDictionary(self::DATASET);
+		$this->assertSame($expected, $dictionary->getAll());
+	}
+}

--- a/tests/Utility/CaseInsensitiveDictionary/GetIteratorTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/GetIteratorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary;
+
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary\CaseInsensitiveDictionaryTest;
+use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
+
+/**
+ * @covers \WpOrg\Requests\Utility\CaseInsensitiveDictionary::getIterator
+ */
+class GetIteratorTest extends TestCase {
+
+	/**
+	 * Test iterating over a dictionary.
+	 *
+	 * @return void
+	 */
+	public function testGetIterator() {
+		// Initial set up.
+		$dictionary = new CaseInsensitiveDictionary(CaseInsensitiveDictionaryTest::DATASET);
+
+		$this->assertCount(8, $dictionary, 'Dictionary is not countable');
+
+		// If foreach() works and actually enters the loop, we're good.
+		foreach ($dictionary as $key => $value) {
+			$this->assertTrue(true, 'Dictionary is not iterable');
+			break;
+		}
+	}
+}

--- a/tests/Utility/CaseInsensitiveDictionary/GetIteratorTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/GetIteratorTest.php
@@ -3,7 +3,7 @@
 namespace WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary;
 
 use WpOrg\Requests\Tests\TestCase;
-use WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary\CaseInsensitiveDictionaryTest;
+use WpOrg\Requests\Tests\Utility\CaseInsensitiveDictionary\ArrayAccessTest;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 
 /**
@@ -18,7 +18,7 @@ class GetIteratorTest extends TestCase {
 	 */
 	public function testGetIterator() {
 		// Initial set up.
-		$dictionary = new CaseInsensitiveDictionary(CaseInsensitiveDictionaryTest::DATASET);
+		$dictionary = new CaseInsensitiveDictionary(ArrayAccessTest::DATASET);
 
 		$this->assertCount(8, $dictionary, 'Dictionary is not countable');
 


### PR DESCRIPTION
### Utility\CaseInsensitiveDictionaryTest: split getAll() specific tests to dedicated test class

### Utility\CaseInsensitiveDictionaryTest: split getIterator() specific tests to dedicated test class

### Utility\CaseInsensitiveDictionaryTest: split constructor specific tests to dedicated test class

### Utility\CaseInsensitiveDictionary\ConstructorTest: add extra test specifically for the constructor

... to make the `Utility\CaseInsensitiveDictionary\ConstructorTest` feature complete and independent of the array access tests.

### Utility\CaseInsensitiveDictionary\CaseInsensitiveDictionaryTest:rename to `ArrayAccessTest`

... as the remaining tests all relate directly to the array access methods.


Related to #648