### PR TITLE
Cookie\UriMatchesTest: improve and stabilize

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -242,4 +242,9 @@
 		<exclude-pattern>/tests/*\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Using var_export() in test code is fine. -->
+	<rule ref="WordPress.PHP.DevelopmentFunctions.error_log_var_export">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/tests/Cookie/UriMatchesTest.php
+++ b/tests/Cookie/UriMatchesTest.php
@@ -13,19 +13,41 @@ use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 final class UriMatchesTest extends TestCase {
 
 	/**
+	 * Verify uri_matches() correctly identifies exact URI matches.
+	 *
 	 * @dataProvider dataUrlMatch
+	 *
+	 * @param string $domain         Base domain.
+	 * @param string $path           Path to be appended to the domain.
+	 * @param string $check          The URI to verify for a match.
+	 * @param bool   $matches        The expected function return value for an exact match.
+	 * @param bool   $domain_matches The expected function return value for a domain only match.
+	 *
+	 * @return void
 	 */
 	public function testUrlExactMatch($domain, $path, $check, $matches, $domain_matches) {
 		$attributes           = new CaseInsensitiveDictionary();
 		$attributes['domain'] = $domain;
 		$attributes['path']   = $path;
-		$check                = new Iri($check);
-		$cookie               = new Cookie('requests-testcookie', 'testvalue', $attributes);
+
+		$check  = new Iri($check);
+		$cookie = new Cookie('requests-testcookie', 'testvalue', $attributes);
+
 		$this->assertSame($matches, $cookie->uri_matches($check));
 	}
 
 	/**
+	 * Verify uri_matches() correctly identifies URI matches disregarding subdomains.
+	 *
 	 * @dataProvider dataUrlMatch
+	 *
+	 * @param string $domain         Base domain.
+	 * @param string $path           Path to be appended to the domain.
+	 * @param string $check          The URI to verify for a match.
+	 * @param bool   $matches        The expected function return value for an exact match.
+	 * @param bool   $domain_matches The expected function return value for a domain only match.
+	 *
+	 * @return void
 	 */
 	public function testUrlMatch($domain, $path, $check, $matches, $domain_matches) {
 		$attributes           = new CaseInsensitiveDictionary();
@@ -34,8 +56,10 @@ final class UriMatchesTest extends TestCase {
 		$flags                = [
 			'host-only' => false,
 		];
-		$check                = new Iri($check);
-		$cookie               = new Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
+
+		$check  = new Iri($check);
+		$cookie = new Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
+
 		$this->assertSame($domain_matches, $cookie->uri_matches($check));
 	}
 

--- a/tests/Cookie/UriMatchesTest.php
+++ b/tests/Cookie/UriMatchesTest.php
@@ -46,28 +46,112 @@ final class UriMatchesTest extends TestCase {
 	 */
 	public function dataUrlMatch() {
 		return [
-			// Domain handling
-			['example.com', '/', 'http://example.com/', true, true],
-			['example.com', '/', 'http://www.example.com/', false, true],
-			['example.com', '/', 'http://example.net/', false, false],
-			['example.com', '/', 'http://www.example.net/', false, false],
+			// Domain handling.
+			'Domain handling: same domain name, same TLD' => [
+				'domain'         => 'example.com',
+				'path'           => '/',
+				'check'          => 'http://example.com/',
+				'matched'        => true,
+				'domain_matches' => true,
+			],
+			'Domain handling: same domain name, same TLD, different subdomain' => [
+				'domain'         => 'example.com',
+				'path'           => '/',
+				'check'          => 'http://www.example.com/',
+				'matched'        => false,
+				'domain_matches' => true,
+			],
+			'Domain handling: same domain name, different TLD' => [
+				'domain'         => 'example.com',
+				'path'           => '/',
+				'check'          => 'http://example.net/',
+				'matched'        => false,
+				'domain_matches' => false,
+			],
+			'Domain handling: same domain name, different TLD, different subdomain' => [
+				'domain'         => 'example.com',
+				'path'           => '/',
+				'check'          => 'http://www.example.net/',
+				'matched'        => false,
+				'domain_matches' => false,
+			],
 
-			// /test
-			['example.com', '/test', 'http://example.com/', false, false],
-			['example.com', '/test', 'http://www.example.com/', false, false],
+			// Path handling - /test (no trailing slash).
+			'Path handling "/test": same domain name, same TLD, URI provided without path' => [
+				'domain'         => 'example.com',
+				'path'           => '/test',
+				'check'          => 'http://example.com/',
+				'matched'        => false,
+				'domain_matches' => false,
+			],
+			'Path handling "/test": same domain name, same TLD, different subdomain, URI provided without path' => [
+				'domain'         => 'example.com',
+				'path'           => '/test',
+				'check'          => 'http://www.example.com/',
+				'matched'        => false,
+				'domain_matches' => false,
+			],
 
-			['example.com', '/test', 'http://example.com/test', true, true],
-			['example.com', '/test', 'http://www.example.com/test', false, true],
+			'Path handling "/test": same domain name, same TLD, URI provided including path' => [
+				'domain'         => 'example.com',
+				'path'           => '/test',
+				'check'          => 'http://example.com/test',
+				'matched'        => true,
+				'domain_matches' => true,
+			],
+			'Path handling "/test": same domain name, same TLD, different subdomain, URI provided including path' => [
+				'domain'         => 'example.com',
+				'path'           => '/test',
+				'check'          => 'http://www.example.com/test',
+				'matched'        => false,
+				'domain_matches' => true,
+			],
 
-			['example.com', '/test', 'http://example.com/testing', false, false],
-			['example.com', '/test', 'http://www.example.com/testing', false, false],
+			'Path handling "/test": same domain name, same TLD, different path' => [
+				'domain'         => 'example.com',
+				'path'           => '/test',
+				'check'          => 'http://example.com/testing',
+				'matched'        => false,
+				'domain_matches' => false,
+			],
+			'Path handling "/test": same domain name, same TLD, different subdomain, different path' => [
+				'domain'         => 'example.com',
+				'path'           => '/test',
+				'check'          => 'http://www.example.com/testing',
+				'matched'        => false,
+				'domain_matches' => false,
+			],
 
-			['example.com', '/test', 'http://example.com/test/', true, true],
-			['example.com', '/test', 'http://www.example.com/test/', false, true],
+			'Path handling "/test": same domain name, same TLD, URI provided including path with trailing slash' => [
+				'domain'         => 'example.com',
+				'path'           => '/test',
+				'check'          => 'http://example.com/test/',
+				'matched'        => true,
+				'domain_matches' => true,
+			],
+			'Path handling "/test": same domain name, same TLD, different subdomain, URI provided including path with trailing slash' => [
+				'domain'         => 'example.com',
+				'path'           => '/test',
+				'check'          => 'http://www.example.com/test/',
+				'matched'        => false,
+				'domain_matches' => true,
+			],
 
-			// /test/
-			['example.com', '/test/', 'http://example.com/', false, false],
-			['example.com', '/test/', 'http://www.example.com/', false, false],
+			// Path handling - /test/ (with trailing slash).
+			'Path handling "/test/" (incl trailing slash): same domain name, same TLD, URI provided without path' => [
+				'domain'         => 'example.com',
+				'path'           => '/test/',
+				'check'          => 'http://example.com/',
+				'matched'        => false,
+				'domain_matches' => false,
+			],
+			'Path handling "/test/" (incl trailing slash): same domain name, same TLD, different subdomain, URI provided without path' => [
+				'domain'         => 'example.com',
+				'path'           => '/test/',
+				'check'          => 'http://www.example.com/',
+				'matched'        => false,
+				'domain_matches' => false,
+			],
 		];
 	}
 

--- a/tests/Cookie/UriMatchesTest.php
+++ b/tests/Cookie/UriMatchesTest.php
@@ -242,14 +242,35 @@ final class UriMatchesTest extends TestCase {
 	 * Cookies parsed from headers internally in Requests will always have a
 	 * domain/path set, but those created manually will not. Manual cookies
 	 * should be regarded as "global" cookies (that is, set for `.`).
+	 *
+	 * @dataProvider dataManuallySetCookie
+	 *
+	 * @param string $url The URL to verify for a match.
+	 *
+	 * @return void
 	 */
-	public function testManuallySetCookie() {
+	public function testManuallySetCookie($url) {
 		$cookie = new Cookie('requests-testcookie', 'testvalue');
-		$this->assertTrue($cookie->uri_matches(new Iri('http://example.com/')));
-		$this->assertTrue($cookie->uri_matches(new Iri('http://example.com/test')));
-		$this->assertTrue($cookie->uri_matches(new Iri('http://example.com/test/')));
-		$this->assertTrue($cookie->uri_matches(new Iri('http://example.net/')));
-		$this->assertTrue($cookie->uri_matches(new Iri('http://example.net/test')));
-		$this->assertTrue($cookie->uri_matches(new Iri('http://example.net/test/')));
+		$iri    = new Iri($url);
+
+		$this->assertTrue($cookie->uri_matches($iri));
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataManuallySetCookie() {
+		$urls = [
+			'http://example.com/',
+			'http://example.com/test',
+			'http://example.com/test/',
+			'http://example.net/',
+			'http://example.net/test',
+			'http://example.net/test/',
+		];
+
+		return $this->textArrayToDataprovider($urls);
 	}
 }

--- a/tests/Cookie/UriMatchesTest.php
+++ b/tests/Cookie/UriMatchesTest.php
@@ -263,6 +263,7 @@ final class UriMatchesTest extends TestCase {
 	 */
 	public function dataManuallySetCookie() {
 		$urls = [
+			'http://example.com',
 			'http://example.com/',
 			'http://example.com/test',
 			'http://example.com/test/',

--- a/tests/Cookie/UriMatchesTest.php
+++ b/tests/Cookie/UriMatchesTest.php
@@ -179,22 +179,61 @@ final class UriMatchesTest extends TestCase {
 		];
 	}
 
-	public function testUrlMatchSecure() {
+	/**
+	 * Verify identifying URI matches correctly when the secure attribute is set.
+	 *
+	 * @dataProvider dataUrlMatchSecure
+	 *
+	 * @param bool   $secure   Value for the secure attribute.
+	 * @param string $scheme   Which scheme to use in the check.
+	 * @param bool   $expected The expected function return value.
+	 *
+	 * @return void
+	 */
+	public function testUrlMatchSecure($secure, $scheme, $expected) {
 		$attributes           = new CaseInsensitiveDictionary();
 		$attributes['domain'] = 'example.com';
 		$attributes['path']   = '/';
-		$attributes['secure'] = true;
+		$attributes['secure'] = $secure;
 		$flags                = [
 			'host-only' => false,
 		];
 		$cookie               = new Cookie('requests-testcookie', 'testvalue', $attributes, $flags);
 
-		$this->assertTrue($cookie->uri_matches(new Iri('https://example.com/')));
-		$this->assertFalse($cookie->uri_matches(new Iri('http://example.com/')));
+		$this->assertSame($expected, $cookie->uri_matches(new Iri($scheme . '://example.com/')), 'Expectation for exact match failed');
 
-		// Double-check host-only
-		$this->assertTrue($cookie->uri_matches(new Iri('https://www.example.com/')));
-		$this->assertFalse($cookie->uri_matches(new Iri('http://www.example.com/')));
+		// Double-check host-only.
+		$this->assertSame($expected, $cookie->uri_matches(new Iri($scheme . '://www.example.com/')), 'Expectation for domain only match failed');
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataUrlMatchSecure() {
+		return [
+			'Secure matching: off, scheme: http' => [
+				'secure'    => false,
+				'scheme'    => 'http',
+				'expected'  => true,
+			],
+			'Secure matching: off, scheme: https' => [
+				'secure'    => false,
+				'scheme'    => 'https',
+				'expected'  => true,
+			],
+			'Secure matching: on, scheme: http' => [
+				'secure'    => true,
+				'scheme'    => 'http',
+				'expected'  => false,
+			],
+			'Secure matching: on, scheme: https' => [
+				'secure'    => true,
+				'scheme'    => 'https',
+				'expected'  => true,
+			],
+		];
 	}
 
 	/**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace WpOrg\Requests\Tests;
 
+use Exception;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TypeProviderHelper;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase as Polyfill_TestCase;
@@ -42,6 +43,37 @@ abstract class TestCase extends Polyfill_TestCase {
 		foreach (Requests::DEFAULT_TRANSPORTS as $transport) {
 			$name        = substr($transport, (strrpos($transport, '\\') + 1));
 			$data[$name] = [$transport];
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Helper function to convert a single-level array containing text strings to a named data provider.
+	 *
+	 * @param string[] $input Input array.
+	 *
+	 * @return array[] Array which is usable as a test data provider with named data sets.
+	 */
+	public function textArrayToDataprovider($input) {
+		$data = [];
+		foreach ($input as $value) {
+			if (!is_string($value)) {
+				throw new Exception(
+					sprintf(
+						'All values in the input array should be text strings. Fix the input data. Received: %s',
+						var_export($value, true)
+					)
+				);
+			}
+
+			if (isset($data[$value])) {
+				throw new Exception(
+					"Attempting to add a duplicate data set for value $value to the data provider. Fix the input data."
+				);
+			}
+
+			$data[$value] = [$value];
 		}
 
 		return $data;


### PR DESCRIPTION
### TestCase: add helper function to create a data provider from a simple array

Helper function to convert a simple, single-level text array to a data provider with named test cases, where the value of the test case is the same as the name of the test case.

Includes adding an exception to the PHPCS ruleset for test code.

### Cookie\UriMatchesTest::testUrlMatch*(): use named data provider

This commit:
* Adds descriptive names to each of the cases being tested via the data provider.
* Adds keys to the parameters passed for each test case to make it easier to understand the test case.
* Improves the inline documentation in the data provider.

### Cookie\UriMatchesTest::testUrlMatch*(): minor documentation and readability improvements

### Cookie\UriMatchesTest::testUrlMatchSecure(): improve test

Refactor the test to use a data provider and cover all possible situations.

Includes:
* Adding the `$message` parameter to assertions.
* Adding a docblock to the test.

### Cookie\UriMatchesTest::testUrlMatchManuallySet(): refactor to data provider

### Cookie\UriMatchesTest::testUrlMatchManuallySet(): add extra test case

Related to #497