### PR TITLE
GHA Remove usage of `::set-output`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,9 @@ jobs:
         id: set_cov
         run: |
           if [ ${{ matrix.coverage }} == "true" ]; then
-            echo '::set-output name=COV::xdebug'
+            echo "COV=xdebug" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=COV::none'
+            echo "COV=none" >> $GITHUB_OUTPUT
           fi
 
       - name: Install PHP

--- a/.github/workflows/update-cacert.yml
+++ b/.github/workflows/update-cacert.yml
@@ -40,18 +40,18 @@ jobs:
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
           if [[ "${{ github.event_name }}" == 'schedule' ]]; then
-            echo "::set-output name=BASE::develop"
-            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert"
+            echo "BASE=develop" >> $GITHUB_OUTPUT
+            echo "PR_BRANCH=feature/auto-update-cacert" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == 'push' ]]; then
             # Pull requests should always go to develop, even when triggered via a push to stable.
-            echo "::set-output name=BASE::develop"
-            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert"
+            echo "BASE=develop" >> $GITHUB_OUTPUT
+            echo "PR_BRANCH=feature/auto-update-cacert" >> $GITHUB_OUTPUT
           elif [[ $PR_NUM != '' ]]; then # = PR or manual (re-)run for a workflow triggered by a PR.
-            echo "::set-output name=BASE::$HEAD_REF"
-            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert-$PR_NUM"
+            echo "BASE=$HEAD_REF" >> $GITHUB_OUTPUT
+            echo "PR_BRANCH=feature/auto-update-cacert-$PR_NUM" >> $GITHUB_OUTPUT
           else # = manual run.
-            echo "::set-output name=BASE::$HEAD_REF"
-            echo "::set-output name=PR_BRANCH::feature/auto-update-cacert-misc"
+            echo "BASE=$HEAD_REF" >> $GITHUB_OUTPUT
+            echo "PR_BRANCH=feature/auto-update-cacert-misc" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code
@@ -83,7 +83,7 @@ jobs:
       # http://man7.org/linux/man-pages/man1/date.1.html
       - name: "Get date"
         id: get-date
-        run: echo "::set-output name=DATE::$(/bin/date -u "+%F")"
+        run: echo "DATE=$(/bin/date -u "+%F")" >> $GITHUB_OUTPUT
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -39,9 +39,9 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "::set-output name=BRANCH::$REF"
+            echo "BRANCH=$REF" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=BRANCH::stable'
+            echo "BRANCH::stable" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code
@@ -95,15 +95,15 @@ jobs:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "::set-output name=REF::$REF_NAME"
-            echo '::set-output name=PR_TITLE_PREFIX::[TEST | DO NOT MERGE] '
-            echo '::set-output name=PR_BODY::Test run for the website update after changes to the automated scripts.'
-            echo '::set-output name=DRAFT::true'
+            echo "REF=$REF_NAME" >> $GITHUB_OUTPUT
+            echo "PR_TITLE_PREFIX=[TEST | DO NOT MERGE] " >> $GITHUB_OUTPUT
+            echo "PR_BODY=Test run for the website update after changes to the automated scripts." >> $GITHUB_OUTPUT
+            echo "DRAFT=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=REF::$TAG_NAME"
-            echo '::set-output name=PR_TITLE_PREFIX::'
-            echo "::set-output name=PR_BODY::Website update after the release of Requests $TAG_NAME."
-            echo '::set-output name=DRAFT::false'
+            echo "REF=$TAG_NAME" >> $GITHUB_OUTPUT
+            echo "PR_TITLE_PREFIX=" >> $GITHUB_OUTPUT
+            echo "PR_BODY=Website update after the release of Requests $TAG_NAME." >> $GITHUB_OUTPUT
+            echo "DRAFT=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code


### PR DESCRIPTION
<!--
Thank you for creating this pull request!

Provide a general summary of your changes in the Title above.
And please provide enough information in the description below, so that others can review your pull request (PR).
-->

## Pull Request Type

- [ X] I have checked there is no other PR open for the same change.

This is a:
- [X] Bug fix
- [ ] New feature
- [ ] Code quality improvement

## Context
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
What should be mentioned about this PR in the changelog?
-->
## Detailed Description
This PR removes usage of  `::set-output` to adapt for c henges announced in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Quality assurance

- [X] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [ ] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!
I.e. code style complies with the project standard, the unit tests pass, code coverage has not gone down.

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make reviewing your changes easier for the maintainers.
============================================================================================
-->
