### PR TITLE
Change "Request" to "Requests" in deprecation message.

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -19,7 +19,7 @@
 if (!defined('REQUESTS_SILENCE_PSR0_DEPRECATIONS') || REQUESTS_SILENCE_PSR0_DEPRECATIONS !== true) {
 	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 	trigger_error(
-		'The PSR-0 `Requests_...` class names in the Request library are deprecated.'
+		'The PSR-0 `Requests_...` class names in the Requests library are deprecated.'
 		. ' Switch to the PSR-4 `WpOrg\Requests\...` class names at your earliest convenience.',
 		E_USER_DEPRECATED
 	);

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -164,7 +164,7 @@ if (class_exists('WpOrg\Requests\Autoload') === false) {
 				if (!defined('REQUESTS_SILENCE_PSR0_DEPRECATIONS') || REQUESTS_SILENCE_PSR0_DEPRECATIONS !== true) {
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 					trigger_error(
-						'The PSR-0 `Requests_...` class names in the Request library are deprecated.'
+						'The PSR-0 `Requests_...` class names in the Requests library are deprecated.'
 						. ' Switch to the PSR-4 `WpOrg\Requests\...` class names at your earliest convenience.',
 						E_USER_DEPRECATED
 					);

--- a/tests/Autoload/AutoloadTest.php
+++ b/tests/Autoload/AutoloadTest.php
@@ -15,7 +15,7 @@ use WpOrg\Requests\Utility\FilteredIterator;
  */
 final class AutoloadTest extends TestCase {
 
-	const MSG = 'The PSR-0 `Requests_...` class names in the Request library are deprecated.';
+	const MSG = 'The PSR-0 `Requests_...` class names in the Requests library are deprecated.';
 
 	/**
 	 * Verify that a deprecation notice is thrown when the "old" Requests class is loaded via a require/include.


### PR DESCRIPTION
There is a minor typo in `library/Requests.php`, `src/Autoload.php` and the test file `tests/Autoload/AutoloadTest.php`.

> The PSR-0 `Requests_...` class names in the Request library are deprecated.

"Request" should be "Requests".

## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [ ] New feature
- [x] Code quality improvement

## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).