### PR TITLE
Tests: add dedicated tests for the Response::is_redirect() method

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -108,7 +108,9 @@ class Response {
 	 */
 	public function is_redirect() {
 		$code = $this->status_code;
-		return in_array($code, [300, 301, 302, 303, 307], true) || $code > 307 && $code < 400;
+		return is_int($code)
+			&& (in_array($code, [300, 301, 302, 303, 307], true)
+				|| ($code > 307 && $code < 400));
 	}
 
 	/**

--- a/tests/Response/IsRedirectTest.php
+++ b/tests/Response/IsRedirectTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Response;
+
+use WpOrg\Requests\Response;
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
+
+/**
+ * @covers \WpOrg\Requests\Response::is_redirect
+ */
+final class IsRedirectTest extends TestCase {
+
+	/**
+	 * Verify a redirection status code is identified correctly.
+	 *
+	 * @dataProvider dataIsRedirect
+	 *
+	 * @param int $code Status code.
+	 *
+	 * @return void
+	 */
+	public function testIsRedirect($code) {
+		$response              = new Response();
+		$response->status_code = $code;
+
+		$this->assertTrue($response->is_redirect());
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataIsRedirect() {
+		$data = [];
+
+		$codes = [300, 301, 302, 303];
+		foreach ($codes as $code) {
+			$data['Status code: ' . $code] = [$code];
+		}
+
+		$codes = range(307, 399, 1);
+		foreach ($codes as $code) {
+			$data['Status code: ' . $code] = [$code];
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Verify a non-redirection status code is identified correctly.
+	 *
+	 * @dataProvider dataNotRedirect
+	 *
+	 * @param int $code Status code.
+	 *
+	 * @return void
+	 */
+	public function testNotRedirect($code) {
+		$response              = new Response();
+		$response->status_code = $code;
+
+		$this->assertFalse($response->is_redirect());
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataNotRedirect() {
+		$data = [];
+
+		$data['Non-blocking request: status code: false (default value)'] = [false];
+
+		$codes = range(100, 299, 1);
+		foreach ($codes as $code) {
+			$data['Status code: ' . $code] = [$code];
+		}
+
+		$codes = [304, 305, 306];
+		foreach ($codes as $code) {
+			$data['Status code: ' . $code] = [$code];
+		}
+
+		$codes = range(400, 599, 1);
+		foreach ($codes as $code) {
+			$data['Status code: ' . $code] = [$code];
+		}
+
+		$except   = TypeProviderHelper::GROUP_INT;
+		$except[] = 'boolean false'; // No need to double test `false`.
+		$invalid  = TypeProviderHelper::getAllExcept($except);
+		foreach ($invalid as $key => $type) {
+			$data['Invalid status code: ' . $key] = [$type['input']];
+		}
+
+		return $data;
+	}
+}


### PR DESCRIPTION
Includes adding some defensive coding to the `Response::is_redirect()` method as there is no safeguard against the `$status_code` being set to an unsupported type as the property is untyped and `public`.