### PR TITLE
GH Actions: run lint and tests against PHP 8.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,10 @@ jobs:
     strategy:
       matrix:
         # Lint against the high/low versions of each PHP major.
-        php: ['5.6', '7.0', '7.4', '8.0', '8.1']
-        experimental: [false]
+        php: ['5.6', '7.0', '7.4', '8.0', '8.1', '8.2']
 
     name: "Lint: PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.php == '8.2' }}
 
     steps:
       - name: Checkout code
@@ -40,15 +39,15 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
-        if: ${{ startsWith( matrix.php, '8' ) == false && matrix.php != 'latest' }}
+        if: ${{ matrix.php != '8.2' }}
         uses: "ramsey/composer-install@v2"
 
-      # For PHP 8.0 and "nightly", we need to install with ignore platform reqs.
+      # For PHP "nightly", we need to install with ignore platform reqs.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ startsWith( matrix.php, '8' ) || matrix.php == 'latest' }}
+        if: ${{ matrix.php == '8.2' }}
         uses: "ramsey/composer-install@v2"
         with:
-          composer-options: --ignore-platform-reqs
+          composer-options: --ignore-platform-req=php
 
       - name: Lint against parse errors
         if: ${{ matrix.php >= '7.2' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       # Keys:
       # - coverage: Whether to run the tests with code coverage.
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.2']
         coverage: [false]
 
         include:
@@ -34,6 +34,7 @@ jobs:
             coverage: true
 
     name: "Test: PHP ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.php == '8.2' }}
 
     steps:
       - name: Checkout code
@@ -68,7 +69,15 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
+        if: ${{ matrix.php != '8.2' }}
         uses: "ramsey/composer-install@v2"
+
+      # For PHP "nightly", we need to install with ignore platform reqs.
+      - name: Install Composer dependencies - with ignore platform
+        if: ${{ matrix.php == '8.2' }}
+        uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: --ignore-platform-req=php
 
       - name: Setup problem matcher to provide annotations for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"


### PR DESCRIPTION
The first alpha of PHP 8.2 was released nearly two weeks ago, so let's start testing against PHP 8.2

Notes:
* Fixed: the `lint` workflow still had outdated conditions for whether to run the `composer install` task with or without ignoring platform requirements.
* Updated: the `--ignore-platform...` option has been updated to use the newer, more selective syntax offered by Composer.
* Simplied: the `lint` workflow still had an `experimental` key which wasn't use and isn't really necessary either.

**Note**: the test run against PHP 8.2 will currently fail on a test-only issue. PR #750 is open to fix that.