### PR TITLE
Cookie\DomainMatchesTest: improve and stabilize

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -207,12 +207,12 @@ class Cookie {
 			return false;
 		}
 
-		if (substr($domain, -1 * strlen($cookie_domain)) !== $cookie_domain) {
+		if (substr($domain, -(strlen($cookie_domain))) !== $cookie_domain) {
 			// The cookie domain should be a suffix of the passed domain.
 			return false;
 		}
 
-		$prefix = substr($domain, 0, strlen($domain) - strlen($cookie_domain));
+		$prefix = substr($domain, 0, -strlen($cookie_domain));
 		if (substr($prefix, -1) !== '.') {
 			// The last character of the passed domain that is not included in the
 			// domain string should be a %x2E (".") character.

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -201,18 +201,19 @@ class Cookie {
 			return false;
 		}
 
-		if (strlen($domain) <= strlen($cookie_domain)) {
+		$cookie_domain_length = strlen($cookie_domain);
+		if (strlen($domain) <= $cookie_domain_length) {
 			// For obvious reasons, the cookie domain cannot be a suffix if the passed domain
 			// is shorter than the cookie domain
 			return false;
 		}
 
-		if (substr($domain, -(strlen($cookie_domain))) !== $cookie_domain) {
+		if (substr($domain, -$cookie_domain_length) !== $cookie_domain) {
 			// The cookie domain should be a suffix of the passed domain.
 			return false;
 		}
 
-		$prefix = substr($domain, 0, -strlen($cookie_domain));
+		$prefix = substr($domain, 0, -$cookie_domain_length);
 		if (substr($prefix, -1) !== '.') {
 			// The last character of the passed domain that is not included in the
 			// domain string should be a %x2E (".") character.

--- a/tests/Cookie/DomainMatchesTest.php
+++ b/tests/Cookie/DomainMatchesTest.php
@@ -4,12 +4,39 @@ namespace WpOrg\Requests\Tests\Cookie;
 
 use WpOrg\Requests\Cookie;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 
 /**
  * @covers \WpOrg\Requests\Cookie::domain_matches
  */
 final class DomainMatchesTest extends TestCase {
+
+	/**
+	 * Verify that invalid input will always result in a non-match.
+	 *
+	 * @dataProvider dataInvalidInput
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testInvalidInput($input) {
+		$attributes           = new CaseInsensitiveDictionary();
+		$attributes['domain'] = 'example.com';
+		$cookie               = new Cookie('requests-testcookie', 'testvalue', $attributes);
+
+		$this->assertFalse($cookie->domain_matches($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function dataInvalidInput() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
+	}
 
 	/**
 	 * Manually set cookies without a domain/path set should always be valid.
@@ -74,8 +101,6 @@ final class DomainMatchesTest extends TestCase {
 	 */
 	public function dataDomainMatch() {
 		return [
-			'Invalid check domain (type): null'         => ['example.com', null, false, false],
-			'Invalid check domain (type): boolean true' => ['example.com', true, false, false],
 			['example.com', 'example.com', true, true],
 			['example.com', 'www.example.com', false, true],
 			['example.com', 'example.net', false, false],

--- a/tests/Cookie/DomainMatchesTest.php
+++ b/tests/Cookie/DomainMatchesTest.php
@@ -72,7 +72,16 @@ final class DomainMatchesTest extends TestCase {
 	}
 
 	/**
+	 * Verify domain_matches() correctly identifies exact domain matches.
+	 *
 	 * @dataProvider dataDomainMatch
+	 *
+	 * @param string $original       Original, known domain.
+	 * @param string $check          Domain to verify for a match.
+	 * @param bool   $matches        The expected function return value for an exact match.
+	 * @param bool   $domain_matches The expected function return value for a domain only match.
+	 *
+	 * @return void
 	 */
 	public function testDomainExactMatch($original, $check, $matches, $domain_matches) {
 		$attributes           = new CaseInsensitiveDictionary();
@@ -82,7 +91,16 @@ final class DomainMatchesTest extends TestCase {
 	}
 
 	/**
+	 * Verify domain_matches() correctly identifies domain matches disregarding subdomains.
+	 *
 	 * @dataProvider dataDomainMatch
+	 *
+	 * @param string $original       Original, known domain.
+	 * @param string $check          Domain to verify for a match.
+	 * @param bool   $matches        The expected function return value for an exact match.
+	 * @param bool   $domain_matches The expected function return value for a domain only match.
+	 *
+	 * @return void
 	 */
 	public function testDomainMatch($original, $check, $matches, $domain_matches) {
 		$attributes           = new CaseInsensitiveDictionary();

--- a/tests/Cookie/DomainMatchesTest.php
+++ b/tests/Cookie/DomainMatchesTest.php
@@ -17,11 +17,31 @@ final class DomainMatchesTest extends TestCase {
 	 * Cookies parsed from headers internally in Requests will always have a
 	 * domain/path set, but those created manually will not. Manual cookies
 	 * should be regarded as "global" cookies (that is, set for `.`).
+	 *
+	 * @dataProvider dataManuallySetCookie
+	 *
+	 * @param string $domain Domain to verify for a match.
+	 *
+	 * @return void
 	 */
-	public function testManuallySetCookie() {
+	public function testManuallySetCookie($domain) {
 		$cookie = new Cookie('requests-testcookie', 'testvalue');
-		$this->assertTrue($cookie->domain_matches('example.com'));
-		$this->assertTrue($cookie->domain_matches('example.net'));
+
+		$this->assertTrue($cookie->domain_matches($domain));
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataManuallySetCookie() {
+		$domains = [
+			'example.com',
+			'example.net',
+		];
+
+		return $this->textArrayToDataprovider($domains);
 	}
 
 	/**

--- a/tests/Cookie/DomainMatchesTest.php
+++ b/tests/Cookie/DomainMatchesTest.php
@@ -101,26 +101,86 @@ final class DomainMatchesTest extends TestCase {
 	 */
 	public function dataDomainMatch() {
 		return [
-			['example.com', 'example.com', true, true],
-			['example.com', 'www.example.com', false, true],
-			['example.com', 'example.net', false, false],
+			'Domain: exact match' => [
+				'original'       => 'example.com',
+				'check'          => 'example.com',
+				'matches'        => true,
+				'domain_matches' => true,
+			],
+			'Domain: same domain, same TLD, different subdomain' => [
+				'original'       => 'example.com',
+				'check'          => 'www.example.com',
+				'matches'        => false,
+				'domain_matches' => true,
+			],
+			'Domain: same domain, different TLD' => [
+				'original'       => 'example.com',
+				'check'          => 'example.net',
+				'matches'        => false,
+				'domain_matches' => false,
+			],
 
-			// Leading period
-			['.example.com', 'example.com', true, true],
-			['.example.com', 'www.example.com', false, true],
-			['.example.com', 'example.net', false, false],
+			// Leading period.
+			'Original domain with leading period, otherwise exact match' => [
+				'original'       => '.example.com',
+				'check'          => 'example.com',
+				'matches'        => true,
+				'domain_matches' => true,
+			],
+			'Original domain with leading period, same domain, same TLD, different subdomain' => [
+				'original'       => '.example.com',
+				'check'          => 'www.example.com',
+				'matches'        => false,
+				'domain_matches' => true,
+			],
+			'Original domain with leading period, same domain, different TLD' => [
+				'original'       => '.example.com',
+				'check'          => 'example.net',
+				'matches'        => false,
+				'domain_matches' => false,
+			],
 
-			// Prefix, but not subdomain
-			['example.com', 'notexample.com', false, false],
-			['example.com', 'notexample.net', false, false],
+			// Prefix, but not subdomain.
+			'Overlap: different domain with original domain substring of check' => [
+				'original'       => 'example.com',
+				'check'          => 'notexample.com',
+				'matches'        => false,
+				'domain_matches' => false,
+			],
+			'Overlap: different domain with original domain substring of check, different TLD' => [
+				'original'       => 'example.com',
+				'check'          => 'notexample.net',
+				'matches'        => false,
+				'domain_matches' => false,
+			],
 
-			// Reject IP address prefixes
-			['127.0.0.1', '127.0.0.1', true, true],
-			['127.0.0.1', 'abc.127.0.0.1', false, false],
-			['127.0.0.1', 'example.com', false, false],
+			// Reject IP address prefixes.
+			'IP addresses: exact match' => [
+				'original'       => '127.0.0.1',
+				'check'          => '127.0.0.1',
+				'matches'        => true,
+				'domain_matches' => true,
+			],
+			'IP address: original is IP, check appears to have subdomain prefix' => [
+				'original'       => '127.0.0.1',
+				'check'          => 'abc.127.0.0.1',
+				'matches'        => false,
+				'domain_matches' => false,
+			],
+			'IP addresses: non-matching' => [
+				'original'       => '127.0.0.1',
+				'check'          => 'example.com',
+				'matches'        => false,
+				'domain_matches' => false,
+			],
 
-			// Check that we're checking the actual length
-			['127.com', 'test.127.com', false, true],
+			// Check that we're checking the actual length.
+			'Actual length check' => [
+				'original'       => '127.com',
+				'check'          => 'test.127.com',
+				'matches'        => false,
+				'domain_matches' => true,
+			],
 		];
 	}
 }

--- a/tests/Cookie/DomainMatchesTest.php
+++ b/tests/Cookie/DomainMatchesTest.php
@@ -101,6 +101,13 @@ final class DomainMatchesTest extends TestCase {
 	 */
 	public function dataDomainMatch() {
 		return [
+			'Empty string' => [
+				'original'       => 'example.com',
+				'check'          => '',
+				'matches'        => false,
+				'domain_matches' => false,
+			],
+
 			'Domain: exact match' => [
 				'original'       => 'example.com',
 				'check'          => 'example.com',
@@ -180,6 +187,12 @@ final class DomainMatchesTest extends TestCase {
 				'check'          => 'test.127.com',
 				'matches'        => false,
 				'domain_matches' => true,
+			],
+			'Length check: check domain shorter than original' => [
+				'original'       => '127.com',
+				'check'          => '27.com',
+				'matches'        => false,
+				'domain_matches' => false,
 			],
 		];
 	}


### PR DESCRIPTION
### Cookie\DomainMatchesTest::testUrlMatchManuallySet(): refactor to data provider

### Cookie\DomainMatchesTest::testDomainMatch*(): split type check tests off to separate test method

... with a `TypeProviderHelper` based data provider to safeguard all invalid types will be rejected.

### Cookie\DomainMatchesTest::testDomainMatch*(): use named data provider

This commit:
* Adds descriptive names to each of the cases being tested via the data provider.
* Adds keys to the parameters passed for each test case to make it easier to understand the test case.
* Improves the punctuation for the inline documentation in the data provider.

### Cookie\DomainMatchesTest::testDomainMatch*(): add extra test cases

.. to safeguard the existing behaviour.

### Cookie\DomainMatchesTest::testDomainMatch*(): minor documentation improvements

### Cookie::domain_matches(): minor code simplifications [1]

Remove a few redundant calculations and a redundant function call.

### Cookie::domain_matches(): minor code simplifications [2]

Store the value of the repeated strlen calculation for re-use instead of calling the function multiple times.