### PR TITLE
GH Actions/update website: update for new "create pull request" action runner version

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -21,6 +21,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   prepare:
     name: "Prepare website update"
@@ -180,6 +184,11 @@ jobs:
           draft: ${{ steps.get_pr_info.outputs.DRAFT }}
 
       # Test that the site builds correctly.
+      - name: Checkout the newly created branch
+        uses: actions/checkout@v3
+        with:
+          ref: feature/auto-ghpages-update-${{ steps.get_pr_info.outputs.REF }}
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
1. Looks like GitHub recently made some changes in how the `GITHUB_TOKEN` behaves when a workflow is triggered by a PR created via Dependabot.
    Due to this change, the PR which this workflow is trying to create is blocked, which is what's causing the build failure on PR #804.
    By adding these explicit permissions, the workflow should be able to create the "website update" PR, even when the workflow is triggered by a Dependabot PR.
    Refs:
    * https://github.com/peter-evans/create-pull-request/issues/1873
    * https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
2. In version 5 of the `peter-evans/create-pull-request` action runner, the original branch will be checked out after the PR creation has finished.
    This is different from version 4, which left the PR branch checked out.
    As the test build of the GH Pages site should be run on the PR branch (as otherwise we would be testing the already deployed `gh-pages` branch), we need to add an extra step to re-checkout the PR branch after the PR has been created and before running the GH Pages build test.

Once this PR has been merged, PR #804 should be rebased and :fingers_crossed: the workflow build should pass.

👉🏻 Even though this PR is pulled against `develop`, I'm milestoning it for the next `2.0.x` release as this change should probably be backported.