### PR TITLE
Cookie\PathMatchesTest: improve and stabilize

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -254,14 +254,19 @@ class Cookie {
 			return true;
 		}
 
-		if (strlen($request_path) > strlen($cookie_path) && substr($request_path, 0, strlen($cookie_path)) === $cookie_path) {
+		$cookie_path_length = strlen($cookie_path);
+		if (strlen($request_path) <= $cookie_path_length) {
+			return false;
+		}
+
+		if (substr($request_path, 0, $cookie_path_length) === $cookie_path) {
 			if (substr($cookie_path, -1) === '/') {
 				// The cookie-path is a prefix of the request-path, and the last
 				// character of the cookie-path is %x2F ("/").
 				return true;
 			}
 
-			if (substr($request_path, strlen($cookie_path), 1) === '/') {
+			if (substr($request_path, $cookie_path_length, 1) === '/') {
 				// The cookie-path is a prefix of the request-path, and the
 				// first character of the request-path that is not included in
 				// the cookie-path is a %x2F ("/") character.

--- a/tests/Cookie/PathMatchesTest.php
+++ b/tests/Cookie/PathMatchesTest.php
@@ -37,6 +37,7 @@ final class PathMatchesTest extends TestCase {
 	 */
 	public function dataManuallySetCookie() {
 		$paths = [
+			'',
 			'/',
 			'/test',
 			'/test/',

--- a/tests/Cookie/PathMatchesTest.php
+++ b/tests/Cookie/PathMatchesTest.php
@@ -74,6 +74,12 @@ final class PathMatchesTest extends TestCase {
 					'matches'  => true,
 				];
 
+				$data['Non-match: "/test" vs ' . $key] = [
+					'original' => '/test',
+					'check'    => $value['input'],
+					'matches'  => false,
+				];
+
 				continue;
 			}
 

--- a/tests/Cookie/PathMatchesTest.php
+++ b/tests/Cookie/PathMatchesTest.php
@@ -4,6 +4,7 @@ namespace WpOrg\Requests\Tests\Cookie;
 
 use WpOrg\Requests\Cookie;
 use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 
 /**
@@ -47,6 +48,7 @@ final class PathMatchesTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider dataPathMatchUndesiredInputTypes
 	 * @dataProvider dataPathMatch
 	 */
 	public function testPathMatch($original, $check, $matches) {
@@ -57,17 +59,45 @@ final class PathMatchesTest extends TestCase {
 	}
 
 	/**
-	 * Data provider.
+	 * Data provider for checking data type handling.
+	 *
+	 * @return array
+	 */
+	public function dataPathMatchUndesiredInputTypes() {
+		$data      = [];
+		$all_types = TypeProviderHelper::getAll();
+		foreach ($all_types as $key => $value) {
+			if (in_array($key, TypeProviderHelper::GROUP_EMPTY, true)) {
+				$data['Match:     "/" vs ' . $key] = [
+					'original' => '/',
+					'check'    => $value['input'],
+					'matches'  => true,
+				];
+
+				continue;
+			}
+
+			/*
+			 * The other type inputs should all lead to a `false` result.
+			 * Non-scalar types for being non-scalar and the string types for not actually being a path.
+			 */
+			$data['Non-match: "/" vs ' . $key] = [
+				'original' => '/',
+				'check'    => $value['input'],
+				'matches'  => false,
+			];
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Data provider for checking the actual functionality.
 	 *
 	 * @return array
 	 */
 	public function dataPathMatch() {
 		return [
-			'Invalid check path (type): null'    => ['/', null, true],
-			'Invalid check path (type): true'    => ['/', true, false],
-			'Invalid check path (type): integer' => ['/', 123, false],
-			'Invalid check path (type): array'   => ['/', [1, 2], false],
-			['/', '', true],
 			['/', '/', true],
 
 			['/', '/test', true],

--- a/tests/Cookie/PathMatchesTest.php
+++ b/tests/Cookie/PathMatchesTest.php
@@ -124,6 +124,11 @@ final class PathMatchesTest extends TestCase {
 				'check'    => '/test/',
 				'matches'  => true,
 			],
+			'Partial match: "/test/" (with trailing slash) vs "/test/ing"' => [
+				'original' => '/test/',
+				'check'    => '/test/ing',
+				'matches'  => true,
+			],
 			'Partial match: "/test" vs "/test/" (without vs with trailing slash)' => [
 				'original' => '/test',
 				'check'    => '/test/',

--- a/tests/Cookie/PathMatchesTest.php
+++ b/tests/Cookie/PathMatchesTest.php
@@ -98,20 +98,64 @@ final class PathMatchesTest extends TestCase {
 	 */
 	public function dataPathMatch() {
 		return [
-			['/', '/', true],
+			'Exact match: "/"' => [
+				'original' => '/',
+				'check'    => '/',
+				'matches'  => true,
+			],
 
-			['/', '/test', true],
-			['/', '/test/', true],
+			'Partial match: "/" vs "/test"' => [
+				'original' => '/',
+				'check'    => '/test',
+				'matches'  => true,
+			],
+			'Partial match: "/" vs "/test/" (with trailing slash)' => [
+				'original' => '/',
+				'check'    => '/test/',
+				'matches'  => true,
+			],
 
-			['/test', '/', false],
-			['/test', '/test', true],
-			['/test', '/testing', false],
-			['/test', '/test/', true],
-			['/test', '/test/ing', true],
-			['/test', '/test/ing/', true],
+			'Partial non-match: "/test" vs "/"' => [
+				'original' => '/test',
+				'check'    => '/',
+				'matches'  => false,
+			],
+			'Exact match: "/test"' => [
+				'original' => '/test',
+				'check'    => '/test',
+				'matches'  => true,
+			],
+			'Partial non-match: "/test" vs "/testing"' => [
+				'original' => '/test',
+				'check'    => '/testing',
+				'matches'  => false,
+			],
+			'Partial match: "/test" vs "/test/" (without vs with trailing slash)' => [
+				'original' => '/test',
+				'check'    => '/test/',
+				'matches'  => true,
+			],
+			'Partial match: "/test" vs "/test/ing"' => [
+				'original' => '/test',
+				'check'    => '/test/ing',
+				'matches'  => true,
+			],
+			'Partial match: "/test" vs "/test/ing/" (with trailing slash)' => [
+				'original' => '/test',
+				'check'    => '/test/ing/',
+				'matches'  => true,
+			],
 
-			['/test/', '/test/', true],
-			['/test/', '/', false],
+			'Exact match: "/test/" (with trailing slash' => [
+				'original' => '/test/',
+				'check'    => '/test/',
+				'matches'  => true,
+			],
+			'Partial non-match: "/test/" (with trailing slash) vs "/"' => [
+				'original' => '/test/',
+				'check'    => '/',
+				'matches'  => false,
+			],
 		];
 	}
 }

--- a/tests/Cookie/PathMatchesTest.php
+++ b/tests/Cookie/PathMatchesTest.php
@@ -103,6 +103,16 @@ final class PathMatchesTest extends TestCase {
 				'check'    => '/',
 				'matches'  => true,
 			],
+			'Exact match: "/test"' => [
+				'original' => '/test',
+				'check'    => '/test',
+				'matches'  => true,
+			],
+			'Exact match: "/test/" (with trailing slash' => [
+				'original' => '/test/',
+				'check'    => '/test/',
+				'matches'  => true,
+			],
 
 			'Partial match: "/" vs "/test"' => [
 				'original' => '/',
@@ -113,22 +123,6 @@ final class PathMatchesTest extends TestCase {
 				'original' => '/',
 				'check'    => '/test/',
 				'matches'  => true,
-			],
-
-			'Partial non-match: "/test" vs "/"' => [
-				'original' => '/test',
-				'check'    => '/',
-				'matches'  => false,
-			],
-			'Exact match: "/test"' => [
-				'original' => '/test',
-				'check'    => '/test',
-				'matches'  => true,
-			],
-			'Partial non-match: "/test" vs "/testing"' => [
-				'original' => '/test',
-				'check'    => '/testing',
-				'matches'  => false,
 			],
 			'Partial match: "/test" vs "/test/" (without vs with trailing slash)' => [
 				'original' => '/test',
@@ -146,10 +140,15 @@ final class PathMatchesTest extends TestCase {
 				'matches'  => true,
 			],
 
-			'Exact match: "/test/" (with trailing slash' => [
-				'original' => '/test/',
-				'check'    => '/test/',
-				'matches'  => true,
+			'Partial non-match: "/test" vs "/"' => [
+				'original' => '/test',
+				'check'    => '/',
+				'matches'  => false,
+			],
+			'Partial non-match: "/test" vs "/testing"' => [
+				'original' => '/test',
+				'check'    => '/testing',
+				'matches'  => false,
 			],
 			'Partial non-match: "/test/" (with trailing slash) vs "/"' => [
 				'original' => '/test/',

--- a/tests/Cookie/PathMatchesTest.php
+++ b/tests/Cookie/PathMatchesTest.php
@@ -48,13 +48,22 @@ final class PathMatchesTest extends TestCase {
 	}
 
 	/**
+	 * Verify path_matches() correctly identifies whether a given path matches.
+	 *
 	 * @dataProvider dataPathMatchUndesiredInputTypes
 	 * @dataProvider dataPathMatch
+	 *
+	 * @param string $original Original, known path.
+	 * @param mixed  $check    Path to verify for a match.
+	 * @param bool   $matches  The expected function return value for an exact match.
+	 *
+	 * @return void
 	 */
 	public function testPathMatch($original, $check, $matches) {
 		$attributes         = new CaseInsensitiveDictionary();
 		$attributes['path'] = $original;
 		$cookie             = new Cookie('requests-testcookie', 'testvalue', $attributes);
+
 		$this->assertSame($matches, $cookie->path_matches($check));
 	}
 

--- a/tests/Cookie/PathMatchesTest.php
+++ b/tests/Cookie/PathMatchesTest.php
@@ -17,12 +17,32 @@ final class PathMatchesTest extends TestCase {
 	 * Cookies parsed from headers internally in Requests will always have a
 	 * domain/path set, but those created manually will not. Manual cookies
 	 * should be regarded as "global" cookies (that is, set for `.`).
+	 *
+	 * @dataProvider dataManuallySetCookie
+	 *
+	 * @param string $path Path to verify for a match.
+	 *
+	 * @return void
 	 */
-	public function testManuallySetCookie() {
+	public function testManuallySetCookie($path) {
 		$cookie = new Cookie('requests-testcookie', 'testvalue');
-		$this->assertTrue($cookie->path_matches('/'));
-		$this->assertTrue($cookie->path_matches('/test'));
-		$this->assertTrue($cookie->path_matches('/test/'));
+
+		$this->assertTrue($cookie->path_matches($path));
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataManuallySetCookie() {
+		$paths = [
+			'/',
+			'/test',
+			'/test/',
+		];
+
+		return $this->textArrayToDataprovider($paths);
 	}
 
 	/**


### PR DESCRIPTION
### Cookie\PathMatchesTest::testUrlMatchManuallySet(): refactor to data provider

### Cookie\PathMatchesTest::testUrlMatchManuallySet(): add extra test case

### Cookie\PathMatchesTest::testPathMatch(): split type check tests off to separate data provider

Similar to changes elsewhere, the behaviour with all types of input should be verified, not just for a selection.

This adds a new data provider which uses the `TypeProviderHelper` data as a basis to create a data provider in the format expected by the `testPathMatch()` method to ensure all data types are thoroughly tested.

Includes removing those test cases which are already included in the `TypeProviderHelper` from the original `pathMatchProvider()` array.

### Cookie\PathMatchesTest::testPathMatch(): use named data provider

This commit:
* Adds descriptive names to each of the cases being tested via the `pathMatchProvider()` data provider.
* Adds keys to the parameters passed for each test case to make it easier to understand the test case.

### Cookie\PathMatchesTest::testPathMatch(): re-order the test cases in the data provider

.. to an order which more closely matches the order of the conditions in the method under test.

### Cookie\PathMatchesTest::testPathMatch(): add extra test case

.. to safeguard the existing behaviour.

### Cookie::path_matches(): bow out early when possible

This lowers the cyclomatic complexity of the method and the possible paths through the method, without changing the functionality.

Includes assigning the result of a repeated function call to a variable instead of repeatedly doing the same function call.

### Cookie\PathMatchesTest::testPathMatch(): add extra test case set for "empty" types

... to cover an additional path through the method.

### Cookie\PathMatchesTest::testPathMatch(): minor documentation and readability improvements