### PR TITLE
Cookie\Jar tests: stabilize and improve

### DIFF
--- a/tests/Cookie/Jar/ArrayAccessTest.php
+++ b/tests/Cookie/Jar/ArrayAccessTest.php
@@ -23,18 +23,25 @@ final class ArrayAccessTest extends TestCase {
 				'requests-testcookie' => 'testvalue',
 			]
 		);
-		$this->assertEquals($jar1, $jar2);
+
+		$this->assertEquals($jar1, $jar2, 'Jar objects are not equivalent of each other');
+		$this->assertSame(
+			$jar1['requests-testcookie'],
+			$jar2['requests-testcookie'],
+			'Array access did not yield the same value for the requested key on both objects'
+		);
 	}
 
 	public function testJarUnsetter() {
 		$jar                        = new Jar();
 		$jar['requests-testcookie'] = 'testvalue';
 
-		$this->assertSame('testvalue', $jar['requests-testcookie']);
+		$this->assertSame('testvalue', $jar['requests-testcookie'], 'Initial value was not set to expected value');
 
 		unset($jar['requests-testcookie']);
-		$this->assertEmpty($jar['requests-testcookie']);
-		$this->assertFalse(isset($jar['requests-testcookie']));
+
+		$this->assertArrayNotHasKey('requests-testcookie', $jar, 'Jar array index "requests-testcookie" still exists after unsetting');
+		$this->assertNull($jar['requests-testcookie'], 'Array access on unset key does not yield null');
 	}
 
 	public function testJarAsList() {

--- a/tests/Cookie/Jar/GetIteratorTest.php
+++ b/tests/Cookie/Jar/GetIteratorTest.php
@@ -18,7 +18,7 @@ final class GetIteratorTest extends TestCase {
 		$jar     = new Jar($cookies);
 
 		foreach ($jar as $key => $value) {
-			$this->assertSame($cookies[$key], $value);
+			$this->assertSame($cookies[$key], $value, "Value for $key does not match expectation during iteration");
 		}
 	}
 }

--- a/tests/Cookie/Jar/JarTest.php
+++ b/tests/Cookie/Jar/JarTest.php
@@ -18,6 +18,13 @@ use WpOrg\Requests\Tests\TestCase;
  */
 final class JarTest extends TestCase {
 
+	public function testSendingCookieWithEmptyJar() {
+		$cookies = new Jar();
+		$data    = $this->setCookieRequest($cookies);
+
+		$this->assertCount(0, $data);
+	}
+
 	public function testSendingCookieWithJar() {
 		$cookies = new Jar(
 			[

--- a/tests/Cookie/Jar/JarTest.php
+++ b/tests/Cookie/Jar/JarTest.php
@@ -5,6 +5,7 @@ namespace WpOrg\Requests\Tests\Cookie\Jar;
 use WpOrg\Requests\Cookie;
 use WpOrg\Requests\Cookie\Jar;
 use WpOrg\Requests\Requests;
+use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\TestCase;
 
 /**
@@ -25,8 +26,8 @@ final class JarTest extends TestCase {
 		);
 		$data    = $this->setCookieRequest($cookies);
 
-		$this->assertArrayHasKey('requests-testcookie1', $data);
-		$this->assertSame('testvalue1', $data['requests-testcookie1']);
+		$this->assertArrayHasKey('requests-testcookie1', $data, 'Key "requests-testcookie1" does not exist in the array');
+		$this->assertSame('testvalue1', $data['requests-testcookie1'], 'Value for cookie does not match expectation');
 	}
 
 	public function testSendingMultipleCookiesWithJar() {
@@ -38,11 +39,11 @@ final class JarTest extends TestCase {
 		);
 		$data    = $this->setCookieRequest($cookies);
 
-		$this->assertArrayHasKey('requests-testcookie1', $data);
-		$this->assertSame('testvalue1', $data['requests-testcookie1']);
+		$this->assertArrayHasKey('requests-testcookie1', $data, 'Key "requests-testcookie1" does not exist in the array');
+		$this->assertSame('testvalue1', $data['requests-testcookie1'], 'Value for cookie 1 does not match expectation');
 
-		$this->assertArrayHasKey('requests-testcookie2', $data);
-		$this->assertSame('testvalue2', $data['requests-testcookie2']);
+		$this->assertArrayHasKey('requests-testcookie2', $data, 'Key "requests-testcookie2" does not exist in the array');
+		$this->assertSame('testvalue2', $data['requests-testcookie2'], 'Value for cookie 2 does not match expectation');
 	}
 
 	public function testSendingPrebakedCookie() {
@@ -53,8 +54,8 @@ final class JarTest extends TestCase {
 		);
 		$data    = $this->setCookieRequest($cookies);
 
-		$this->assertArrayHasKey('requests-testcookie', $data);
-		$this->assertSame('testvalue', $data['requests-testcookie']);
+		$this->assertArrayHasKey('requests-testcookie', $data, 'Key "requests-testcookie" does not exist in the array');
+		$this->assertSame('testvalue', $data['requests-testcookie'], 'Value for cookie does not match expectation');
 	}
 
 	/**
@@ -70,9 +71,13 @@ final class JarTest extends TestCase {
 		];
 		$response = Requests::get(httpbin('/cookies/set'), [], $options);
 
+		$this->assertInstanceOf(Response::class, $response, 'GET request did not return a Response object');
 		$data = json_decode($response->body, true);
-		$this->assertIsArray($data);
-		$this->assertArrayHasKey('cookies', $data);
+
+		$this->assertIsArray($data, 'Decoded response is not an array');
+		$this->assertArrayHasKey('cookies', $data, 'Decoded response array does not contain the key "cookie"');
+		$this->assertIsArray($data['cookies'], '"Cookie" key in the decoded response is not an array');
+
 		return $data['cookies'];
 	}
 }


### PR DESCRIPTION
### Cookie\Jar\GetIteratorTest: add message param to assertion

... as the same assertion is called multiple times.

### Cookie\Jar\ArrayAccessTest: various minor improvements

* Add `$message` parameter to all assertions.
* Add extra assertion to the `testCookieJarSetter()` test verifying the cookie value was set correctly.
    As it was, if the value setting failed on both objects, the test would still have passed, which is not the intention.
* Use more specific assertions in the `testCookieJarUnsetter()` test.
    The value returned for array access to an unset value was tested with `assertEmpty()`. In reality, the code is specifically set to return `null` for unset/not set values, so let's make the test more precise and test for `null`.
    Along the same lines, we can use the more specific `assertArrayNotHasKey()` assertion instead of doing an `isset()` within an assertion.

### Cookie\Jar\JarTest: stabilize tests

* Add `$message` parameter to all assertions.
* Add an additional assertion verifying that the request returned a `Response` instance.
* Add an additional assertion checking that `$data['cookies']` is actually an array to the `setCookieRequest()` test helper method.

### Cookie\Jar\JarTest: add extra test

.. to increase path coverage.

Related to #497