### PR TITLE
GH Actions: see deprecations in all relevant workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
           coverage: none
           tools: cs2pr
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -33,6 +33,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, log_errors_max_len=0
           coverage: none
 
       # At least one test needs a non-en_US locale to be available, so make sure it is.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, log_errors_max_len=0
           coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           tools: cs2pr
 


### PR DESCRIPTION
Follow up to PR #501 and in particular commit https://github.com/WordPress/Requests/pull/501/commits/1bb0e934921c215dff97ec678abc62d5afeef4bf.

I honestly don't know why I initially added the ini setting changes only in the `test` workflow, but by rights, they should be in both the `test`, `quicktest` as well as the `lint` workflows.

This commit fixes the omission.

And if I'm touching these lines now anyway, I may as well also enable `zend.assertions=1` for the test workflows.