### PR TITLE
Cookie\FormatTest: add extra test case

### DIFF
--- a/tests/Cookie/FormatTest.php
+++ b/tests/Cookie/FormatTest.php
@@ -78,6 +78,11 @@ final class FormatTest extends TestCase {
 				'value'    => 'testvalue',
 				'expected' => '=testvalue',
 			],
+			'Has key, empty value' => [
+				'name'     => 'requests-testcookie',
+				'value'    => '',
+				'expected' => 'requests-testcookie=',
+			],
 			'Has key and value' => [
 				'name'     => 'requests-testcookie',
 				'value'    => 'testvalue',


### PR DESCRIPTION
Follow up after #740

Hmm... looks like I apparently forgot to push the additional test case I mentioned in https://github.com/WordPress/Requests/pull/740#issuecomment-1135829351 .... oops...

Let's have it anyway.