### PR TITLE
Cookie integration tests: minor improvements

### DIFF
--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -8,7 +8,14 @@ use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
 use WpOrg\Requests\Tests\TestCase;
 
+/**
+ * Integration tests for the Cookie class.
+ *
+ * @covers \WpOrg\Requests\Cookie
+ * @covers \WpOrg\Requests\Cookie\Jar
+ */
 final class CookieTest extends TestCase {
+
 	public function testReceivingCookies() {
 		$options = [
 			'follow_redirects' => false,

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -32,18 +32,6 @@ final class CookieTest extends TestCase {
 		$this->assertSame('testvalue', $cookie->value);
 	}
 
-	private function setCookieRequest($cookies) {
-		$options  = [
-			'cookies' => $cookies,
-		];
-		$response = Requests::get(httpbin('/cookies/set'), [], $options);
-
-		$data = json_decode($response->body, true);
-		$this->assertIsArray($data);
-		$this->assertArrayHasKey('cookies', $data);
-		return $data['cookies'];
-	}
-
 	public function testSendingCookie() {
 		$cookies = [
 			'requests-testcookie1' => 'testvalue1',
@@ -84,5 +72,24 @@ final class CookieTest extends TestCase {
 
 		$this->assertArrayHasKey('requests-testcookie2', $data);
 		$this->assertSame('testvalue2', $data['requests-testcookie2']);
+	}
+
+	/**
+	 * Test helper.
+	 *
+	 * @param array $cookies The cookies to set.
+	 *
+	 * @return array
+	 */
+	private function setCookieRequest($cookies) {
+		$options  = [
+			'cookies' => $cookies,
+		];
+		$response = Requests::get(httpbin('/cookies/set'), [], $options);
+
+		$data = json_decode($response->body, true);
+		$this->assertIsArray($data);
+		$this->assertArrayHasKey('cookies', $data);
+		return $data['cookies'];
 	}
 }


### PR DESCRIPTION
### CookieTest: move helper method down

... and add documentation to it.

### CookieTest: stabilize assertions

* Add `$message` parameter to all assertions.
* Verify object type before property access.
* Verify something is an array before checking the key.
* Verify array keys exists before checking the value.

### CookieTest: add @covers tag