### PR TITLE
GH Actions: remove build against PHP 5.6.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
       # Keys:
       # - coverage: Whether to run the tests with code coverage.
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.3']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.3']
         coverage: [false]
 
         include:
           # Run code coverage on low/high PHP.
-          - php: '5.6.20'
+          - php: '5.6'
             coverage: true
           - php: '8.2'
             coverage: true


### PR DESCRIPTION
The `setup-php` action doesn't allow for requesting specific minors, so the PHP `5.6.20` build was in practice `5.6.40`, which was already being tested, so it having a separate `5.6.20` build has no added value.