### PR TITLE
GH Actions: fix use of deprecated `set-output`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,21 +40,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set coverage variable
-        id: set_cov
-        run: |
-          if [ ${{ matrix.coverage }} == "true" ]; then
-            echo '::set-output name=COV::xdebug'
-          else
-            echo '::set-output name=COV::none'
-          fi
-
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
-          coverage: ${{ steps.set_cov.outputs.COV }}
+          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           tools: cs2pr
 
       # At least one test needs a non-en_US locale to be available, so make sure it is.

--- a/.github/workflows/update-cacert.yml
+++ b/.github/workflows/update-cacert.yml
@@ -40,18 +40,18 @@ jobs:
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
           if [[ "${{ github.event_name }}" == 'schedule' ]]; then
-            echo "::set-output name=BASE::develop"
-            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert"
+            echo "BASE=develop" >> $GITHUB_OUTPUT
+            echo "PR_BRANCH=feature/auto-update-cacert" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == 'push' ]]; then
             # Pull requests should always go to develop, even when triggered via a push to stable.
-            echo "::set-output name=BASE::develop"
-            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert"
+            echo "BASE=develop" >> $GITHUB_OUTPUT
+            echo "PR_BRANCH=feature/auto-update-cacert" >> $GITHUB_OUTPUT
           elif [[ $PR_NUM != '' ]]; then # = PR or manual (re-)run for a workflow triggered by a PR.
-            echo "::set-output name=BASE::$HEAD_REF"
-            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert-$PR_NUM"
+            echo "BASE=$HEAD_REF" >> $GITHUB_OUTPUT
+            echo "PR_BRANCH=feature/auto-update-cacert-$PR_NUM" >> $GITHUB_OUTPUT
           else # = manual run.
-            echo "::set-output name=BASE::$HEAD_REF"
-            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert-misc"
+            echo "BASE=$HEAD_REF" >> $GITHUB_OUTPUT
+            echo "PR_BRANCH=feature/auto-update-cacert-misc" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code
@@ -83,7 +83,7 @@ jobs:
       # http://man7.org/linux/man-pages/man1/date.1.html
       - name: "Get date"
         id: get-date
-        run: echo "::set-output name=DATE::$(/bin/date -u "+%F")"
+        run: echo "DATE=$(/bin/date -u "+%F")" >> $GITHUB_OUTPUT
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -39,9 +39,9 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "::set-output name=BRANCH::$REF"
+            echo "BRANCH=$REF" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=BRANCH::stable'
+            echo 'BRANCH=stable' >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code
@@ -95,15 +95,15 @@ jobs:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "::set-output name=REF::$REF_NAME"
-            echo '::set-output name=PR_TITLE_PREFIX::[TEST | DO NOT MERGE] '
-            echo '::set-output name=PR_BODY::Test run for the website update after changes to the automated scripts.'
-            echo '::set-output name=DRAFT::true'
+            echo "REF=$REF_NAME" >> $GITHUB_OUTPUT
+            echo 'PR_TITLE_PREFIX=[TEST | DO NOT MERGE] ' >> $GITHUB_OUTPUT
+            echo 'PR_BODY=Test run for the website update after changes to the automated scripts.' >> $GITHUB_OUTPUT
+            echo 'DRAFT=true' >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=REF::$TAG_NAME"
-            echo '::set-output name=PR_TITLE_PREFIX::'
-            echo "::set-output name=PR_BODY::Website update after the release of Requests $TAG_NAME."
-            echo '::set-output name=DRAFT::false'
+            echo "REF=$TAG_NAME" >> $GITHUB_OUTPUT
+            echo 'PR_TITLE_PREFIX=' >> $GITHUB_OUTPUT
+            echo "PR_BODY=Website update after the release of Requests $TAG_NAME." >> $GITHUB_OUTPUT
+            echo 'DRAFT=false' >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code


### PR DESCRIPTION
GitHub has deprecated the use of `set-output` (and `set-state`) in favour of new environment files.

This commit updates workflows to use the new methodology (or to avoid `set-output` altogether).

Refs:
* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

