### PR TITLE
Unblock CI

### DIFF
--- a/tests/Auth/Basic/BasicTest.php
+++ b/tests/Auth/Basic/BasicTest.php
@@ -26,7 +26,7 @@ final class BasicTest extends TestCase {
 			'auth'      => ['user', 'passwd'],
 			'transport' => $transport,
 		];
-		$request = Requests::get(httpbin('/basic-auth/user/passwd'), [], $options);
+		$request = Requests::get($this->httpbin('/basic-auth/user/passwd'), [], $options);
 
 		// Verify the request succeeded.
 		$this->assertInstanceOf(
@@ -73,7 +73,7 @@ final class BasicTest extends TestCase {
 			'auth'      => new Basic(['user', 'passwd']),
 			'transport' => $transport,
 		];
-		$request = Requests::get(httpbin('/basic-auth/user/passwd'), [], $options);
+		$request = Requests::get($this->httpbin('/basic-auth/user/passwd'), [], $options);
 
 		// Verify the request succeeded.
 		$this->assertInstanceOf(
@@ -123,7 +123,7 @@ final class BasicTest extends TestCase {
 
 		$options['auth']->user = 'user';
 		$options['auth']->pass = 'passwd';
-		$request               = Requests::get(httpbin('/basic-auth/user/passwd'), [], $options);
+		$request               = Requests::get($this->httpbin('/basic-auth/user/passwd'), [], $options);
 
 		// Verify the request succeeded.
 		$this->assertInstanceOf(
@@ -171,7 +171,7 @@ final class BasicTest extends TestCase {
 			'transport' => $transport,
 		];
 		$data    = 'test';
-		$request = Requests::post(httpbin('/post'), [], $data, $options);
+		$request = Requests::post($this->httpbin('/post'), [], $data, $options);
 
 		// Verify the request succeeded.
 		$this->assertInstanceOf(

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -20,7 +20,7 @@ final class CookieTest extends TestCase {
 		$options = [
 			'follow_redirects' => false,
 		];
-		$url     = httpbin('/cookies/set?requests-testcookie=testvalue');
+		$url     = $this->httpbin('/cookies/set?requests-testcookie=testvalue');
 
 		$response = Requests::get($url, [], $options);
 		$this->assertInstanceOf(Response::class, $response, 'Requests::get() did not return a Response object');
@@ -37,7 +37,7 @@ final class CookieTest extends TestCase {
 		$options = [
 			'follow_redirects' => true,
 		];
-		$url     = httpbin('/cookies/set?requests-testcookie=testvalue');
+		$url     = $this->httpbin('/cookies/set?requests-testcookie=testvalue');
 
 		$response = Requests::get($url, [], $options);
 		$this->assertInstanceOf(Response::class, $response, 'Requests::get() did not return a Response object');
@@ -68,7 +68,7 @@ final class CookieTest extends TestCase {
 		$options = [
 			'follow_redirects' => true,
 		];
-		$url     = httpbin('/cookies/set/testcookie/testvalue');
+		$url     = $this->httpbin('/cookies/set/testcookie/testvalue');
 		$url    .= '?expiry=1';
 
 		$response = Requests::get($url, [], $options);
@@ -110,7 +110,7 @@ final class CookieTest extends TestCase {
 			'cookies' => $cookies,
 		];
 
-		$response = Requests::get(httpbin('/cookies/set'), [], $options);
+		$response = Requests::get($this->httpbin('/cookies/set'), [], $options);
 		$this->assertInstanceOf(Response::class, $response, 'Requests::get() did not return a Response object');
 
 		$data = json_decode($response->body, true);

--- a/tests/Cookie/Jar/JarTest.php
+++ b/tests/Cookie/Jar/JarTest.php
@@ -75,7 +75,7 @@ final class JarTest extends TestCase {
 		$options  = [
 			'cookies' => $cookies,
 		];
-		$response = Requests::get(httpbin('/cookies/set'), [], $options);
+		$response = Requests::get($this->httpbin('/cookies/set'), [], $options);
 
 		$this->assertInstanceOf(Response::class, $response, 'GET request did not return a Response object');
 		$data = json_decode($response->body, true);

--- a/tests/Proxy/Http/HttpTest.php
+++ b/tests/Proxy/Http/HttpTest.php
@@ -37,7 +37,7 @@ final class HttpTest extends TestCase {
 			'proxy'     => REQUESTS_HTTP_PROXY,
 			'transport' => $transport,
 		];
-		$response = Requests::get(httpbin('/get'), [], $options);
+		$response = Requests::get($this->httpbin('/get'), [], $options);
 		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 		$data = json_decode($response->body, true);
@@ -54,7 +54,7 @@ final class HttpTest extends TestCase {
 			'proxy'     => [REQUESTS_HTTP_PROXY],
 			'transport' => $transport,
 		];
-		$response = Requests::get(httpbin('/get'), [], $options);
+		$response = Requests::get($this->httpbin('/get'), [], $options);
 		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 		$data = json_decode($response->body, true);
@@ -73,7 +73,7 @@ final class HttpTest extends TestCase {
 		];
 		$this->expectException(ArgumentCount::class);
 		$this->expectExceptionMessage('WpOrg\Requests\Proxy\Http::__construct() expects an array with exactly one element or exactly three elements');
-		Requests::get(httpbin('/get'), [], $options);
+		Requests::get($this->httpbin('/get'), [], $options);
 	}
 
 	/**
@@ -86,7 +86,7 @@ final class HttpTest extends TestCase {
 			'proxy'     => new Http(REQUESTS_HTTP_PROXY),
 			'transport' => $transport,
 		];
-		$response = Requests::get(httpbin('/get'), [], $options);
+		$response = Requests::get($this->httpbin('/get'), [], $options);
 		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 		$data = json_decode($response->body, true);
@@ -107,7 +107,7 @@ final class HttpTest extends TestCase {
 			],
 			'transport' => $transport,
 		];
-		$response = Requests::get(httpbin('/get'), [], $options);
+		$response = Requests::get($this->httpbin('/get'), [], $options);
 		$this->assertSame(200, $response->status_code);
 		$this->assertSame('http', $response->headers['x-requests-proxied']);
 
@@ -138,7 +138,7 @@ final class HttpTest extends TestCase {
 			$this->expectExceptionMessage('fsocket timed out');
 		}
 
-		$response = Requests::get(httpbin('/get'), [], $options);
+		$response = Requests::get($this->httpbin('/get'), [], $options);
 		$this->assertSame(407, $response->status_code);
 	}
 
@@ -150,10 +150,10 @@ final class HttpTest extends TestCase {
 
 		$requests = [
 			'test1' => [
-				'url' => httpbin('/get'),
+				'url' => $this->httpbin('/get'),
 			],
 			'test2' => [
-				'url' => httpbin('/get'),
+				'url' => $this->httpbin('/get'),
 			],
 		];
 
@@ -174,7 +174,7 @@ final class HttpTest extends TestCase {
 			$this->assertSame('http', $response->headers['x-requests-proxied']);
 
 			$result = json_decode($response->body, true);
-			$this->assertSame(httpbin('/get'), $result['url']);
+			$this->assertSame($this->httpbin('/get'), $result['url']);
 			$this->assertEmpty($result['args']);
 			$this->assertSame('http', $result['headers']['x-requests-proxy']);
 		}

--- a/tests/Requests/RequestsTest.php
+++ b/tests/Requests/RequestsTest.php
@@ -148,7 +148,7 @@ final class RequestsTest extends TestCase {
 	}
 
 	public function testDefaultTransport() {
-		$request = Requests::get(new Iri(httpbin('/get')));
+		$request = Requests::get(new Iri($this->httpbin('/get')));
 		$this->assertSame(200, $request->status_code);
 	}
 
@@ -297,6 +297,6 @@ final class RequestsTest extends TestCase {
 		$options = ['timeout' => 0.5];
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('timed out');
-		Requests::get(httpbin('/delay/3'), [], $options);
+		Requests::get($this->httpbin('/delay/3'), [], $options);
 	}
 }

--- a/tests/Session/ConstructorTest.php
+++ b/tests/Session/ConstructorTest.php
@@ -116,8 +116,8 @@ final class ConstructorTest extends TestCase {
 	public function dataValidUrl() {
 		return [
 			'null'              => [null],
-			'string'            => [httpbin('/')],
-			'stringable object' => [new Iri(httpbin('/'))],
+			'string'            => [$this->httpbin('/')],
+			'stringable object' => [new Iri($this->httpbin('/'))],
 		];
 	}
 }

--- a/tests/Session/RequestMultipleTest.php
+++ b/tests/Session/RequestMultipleTest.php
@@ -67,13 +67,13 @@ final class RequestMultipleTest extends TestCase {
 	}
 
 	public function testMultiple() {
-		$session   = new Session(httpbin('/'), ['X-Requests-Session' => 'Multiple']);
+		$session   = new Session($this->httpbin('/'), ['X-Requests-Session' => 'Multiple']);
 		$requests  = [
 			'test1' => [
-				'url' => httpbin('/get'),
+				'url' => $this->httpbin('/get'),
 			],
 			'test2' => [
-				'url' => httpbin('/get'),
+				'url' => $this->httpbin('/get'),
 			],
 		];
 		$responses = $session->request_multiple($requests);
@@ -84,7 +84,7 @@ final class RequestMultipleTest extends TestCase {
 		$this->assertSame(200, $responses['test1']->status_code);
 
 		$result = json_decode($responses['test1']->body, true);
-		$this->assertSame(httpbin('/get'), $result['url']);
+		$this->assertSame($this->httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 
 		// test2
@@ -93,7 +93,7 @@ final class RequestMultipleTest extends TestCase {
 		$this->assertSame(200, $responses['test2']->status_code);
 
 		$result = json_decode($responses['test2']->body, true);
-		$this->assertSame(httpbin('/get'), $result['url']);
+		$this->assertSame($this->httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 }

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -7,13 +7,13 @@ use WpOrg\Requests\Tests\TestCase;
 
 final class SessionTest extends TestCase {
 	public function testURLResolution() {
-		$session = new Session(httpbin('/'));
+		$session = new Session($this->httpbin('/'));
 
 		// Set the cookies up
 		$response = $session->get('/get');
 		$this->assertTrue($response->success, 'Session property "success" is not equal to true');
 		$this->assertSame(
-			httpbin('/get'),
+			$this->httpbin('/get'),
 			$response->url,
 			'Session property "url" is not equal to the expected get URL'
 		);
@@ -22,7 +22,7 @@ final class SessionTest extends TestCase {
 		$this->assertNotNull($data, 'Decoded response body is null');
 		$this->assertArrayHasKey('url', $data, 'Response data array does not have key "url"');
 		$this->assertSame(
-			httpbin('/get'),
+			$this->httpbin('/get'),
 			$data['url'],
 			'The value of the "url" key in the response data array is not equal to the expected get URL'
 		);
@@ -33,7 +33,7 @@ final class SessionTest extends TestCase {
 			'X-Requests-Session' => 'BasicGET',
 			'X-Requests-Request' => 'notset',
 		];
-		$session         = new Session(httpbin('/'), $session_headers);
+		$session         = new Session($this->httpbin('/'), $session_headers);
 		$response        = $session->get('/get', ['X-Requests-Request' => 'GET']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
@@ -50,7 +50,7 @@ final class SessionTest extends TestCase {
 			'X-Requests-Session' => 'BasicHEAD',
 			'X-Requests-Request' => 'notset',
 		];
-		$session         = new Session(httpbin('/'), $session_headers);
+		$session         = new Session($this->httpbin('/'), $session_headers);
 		$response        = $session->head('/get', ['X-Requests-Request' => 'HEAD']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
@@ -61,7 +61,7 @@ final class SessionTest extends TestCase {
 			'X-Requests-Session' => 'BasicDELETE',
 			'X-Requests-Request' => 'notset',
 		];
-		$session         = new Session(httpbin('/'), $session_headers);
+		$session         = new Session($this->httpbin('/'), $session_headers);
 		$response        = $session->delete('/delete', ['X-Requests-Request' => 'DELETE']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
@@ -78,7 +78,7 @@ final class SessionTest extends TestCase {
 			'X-Requests-Session' => 'BasicPOST',
 			'X-Requests-Request' => 'notset',
 		];
-		$session         = new Session(httpbin('/'), $session_headers);
+		$session         = new Session($this->httpbin('/'), $session_headers);
 		$response        = $session->post('/post', ['X-Requests-Request' => 'POST'], ['postdata' => 'exists']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
@@ -95,7 +95,7 @@ final class SessionTest extends TestCase {
 			'X-Requests-Session' => 'BasicPUT',
 			'X-Requests-Request' => 'notset',
 		];
-		$session         = new Session(httpbin('/'), $session_headers);
+		$session         = new Session($this->httpbin('/'), $session_headers);
 		$response        = $session->put('/put', ['X-Requests-Request' => 'PUT'], ['postdata' => 'exists']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
@@ -112,7 +112,7 @@ final class SessionTest extends TestCase {
 			'X-Requests-Session' => 'BasicPATCH',
 			'X-Requests-Request' => 'notset',
 		];
-		$session         = new Session(httpbin('/'), $session_headers);
+		$session         = new Session($this->httpbin('/'), $session_headers);
 		$response        = $session->patch('/patch', ['X-Requests-Request' => 'PATCH'], ['postdata' => 'exists']);
 		$response->throw_for_status(false);
 		$this->assertSame(200, $response->status_code);
@@ -125,7 +125,7 @@ final class SessionTest extends TestCase {
 	}
 
 	public function testSharedCookies() {
-		$session = new Session(httpbin('/'));
+		$session = new Session($this->httpbin('/'));
 
 		$options  = [
 			'follow_redirects' => false,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,6 +33,20 @@ abstract class TestCase extends Polyfill_TestCase {
 	}
 
 	/**
+	 * Retrieve a URL to use for testing.
+	 *
+	 * @param string $suffix The query path to add to the base URL.
+	 * @param bool   $ssl    Whether to get the URL using the `http` or the `https` protocol.
+	 *                       Defaults to `false`, which will result in a URL using `http`.
+	 *
+	 * @return string
+	 */
+	public function httpbin($suffix = '', $ssl = false) {
+		$host = $ssl ? 'https://' . \REQUESTS_TEST_HOST_HTTPS : 'http://' . \REQUESTS_TEST_HOST_HTTP;
+		return rtrim($host, '/') . '/' . ltrim($suffix, '/');
+	}
+
+	/**
 	 * Data provider for use in tests which need to be run against all default supported transports.
 	 *
 	 * @return array

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,6 +42,14 @@ abstract class TestCase extends Polyfill_TestCase {
 	 * @return string
 	 */
 	public function httpbin($suffix = '', $ssl = false) {
+		if ($ssl === false && REQUESTS_TEST_SERVER_HTTP_AVAILABLE === false) {
+			$this->markTestSkipped(sprintf('Host %s not available. This needs investigation', REQUESTS_TEST_HOST_HTTP));
+		}
+
+		if ($ssl === true && REQUESTS_TEST_SERVER_HTTPS_AVAILABLE === false) {
+			$this->markTestSkipped(sprintf('Host %s not available. This needs investigation', REQUESTS_TEST_HOST_HTTPS));
+		}
+
 		$host = $ssl ? 'https://' . \REQUESTS_TEST_HOST_HTTPS : 'http://' . \REQUESTS_TEST_HOST_HTTP;
 		return rtrim($host, '/') . '/' . ltrim($suffix, '/');
 	}

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -56,7 +56,7 @@ abstract class BaseTestCase extends TestCase {
 		$options  = [
 			'max_bytes' => $limit,
 		];
-		$response = Requests::get(httpbin('/bytes/325'), [], $this->getOptions($options));
+		$response = Requests::get($this->httpbin('/bytes/325'), [], $this->getOptions($options));
 		$this->assertSame($limit, strlen($response->body));
 	}
 
@@ -66,27 +66,27 @@ abstract class BaseTestCase extends TestCase {
 			'max_bytes' => $limit,
 			'filename'  => tempnam(sys_get_temp_dir(), 'RLT'), // RequestsLibraryTest
 		];
-		$response = Requests::get(httpbin('/bytes/482'), [], $this->getOptions($options));
+		$response = Requests::get($this->httpbin('/bytes/482'), [], $this->getOptions($options));
 		$this->assertEmpty($response->body);
 		$this->assertSame($limit, filesize($options['filename']));
 		unlink($options['filename']);
 	}
 
 	public function testSimpleGET() {
-		$request = Requests::get(new Iri(httpbin('/get')), [], $this->getOptions());
+		$request = Requests::get(new Iri($this->httpbin('/get')), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(httpbin('/get'), $result['url']);
+		$this->assertSame($this->httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
 	public function testGETWithArgs() {
-		$request = Requests::get(httpbin('/get?test=true&test2=test'), [], $this->getOptions());
+		$request = Requests::get($this->httpbin('/get?test=true&test2=test'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(httpbin('/get?test=true&test2=test'), $result['url']);
+		$this->assertSame($this->httpbin('/get?test=true&test2=test'), $result['url']);
 		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['args']);
 	}
 
@@ -95,11 +95,11 @@ abstract class BaseTestCase extends TestCase {
 			'test'  => 'true',
 			'test2' => 'test',
 		];
-		$request = Requests::request(httpbin('/get'), [], $data, Requests::GET, $this->getOptions());
+		$request = Requests::request($this->httpbin('/get'), [], $data, Requests::GET, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(httpbin('/get?test=true&test2=test'), $result['url']);
+		$this->assertSame($this->httpbin('/get?test=true&test2=test'), $result['url']);
 		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['args']);
 	}
 
@@ -111,11 +111,11 @@ abstract class BaseTestCase extends TestCase {
 				'test4' => 'test-too',
 			],
 		];
-		$request = Requests::request(httpbin('/get'), [], $data, Requests::GET, $this->getOptions());
+		$request = Requests::request($this->httpbin('/get'), [], $data, Requests::GET, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(httpbin('/get?test=true&test2%5Btest3%5D=test&test2%5Btest4%5D=test-too'), $result['url']);
+		$this->assertSame($this->httpbin('/get?test=true&test2%5Btest3%5D=test&test2%5Btest4%5D=test-too'), $result['url']);
 		$this->assertSame(['test' => 'true', 'test2[test3]' => 'test', 'test2[test4]' => 'test-too'], $result['args']);
 	}
 
@@ -123,11 +123,11 @@ abstract class BaseTestCase extends TestCase {
 		$data    = [
 			'test2' => 'test',
 		];
-		$request = Requests::request(httpbin('/get?test=true'), [], $data, Requests::GET, $this->getOptions());
+		$request = Requests::request($this->httpbin('/get?test=true'), [], $data, Requests::GET, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(httpbin('/get?test=true&test2=test'), $result['url']);
+		$this->assertSame($this->httpbin('/get?test=true&test2=test'), $result['url']);
 		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['args']);
 	}
 
@@ -135,7 +135,7 @@ abstract class BaseTestCase extends TestCase {
 		$headers = [
 			'Requested-At' => (string) time(),
 		];
-		$request = Requests::get(httpbin('/get'), $headers, $this->getOptions());
+		$request = Requests::get($this->httpbin('/get'), $headers, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -143,28 +143,28 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testChunked() {
-		$request = Requests::get(httpbin('/stream/1'), [], $this->getOptions());
+		$request = Requests::get($this->httpbin('/stream/1'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(httpbin('/stream/1'), $result['url']);
+		$this->assertSame($this->httpbin('/stream/1'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
 	public function testHEAD() {
-		$request = Requests::head(httpbin('/get'), [], $this->getOptions());
+		$request = Requests::head($this->httpbin('/get'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 		$this->assertSame('', $request->body);
 	}
 
 	public function testTRACE() {
-		$request = Requests::trace(httpbin('/trace'), [], $this->getOptions());
+		$request = Requests::trace($this->httpbin('/trace'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 	}
 
 	public function testRawPOST() {
 		$data    = 'test';
-		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -175,7 +175,7 @@ abstract class BaseTestCase extends TestCase {
 	 * Issue #248.
 	 */
 	public function testEmptyPOST() {
-		$request = Requests::post(httpbin('/post'), [], null, $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], null, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -258,7 +258,7 @@ abstract class BaseTestCase extends TestCase {
 	 * @return void
 	 */
 	public function testIncorrectDataTypeAcceptedPOST($data, $expected) {
-		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertIsObject($request, 'POST request did not return an object');
 		$this->assertObjectHasAttribute('status_code', $request, 'POST request object does not have a "status_code" property');
 		$this->assertSame(200, $request->status_code, 'POST request status code is not 200');
@@ -299,7 +299,7 @@ abstract class BaseTestCase extends TestCase {
 		$this->expectExceptionMessage('Argument #3 ($data) must be of type array|string');
 
 		$transport = new $this->transport();
-		$transport->request(httpbin('/post'), [], $input, $this->getOptions());
+		$transport->request($this->httpbin('/post'), [], $input, $this->getOptions());
 	}
 
 	/**
@@ -422,7 +422,7 @@ abstract class BaseTestCase extends TestCase {
 
 	public function testFormPost() {
 		$data    = 'test=true&test2=test';
-		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -434,7 +434,7 @@ abstract class BaseTestCase extends TestCase {
 			'test'  => 'true',
 			'test2' => 'test',
 		];
-		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -449,7 +449,7 @@ abstract class BaseTestCase extends TestCase {
 				'test4' => 'test-too',
 			],
 		];
-		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -458,7 +458,7 @@ abstract class BaseTestCase extends TestCase {
 
 	public function testRawPUT() {
 		$data    = 'test';
-		$request = Requests::put(httpbin('/put'), [], $data, $this->getOptions());
+		$request = Requests::put($this->httpbin('/put'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -467,7 +467,7 @@ abstract class BaseTestCase extends TestCase {
 
 	public function testFormPUT() {
 		$data    = 'test=true&test2=test';
-		$request = Requests::put(httpbin('/put'), [], $data, $this->getOptions());
+		$request = Requests::put($this->httpbin('/put'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -479,7 +479,7 @@ abstract class BaseTestCase extends TestCase {
 			'test'  => 'true',
 			'test2' => 'test',
 		];
-		$request = Requests::put(httpbin('/put'), [], $data, $this->getOptions());
+		$request = Requests::put($this->httpbin('/put'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -488,7 +488,7 @@ abstract class BaseTestCase extends TestCase {
 
 	public function testRawPATCH() {
 		$data    = 'test';
-		$request = Requests::patch(httpbin('/patch'), [], $data, $this->getOptions());
+		$request = Requests::patch($this->httpbin('/patch'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -497,7 +497,7 @@ abstract class BaseTestCase extends TestCase {
 
 	public function testFormPATCH() {
 		$data    = 'test=true&test2=test';
-		$request = Requests::patch(httpbin('/patch'), [], $data, $this->getOptions());
+		$request = Requests::patch($this->httpbin('/patch'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code, $request->body);
 
 		$result = json_decode($request->body, true);
@@ -509,7 +509,7 @@ abstract class BaseTestCase extends TestCase {
 			'test'  => 'true',
 			'test2' => 'test',
 		];
-		$request = Requests::patch(httpbin('/patch'), [], $data, $this->getOptions());
+		$request = Requests::patch($this->httpbin('/patch'), [], $data, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -517,16 +517,16 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testOPTIONS() {
-		$request = Requests::options(httpbin('/options'), [], [], $this->getOptions());
+		$request = Requests::options($this->httpbin('/options'), [], [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 	}
 
 	public function testDELETE() {
-		$request = Requests::delete(httpbin('/delete'), [], $this->getOptions());
+		$request = Requests::delete($this->httpbin('/delete'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(httpbin('/delete'), $result['url']);
+		$this->assertSame($this->httpbin('/delete'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
@@ -535,16 +535,16 @@ abstract class BaseTestCase extends TestCase {
 			'test'  => 'true',
 			'test2' => 'test',
 		];
-		$request = Requests::request(httpbin('/delete'), [], $data, Requests::DELETE, $this->getOptions());
+		$request = Requests::request($this->httpbin('/delete'), [], $data, Requests::DELETE, $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(httpbin('/delete?test=true&test2=test'), $result['url']);
+		$this->assertSame($this->httpbin('/delete?test=true&test2=test'), $result['url']);
 		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['args']);
 	}
 
 	public function testLOCK() {
-		$request = Requests::request(httpbin('/lock'), [], [], 'LOCK', $this->getOptions());
+		$request = Requests::request($this->httpbin('/lock'), [], [], 'LOCK', $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 	}
 
@@ -553,7 +553,7 @@ abstract class BaseTestCase extends TestCase {
 			'test'  => 'true',
 			'test2' => 'test',
 		];
-		$request = Requests::request(httpbin('/lock'), [], $data, 'LOCK', $this->getOptions());
+		$request = Requests::request($this->httpbin('/lock'), [], $data, 'LOCK', $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -561,14 +561,14 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testRedirects() {
-		$request = Requests::get(httpbin('/redirect/6'), [], $this->getOptions());
+		$request = Requests::get($this->httpbin('/redirect/6'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$this->assertSame(6, $request->redirects);
 	}
 
 	public function testRelativeRedirects() {
-		$request = Requests::get(httpbin('/relative-redirect/6'), [], $this->getOptions());
+		$request = Requests::get($this->httpbin('/relative-redirect/6'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$this->assertSame(6, $request->redirects);
@@ -580,7 +580,7 @@ abstract class BaseTestCase extends TestCase {
 		];
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Too many redirects');
-		Requests::get(httpbin('/redirect/11'), [], $this->getOptions($options));
+		Requests::get($this->httpbin('/redirect/11'), [], $this->getOptions($options));
 	}
 
 	public static function statusCodeSuccessProvider() {
@@ -639,7 +639,7 @@ abstract class BaseTestCase extends TestCase {
 		$transport       = new TransportMock();
 		$transport->code = $code;
 
-		$url = sprintf(httpbin('/status/%d'), $code);
+		$url = sprintf($this->httpbin('/status/%d'), $code);
 
 		$options = [
 			'follow_redirects' => false,
@@ -657,7 +657,7 @@ abstract class BaseTestCase extends TestCase {
 		$transport       = new TransportMock();
 		$transport->code = $code;
 
-		$url     = sprintf(httpbin('/status/%d'), $code);
+		$url     = sprintf($this->httpbin('/status/%d'), $code);
 		$options = [
 			'follow_redirects' => false,
 			'transport'        => $transport,
@@ -686,7 +686,7 @@ abstract class BaseTestCase extends TestCase {
 		$transport       = new TransportMock();
 		$transport->code = $code;
 
-		$url     = sprintf(httpbin('/status/%d'), $code);
+		$url     = sprintf($this->httpbin('/status/%d'), $code);
 		$options = [
 			'follow_redirects' => false,
 			'transport'        => $transport,
@@ -714,7 +714,7 @@ abstract class BaseTestCase extends TestCase {
 			'transport' => $transport,
 		];
 
-		$request = Requests::get(httpbin('/status/599'), [], $options);
+		$request = Requests::get($this->httpbin('/status/599'), [], $options);
 		$this->assertSame(599, $request->status_code);
 		$this->assertFalse($request->success);
 	}
@@ -727,14 +727,14 @@ abstract class BaseTestCase extends TestCase {
 			'transport' => $transport,
 		];
 
-		$request = Requests::get(httpbin('/status/599'), [], $options);
+		$request = Requests::get($this->httpbin('/status/599'), [], $options);
 		$this->expectException(StatusUnknown::class);
 		$this->expectExceptionMessage('599 Unknown');
 		$request->throw_for_status(true);
 	}
 
 	public function testGzipped() {
-		$request = Requests::get(httpbin('/gzip'), [], $this->getOptions());
+		$request = Requests::get($this->httpbin('/gzip'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body);
@@ -745,13 +745,13 @@ abstract class BaseTestCase extends TestCase {
 		$options = [
 			'filename' => tempnam(sys_get_temp_dir(), 'RLT'), // RequestsLibraryTest
 		];
-		$request = Requests::get(httpbin('/get'), [], $this->getOptions($options));
+		$request = Requests::get($this->httpbin('/get'), [], $this->getOptions($options));
 		$this->assertSame(200, $request->status_code);
 		$this->assertEmpty($request->body);
 
 		$contents = file_get_contents($options['filename']);
 		$result   = json_decode($contents, true);
-		$this->assertSame(httpbin('/get'), $result['url']);
+		$this->assertSame($this->httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 
 		unlink($options['filename']);
@@ -772,7 +772,7 @@ abstract class BaseTestCase extends TestCase {
 		];
 
 		try {
-			Requests::get(httpbin('/get'), [], $this->getOptions($options));
+			Requests::get($this->httpbin('/get'), [], $this->getOptions($options));
 
 			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 		} catch (Exception $e) {
@@ -798,14 +798,14 @@ abstract class BaseTestCase extends TestCase {
 		// First character (F) can be upper or lowercase depending on PHP version.
 		$this->expectExceptionMessage('ailed to open stream');
 
-		Requests::get(httpbin('/get'), [], $this->getOptions($options));
+		Requests::get($this->httpbin('/get'), [], $this->getOptions($options));
 	}
 
 	public function testNonblocking() {
 		$options = [
 			'blocking' => false,
 		];
-		$request = Requests::get(httpbin('/get'), [], $this->getOptions($options));
+		$request = Requests::get($this->httpbin('/get'), [], $this->getOptions($options));
 		$empty   = new Response();
 		$this->assertEquals($empty, $request);
 	}
@@ -821,7 +821,7 @@ abstract class BaseTestCase extends TestCase {
 			return;
 		}
 
-		$request = Requests::get(httpbin('/get', true), [], $this->getOptions());
+		$request = Requests::get($this->httpbin('/get', true), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
@@ -910,16 +910,16 @@ abstract class BaseTestCase extends TestCase {
 		];
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('timed out');
-		Requests::get(httpbin('/delay/10'), [], $this->getOptions($options));
+		Requests::get($this->httpbin('/delay/10'), [], $this->getOptions($options));
 	}
 
 	public function testMultiple() {
 		$requests  = [
 			'test1' => [
-				'url' => httpbin('/get'),
+				'url' => $this->httpbin('/get'),
 			],
 			'test2' => [
-				'url' => httpbin('/get'),
+				'url' => $this->httpbin('/get'),
 			],
 		];
 		$responses = Requests::request_multiple($requests, $this->getOptions());
@@ -930,7 +930,7 @@ abstract class BaseTestCase extends TestCase {
 		$this->assertSame(200, $responses['test1']->status_code);
 
 		$result = json_decode($responses['test1']->body, true);
-		$this->assertSame(httpbin('/get'), $result['url']);
+		$this->assertSame($this->httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 
 		// test2
@@ -939,17 +939,17 @@ abstract class BaseTestCase extends TestCase {
 		$this->assertSame(200, $responses['test2']->status_code);
 
 		$result = json_decode($responses['test2']->body, true);
-		$this->assertSame(httpbin('/get'), $result['url']);
+		$this->assertSame($this->httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 	}
 
 	public function testMultipleWithDifferingMethods() {
 		$requests  = [
 			'get' => [
-				'url' => httpbin('/get'),
+				'url' => $this->httpbin('/get'),
 			],
 			'post' => [
-				'url'  => httpbin('/post'),
+				'url'  => $this->httpbin('/post'),
 				'type' => Requests::POST,
 				'data' => 'test',
 			],
@@ -971,10 +971,10 @@ abstract class BaseTestCase extends TestCase {
 	public function testMultipleWithFailure() {
 		$requests  = [
 			'success' => [
-				'url' => httpbin('/get'),
+				'url' => $this->httpbin('/get'),
 			],
 			'timeout' => [
-				'url'     => httpbin('/delay/10'),
+				'url'     => $this->httpbin('/delay/10'),
 				'options' => [
 					'timeout' => 1,
 				],
@@ -988,10 +988,10 @@ abstract class BaseTestCase extends TestCase {
 	public function testMultipleUsingCallback() {
 		$requests        = [
 			'get' => [
-				'url' => httpbin('/get'),
+				'url' => $this->httpbin('/get'),
 			],
 			'post' => [
-				'url'  => httpbin('/post'),
+				'url'  => $this->httpbin('/post'),
 				'type' => Requests::POST,
 				'data' => 'test',
 			],
@@ -1008,10 +1008,10 @@ abstract class BaseTestCase extends TestCase {
 	public function testMultipleUsingCallbackAndFailure() {
 		$requests        = [
 			'success' => [
-				'url' => httpbin('/get'),
+				'url' => $this->httpbin('/get'),
 			],
 			'timeout' => [
-				'url'     => httpbin('/delay/10'),
+				'url'     => $this->httpbin('/delay/10'),
 				'options' => [
 					'timeout' => 1,
 				],
@@ -1033,13 +1033,13 @@ abstract class BaseTestCase extends TestCase {
 	public function testMultipleToFile() {
 		$requests = [
 			'get' => [
-				'url'     => httpbin('/get'),
+				'url'     => $this->httpbin('/get'),
 				'options' => [
 					'filename' => tempnam(sys_get_temp_dir(), 'RLT'), // RequestsLibraryTest
 				],
 			],
 			'post' => [
-				'url'     => httpbin('/post'),
+				'url'     => $this->httpbin('/post'),
 				'type'    => Requests::POST,
 				'data'    => 'test',
 				'options' => [
@@ -1052,14 +1052,14 @@ abstract class BaseTestCase extends TestCase {
 		// GET request
 		$contents = file_get_contents($requests['get']['options']['filename']);
 		$result   = json_decode($contents, true);
-		$this->assertSame(httpbin('/get'), $result['url']);
+		$this->assertSame($this->httpbin('/get'), $result['url']);
 		$this->assertEmpty($result['args']);
 		unlink($requests['get']['options']['filename']);
 
 		// POST request
 		$contents = file_get_contents($requests['post']['options']['filename']);
 		$result   = json_decode($contents, true);
-		$this->assertSame(httpbin('/post'), $result['url']);
+		$this->assertSame($this->httpbin('/post'), $result['url']);
 		$this->assertSame('test', $result['data']);
 		unlink($requests['post']['options']['filename']);
 	}
@@ -1095,7 +1095,7 @@ abstract class BaseTestCase extends TestCase {
 		];
 		$options = $this->getOptions($options);
 
-		Requests::get(httpbin('/get'), [], $options);
+		Requests::get($this->httpbin('/get'), [], $options);
 	}
 
 	public function testAfterRequestCallback() {
@@ -1117,14 +1117,14 @@ abstract class BaseTestCase extends TestCase {
 		];
 		$options = $this->getOptions($options);
 
-		Requests::get(httpbin('/get'), [], $options);
+		Requests::get($this->httpbin('/get'), [], $options);
 	}
 
 	public function testReusableTransport() {
 		$options = $this->getOptions(['transport' => new $this->transport()]);
 
-		$request1 = Requests::get(httpbin('/get'), [], $options);
-		$request2 = Requests::get(httpbin('/get'), [], $options);
+		$request1 = Requests::get($this->httpbin('/get'), [], $options);
+		$request2 = Requests::get($this->httpbin('/get'), [], $options);
 
 		$this->assertSame(200, $request1->status_code);
 		$this->assertSame(200, $request2->status_code);
@@ -1132,8 +1132,8 @@ abstract class BaseTestCase extends TestCase {
 		$result1 = json_decode($request1->body, true);
 		$result2 = json_decode($request2->body, true);
 
-		$this->assertSame(httpbin('/get'), $result1['url']);
-		$this->assertSame(httpbin('/get'), $result2['url']);
+		$this->assertSame($this->httpbin('/get'), $result1['url']);
+		$this->assertSame($this->httpbin('/get'), $result2['url']);
 
 		$this->assertEmpty($result1['args']);
 		$this->assertEmpty($result2['args']);
@@ -1141,27 +1141,27 @@ abstract class BaseTestCase extends TestCase {
 
 	public function testQueryDataFormat() {
 		$data    = ['test' => 'true', 'test2' => 'test'];
-		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions(['data_format' => 'query']));
+		$request = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions(['data_format' => 'query']));
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(httpbin('/post') . '?test=true&test2=test', $result['url']);
+		$this->assertSame($this->httpbin('/post') . '?test=true&test2=test', $result['url']);
 		$this->assertSame('', $result['data']);
 	}
 
 	public function testBodyDataFormat() {
 		$data    = ['test' => 'true', 'test2' => 'test'];
-		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions(['data_format' => 'body']));
+		$request = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions(['data_format' => 'body']));
 		$this->assertSame(200, $request->status_code);
 
 		$result = json_decode($request->body, true);
-		$this->assertSame(httpbin('/post'), $result['url']);
+		$this->assertSame($this->httpbin('/post'), $result['url']);
 		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
 	}
 
 	public function test303GETmethod() {
 		$data    = ['test' => 'true', 'test2' => 'test'];
-		$request = Requests::post(httpbin('/status/303', true), [], $data, $this->getOptions(['follow_redirects' => true]));
+		$request = Requests::post($this->httpbin('/status/303', true), [], $data, $this->getOptions(['follow_redirects' => true]));
 
 		$this->assertSame(200, $request->status_code);
 		$this->assertSame('/get', substr($request->url, -4));

--- a/tests/Transport/Curl/CurlTest.php
+++ b/tests/Transport/Curl/CurlTest.php
@@ -44,7 +44,7 @@ final class CurlTest extends BaseTestCase {
 		$headers = [
 			'Expect' => 'foo',
 		];
-		$request = Requests::post(httpbin('/post'), $headers, [], $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), $headers, [], $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -58,7 +58,7 @@ final class CurlTest extends BaseTestCase {
 		$options = [
 			'protocol_version' => 1.0,
 		];
-		$request = Requests::post(httpbin('/post'), [], str_repeat('x', 1048576), $this->getOptions($options));
+		$request = Requests::post($this->httpbin('/post'), [], str_repeat('x', 1048576), $this->getOptions($options));
 
 		$result = json_decode($request->body, true);
 
@@ -69,7 +69,7 @@ final class CurlTest extends BaseTestCase {
 	 * @small
 	 */
 	public function testSetsEmptyExpectHeaderWithDefaultSettings() {
-		$request = Requests::post(httpbin('/post'), [], [], $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], [], $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -86,7 +86,7 @@ final class CurlTest extends BaseTestCase {
 				str_repeat('x', 548576),
 			],
 		];
-		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -94,7 +94,7 @@ final class CurlTest extends BaseTestCase {
 	}
 
 	public function testSetsExpectHeaderIfBodyIsExactlyA1MbString() {
-		$request = Requests::post(httpbin('/post'), [], str_repeat('x', 1048576), $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], str_repeat('x', 1048576), $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -111,7 +111,7 @@ final class CurlTest extends BaseTestCase {
 				],
 			],
 		];
-		$request = Requests::post(httpbin('/post'), [], $data, $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -119,7 +119,7 @@ final class CurlTest extends BaseTestCase {
 	}
 
 	public function testSetsExpectHeaderIfBodyExactly1Mb() {
-		$request = Requests::post(httpbin('/post'), [], str_repeat('x', 1048576), $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], str_repeat('x', 1048576), $this->getOptions());
 
 		$result = json_decode($request->body, true);
 
@@ -130,7 +130,7 @@ final class CurlTest extends BaseTestCase {
 	 * @small
 	 */
 	public function testSetsEmptyExpectHeaderIfBodySmallerThan1Mb() {
-		$request = Requests::post(httpbin('/post'), [], str_repeat('x', 1048575), $this->getOptions());
+		$request = Requests::post($this->httpbin('/post'), [], str_repeat('x', 1048575), $this->getOptions());
 
 		$result = json_decode($request->body, true);
 

--- a/tests/Transport/Fsockopen/FsockopenTest.php
+++ b/tests/Transport/Fsockopen/FsockopenTest.php
@@ -44,7 +44,7 @@ final class FsockopenTest extends BaseTestCase {
 		$hooks = new Hooks();
 		$hooks->register('fsockopen.after_headers', [$this, 'checkContentLengthHeader']);
 
-		Requests::post(httpbin('/post'), [], [], $this->getOptions(['hooks' => $hooks]));
+		Requests::post($this->httpbin('/post'), [], [], $this->getOptions(['hooks' => $hooks]));
 	}
 
 	/**
@@ -70,7 +70,7 @@ final class FsockopenTest extends BaseTestCase {
 		$hooks = new Hooks();
 		$hooks->register('fsockopen.after_headers', [$this, 'checkHTTPVersionHeader']);
 
-		Requests::post(httpbin('/post'), [], [], $this->getOptions(['hooks' => $hooks]));
+		Requests::post($this->httpbin('/post'), [], [], $this->getOptions(['hooks' => $hooks]));
 
 		// Reset the locale.
 		setlocale(LC_NUMERIC, $locale);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,6 +35,7 @@ foreach ($test_servers as $type => $server) {
 	}
 
 	unset($output);
+	echo 'REQUESTS_TEST_SERVER_', $type, '_AVAILABLE was set to: ', var_export(constant('REQUESTS_TEST_SERVER_' . $type . '_AVAILABLE'), true), PHP_EOL;
 }
 
 if (is_dir(dirname(__DIR__) . '/vendor')

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -70,8 +70,3 @@ if (defined('__PHPUNIT_PHAR__')) {
 	// Testing via a Composer setup.
 	require_once $vendor_dir . '/autoload.php';
 }
-
-function httpbin($suffix = '', $ssl = false) {
-	$host = $ssl ? 'https://' . REQUESTS_TEST_HOST_HTTPS : 'http://' . REQUESTS_TEST_HOST_HTTP;
-	return rtrim($host, '/') . '/' . ltrim($suffix, '/');
-}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,22 @@ define_from_env('REQUESTS_HTTP_PROXY_AUTH');
 define_from_env('REQUESTS_HTTP_PROXY_AUTH_USER');
 define_from_env('REQUESTS_HTTP_PROXY_AUTH_PASS');
 
+// Make sure the test server(s) is/are available.
+$test_servers = [
+	'HTTP'  => REQUESTS_TEST_HOST_HTTP,
+	'HTTPS' => REQUESTS_TEST_HOST_HTTPS,
+];
+foreach ($test_servers as $type => $server) {
+	$command = 'curl -LI ' . $server . ' -o /dev/null -w "%{http_code}\n" -s';
+	exec($command, $output);
+	if (is_array($output) && isset($output[0]) && (strpos($output[0], '2') === 0 || strpos($output[0], '3') === 0)) {
+		define('REQUESTS_TEST_SERVER_' . $type . '_AVAILABLE', true);
+	} else {
+		define('REQUESTS_TEST_SERVER_' . $type . '_AVAILABLE', false);
+	}
+
+	unset($output);
+}
 
 if (is_dir(dirname(__DIR__) . '/vendor')
 	&& file_exists(dirname(__DIR__) . '/vendor/autoload.php')


### PR DESCRIPTION
CI is currently failing due to a problem with the Heroku server being used during the tests.

While that problem, of course, needs to be solved and solved ASAP, in the mean time, we do need to be able to continue work on Requests.

This PR adds a mechanism to check if the server is available and if not, skips the tests using the Heroku server.

### Tests: move the httpbin function declaration to the TestCase

... and adjust all function calls to it from within the tests.

### Tests: skip tests using `httpbin()` if the server is not available

Bit hacky, but it will work, and more importantly, it will only skip those tests which should be skipped.

### 🆕 Test bootstrap: log debug information about test server availability.