### PR TITLE
PHP 8.2 | Transport\BaseTestCase: explicitly declare all properties

### DIFF
--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -19,6 +19,8 @@ abstract class BaseTestCase extends TestCase {
 
 	protected $skip_https = false;
 
+	protected $completed = [];
+
 	public function set_up() {
 		// Intermediary variable $test_method. This can be simplified (removed) once the minimum supported PHP version is 7.0 or higher.
 		$test_method = [$this->transport, 'test'];
@@ -34,6 +36,11 @@ abstract class BaseTestCase extends TestCase {
 		if (!$ssl_supported) {
 			$this->skip_https = true;
 		}
+	}
+
+	public function tear_down() {
+		// Reset property value after each test.
+		$this->completed = [];
 	}
 
 	protected function getOptions($other = []) {
@@ -996,7 +1003,6 @@ abstract class BaseTestCase extends TestCase {
 		$responses       = Requests::request_multiple($requests, $this->getOptions($options));
 
 		$this->assertSame($this->completed, $responses);
-		$this->completed = [];
 	}
 
 	public function testMultipleUsingCallbackAndFailure() {
@@ -1018,7 +1024,6 @@ abstract class BaseTestCase extends TestCase {
 		$responses       = Requests::request_multiple($requests, $this->getOptions($options));
 
 		$this->assertSame($this->completed, $responses);
-		$this->completed = [];
 	}
 
 	public function completeCallback($response, $key) {


### PR DESCRIPTION
Dynamic (non-explicitly declared) property usage will be deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In this case, the `$completed` property is referenced multiple times throughout this class, so falls in the "known property" category.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties
