### PR TITLE
GH Actions/test: add build against minimum supported PHP version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
       # Keys:
       # - coverage: Whether to run the tests with code coverage.
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.2']
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.2']
         coverage: [false]
 
         include:
-          # Run code coverage on high/low PHP.
-          - php: '5.6'
+          # Run code coverage on low/high PHP.
+          - php: '5.6.20'
             coverage: true
           - php: '8.1'
             coverage: true


### PR DESCRIPTION
While it would be [exceedingly rare](https://w3techs.com/technologies/details/pl-php/5.6) for anyone to still be running PHP ~~5.6.0~~ 5.6.20, I'm proposing to add a build against that PHP version - which is the official minimum supported version for Requests - to:
1. Validate that things as they are actually work against that official minimum supported version.
2. Safeguard against some known edge case bugs in PHP (for which additional tests will be added).
3. Inform us if the minimum supported patch version of PHP should be upped.