### PR TITLE
Fsockopen::request(): decouple the `SNI_enabled` setting from the `verifyname` option

### DIFF
--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -124,9 +124,6 @@ final class Fsockopen implements Transport {
 			// phpcs:ignore PHPCompatibility.Constants.NewConstants.openssl_tlsext_server_nameFound
 			if (defined('OPENSSL_TLSEXT_SERVER_NAME') && OPENSSL_TLSEXT_SERVER_NAME) {
 				$context_options['SNI_enabled'] = true;
-				if (isset($options['verifyname']) && $options['verifyname'] === false) {
-					$context_options['SNI_enabled'] = false;
-				}
 			}
 
 			if (isset($options['verify'])) {

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -893,15 +893,44 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * humanmade.com (owned by Human Made and used with permission) points to
 	 * CloudFront, and will fail if SNI isn't sent.
+	 *
+	 * @dataProvider dataSNISupport
+	 *
+	 * @param array $options Additional options to pass.
+	 *
+	 * @return void
 	 */
-	public function testSNISupport() {
+	public function testSNISupport($options) {
 		if ($this->skip_https) {
 			$this->markTestSkipped('SSL support is not available.');
 			return;
 		}
 
-		$request = Requests::head('https://humanmade.com/', [], $this->getOptions());
+		$request = Requests::head('https://humanmade.com/', [], $this->getOptions($options));
 		$this->assertSame(200, $request->status_code);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function dataSNISupport($options) {
+		return [
+			'Without options' => [
+				'options' => [],
+			],
+			'With option "verifyname" set to true' => [
+				'options' => [
+					'verifyname' => true,
+				],
+			],
+			'With option "verifyname" set to false' => [
+				'options' => [
+					'verifyname' => false,
+				],
+			],
+		];
 	}
 
 	public function testTimeout() {


### PR DESCRIPTION
The `verifyname` option is handled separately a few lines lower down and should not influence the `$context_options['SNI_enabled']` setting.

Includes expanding an existing test to safeguard this.

The `FsockopenTest::testSNISupport()` test would fail with the `With option "verifyname" set to false` data set without this change, while it would pass for Curl. After this change, the test will pass for both types of transport.

Fixes #757

Ref:
* The original code was added in 2caf3eb254eb928c6cdefd18ca2a2c07d1aef6ec