### PR TITLE
QA: stricter type adherence

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -286,7 +286,11 @@ class Cookie {
 	public function normalize() {
 		foreach ($this->attributes as $key => $value) {
 			$orig_value = $value;
-			$value      = $this->normalize_attribute($key, $value);
+
+			if (is_string($key)) {
+				$value = $this->normalize_attribute($key, $value);
+			}
+
 			if ($value === null) {
 				unset($this->attributes[$key]);
 				continue;

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -255,6 +255,7 @@ class Cookie {
 			return true;
 		}
 
+		$request_path       = (string) $request_path;
 		$cookie_path_length = strlen($cookie_path);
 		if (strlen($request_path) <= $cookie_path_length) {
 			return false;

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -329,10 +329,10 @@ class IdnaEncoder {
 						}
 
 						// output the code point for digit t + ((q - t) mod (base - t))
-						$digit   = $t + (($q - $t) % (self::BOOTSTRAP_BASE - $t));
+						$digit   = (int) ($t + (($q - $t) % (self::BOOTSTRAP_BASE - $t)));
 						$output .= self::digit_to_char($digit);
 						// let q = (q - t) div (base - t)
-						$q = floor(($q - $t) / (self::BOOTSTRAP_BASE - $t));
+						$q = (int) floor(($q - $t) / (self::BOOTSTRAP_BASE - $t));
 					}
 
 					// output the code point for digit q

--- a/src/Iri.php
+++ b/src/Iri.php
@@ -395,11 +395,11 @@ class Iri {
 			// preceding "/" (if any) from the output buffer; otherwise,
 			elseif (strpos($input, '/../') === 0) {
 				$input = substr($input, 3);
-				$output = substr_replace($output, '', strrpos($output, '/'));
+				$output = substr_replace($output, '', (strrpos($output, '/') ?: 0));
 			}
 			elseif ($input === '/..') {
 				$input = '/';
-				$output = substr_replace($output, '', strrpos($output, '/'));
+				$output = substr_replace($output, '', (strrpos($output, '/') ?: 0));
 			}
 			// D: if the input buffer consists only of "." or "..", then remove
 			// that from the input buffer; otherwise,

--- a/src/Iri.php
+++ b/src/Iri.php
@@ -824,7 +824,8 @@ class Iri {
 		else {
 			$iuserinfo = null;
 		}
-		if (($port_start = strpos($remaining, ':', strpos($remaining, ']'))) !== false) {
+
+		if (($port_start = strpos($remaining, ':', (strpos($remaining, ']') ?: 0))) !== false) {
 			$port = substr($remaining, $port_start + 1);
 			if ($port === false || $port === '') {
 				$port = null;

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -79,7 +79,10 @@ class Headers extends CaseInsensitiveDictionary {
 			throw InvalidArgument::create(1, '$offset', 'string|int', gettype($offset));
 		}
 
-		$offset = strtolower($offset);
+		if (is_string($offset)) {
+			$offset = strtolower($offset);
+		}
+
 		if (!isset($this->data[$offset])) {
 			return null;
 		}


### PR DESCRIPTION
## Introduction

This PR is the outcome of an experiment to turn on `strict_types` for this code base (which can not happen for real until support for PHP 5.6 has been dropped).

Running the tests over the code base with `strict_types` turned on, initially yielded 646 tests erroring out and 156 tests failing (and three extra tests being skipped).

The below commits fix the majority of these, save for 6 test errors.

These last 6 test errors are `TypeError`s for PHP native functions which expect a `string`, but are receiving a _stringable object_, which for all intends and purposes is perfectly valid.

If and when Requests would move to enabling `strict_types` for real, those last six issues can be solved by adding a `(string)` cast in 3 places in the code base.

---
<details>
  <summary>Details of the last siẋ errors (fold out)</summary>

```
1) WpOrg\Requests\Tests\IdnaEncoder\IdnaEncoderTest::testEncoding with data set "stringable object" (WpOrg\Requests\Tests\Fixtures\StringableObject Object (...), 'xn--tba')                                                             
TypeError: explode(): Argument #2 ($string) must be of type string, WpOrg\Requests\Tests\Fixtures\StringableObject given                                                                                                                 
                                                                                                                                                                                                                                         
path/to/Requests/src/IdnaEncoder.php:68
path/to/Requests/tests/IdnaEncoder/IdnaEncoderTest.php:56
                                                                                                                                                                                                                                         
2) WpOrg\Requests\Tests\Requests\RequestsTest::testDefaultTransport                                                                                                                                                                      
TypeError: preg_match(): Argument #2 ($subject) must be of type string, WpOrg\Requests\Iri given                                                                                                                                         
                                                                                                                                                                                                                                         
path/to/Requests/src/Requests.php:660
path/to/Requests/src/Requests.php:456
path/to/Requests/src/Requests.php:307
path/to/Requests/tests/Requests/RequestsTest.php:151
                                                                                                                                                                                                                                         
3) WpOrg\Requests\Tests\Ssl\MatchDomainTest::testMatch with data set "top-level domain (stringable object)" (WpOrg\Requests\Tests\Fixtures\StringableObject Object (...), WpOrg\Requests\Tests\Fixtures\StringableObject Object (...))   
TypeError: preg_match(): Argument #2 ($subject) must be of type string, WpOrg\Requests\Tests\Fixtures\StringableObject given                                                                                                             
                                                                                                                                                                                                                                         
path/to/Requests/src/Ssl.php:109
path/to/Requests/src/Ssl.php:160
path/to/Requests/tests/Ssl/MatchDomainTest.php:51
                                                                                                                                                                                                                                         
4) WpOrg\Requests\Tests\Ssl\VerifyReferenceNameTest::testVerifyReferenceName with data set "three parts, no wildcard" (WpOrg\Requests\Tests\Fixtures\StringableObject Object (...), true)                                                
TypeError: preg_match(): Argument #2 ($subject) must be of type string, WpOrg\Requests\Tests\Fixtures\StringableObject given                                                                                                             
                                                                                                                                                                                                                                         
path/to/Requests/src/Ssl.php:109
path/to/Requests/tests/Ssl/VerifyReferenceNameTest.php:52

5) WpOrg\Requests\Tests\Transport\Curl\CurlTest::testSimpleGET
TypeError: preg_match(): Argument #2 ($subject) must be of type string, WpOrg\Requests\Iri given

path/to/Requests/src/Requests.php:660
path/to/Requests/src/Requests.php:456
path/to/Requests/src/Requests.php:307
path/to/Requests/tests/Transport/BaseTestCase.php:76

6) WpOrg\Requests\Tests\Transport\Fsockopen\FsockopenTest::testSimpleGET
TypeError: preg_match(): Argument #2 ($subject) must be of type string, WpOrg\Requests\Iri given

path/to/Requests/src/Requests.php:660
path/to/Requests/src/Requests.php:456
path/to/Requests/src/Requests.php:307
path/to/Requests/tests/Transport/BaseTestCase.php:76

```
</details>

---

Note: no tests are added for any of these changes as the existing tests cover them already, but don't show the issue unless `strict_types` mode is turned on.

## Commits

### QA | IdnaEncoder::punycode_encode(): pass the correct type

The `IdnaEncoder::digit_to_char()` method expects an `int`, not a float, for the `$digit` parameter. Same goes for the PHP native `substr()` function called from within the `IdnaEncoder::digit_to_char()` method to which the `$digit` parameter.

This ensures that the values passed to `IdnaEncoder::digit_to_char()`, which due to the use of `%` and `floor` are typed as `float`, will now contain the correct `int` type.

### QA | Iri::remove_dot_segments(): pass the correct type

The PHP native `substr_replace()` function expects an integer for the `$offset` parameter, however, the `strrpos()` function used to determine the _offset_ will return an integer if the `$needle` is found, but `false` when the `$needle` doesn't exist in the `$haystack`.

This tweaks the code to allow for that and ensures that the `substr_replace()` function will always receive an integer.

### QA | Iri::set_authority(): pass the correct type

The PHP native `strpos()` function expects an integer for the `$offset` parameter, however, the `strpos()` function used to determine the _offset_ will return an integer if the `$needle` is found, but `false` when the `$needle` doesn't exist in the `$haystack`.

This tweaks the code to allow for that and ensures that the `strpos()` function will always receive an integer.

### QA | Cookie::normalize(): pass the correct type

A cookie will either be a key/value pair or just a plain value (with an implicit integer key).

The `Cookie::normalize_attribute()` method normalized the value based on a string based `key` and otherwise returns the `value` unchanged, so this function call can be bypassed when the cookie is just a plain value without a key as it won't have any effect anyway.

This prevents a call to the PHP native `strtolower()` function in the  `Cookie::normalize_attribute()` method from passing an integer where a string is expected.

### QA | Headers::getValues(): pass the correct type

An HTTP header will either be a key/value pair or just a plain value (with an implicit integer key).

This minor tweak prevents a call to the PHP native `strtolower()` function being passed an integer where a string is expected.

### QA | Cookie::path_matches(): pass the correct type

The `$request_path` parameter is expected to be a `string`, but in effect, all scalars are accepted, as well as stringable objects.

While this is fine for the code in the first half of the function, the second half strongly relies on PHP type juggling as the type is treated as a string as of that point.

To make this explicit and ensure that both the `strlen()` as well as the `substr()` functions will always receive the correct type, a type casts is being added.
