### PR TITLE
Composer: raise the PHP minimum to PHP 5.6.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requests is a HTTP library written in PHP, for human beings. It is roughly
 based on the API from the excellent [Requests Python
 library](http://python-requests.org/). Requests is [ISC
 Licensed](https://github.com/WordPress/Requests/blob/stable/LICENSE) (similar to
-the new BSD license) and has no dependencies, except for PHP 5.6+.
+the new BSD license) and has no dependencies, except for PHP 5.6.20+.
 
 Despite PHP's use as a language for the web, its tools for sending HTTP requests
 are severely lacking. cURL has an

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "docs": "https://requests.ryanmccue.info/"
   },
   "require": {
-    "php": ">=5.6",
+    "php": ">=5.6.20",
     "ext-json": "*"
   },
   "config": {

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -18,7 +18,7 @@ Goals
 
    No matter what you have installed on your system, you should be able to run
    Requests. We use cURL if it's available, and fallback to sockets otherwise.
-   We require only a baseline of PHP 5.6, leaving the choice of PHP minimum
+   We require only a baseline of PHP 5.6.20, leaving the choice of PHP minimum
    requirement fully in your hands, and giving you the ability to support many
    more hosts.
 


### PR DESCRIPTION
... which is in line with WordPress Core and prevents us potentially having to deal with bugs in PHP 5.6.0 to 5.6.19.

Includes updating the relevant documentation (hope I caught all references).