### PR TITLE
Add `security.md` file

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+The latest minor version of the `2.x` release series is supported for security updates.
+
+## Reporting a Vulnerability
+
+The Requests team takes security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+**Please do not report or discuss security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Issues can be reported privately to the maintainers by opening a [Security vulnerability report].
+
+Additionally, as Requests is used by the WordPress CMS, security issues can be reported via the [WordPress HackerOne][WordPress HackerOne] program.
+Full details of the WordPress Security Policy and the list of covered projects and infrastructure can be found on [HackerOne][WordPress HackerOne].
+
+### Preferences
+
+* Please provide detailed reports with reproducible steps and a clearly defined impact.
+* Include the version number of the vulnerable package in your report.
+* Fixes are most welcome.
+    A private PR can be created from the security report to work on and discuss the patch.
+
+[Security vulnerability report]: https://github.com/WordPress/Requests/security/advisories/new
+[WordPress HackerOne]:           https://hackerone.com/wordpress


### PR DESCRIPTION
... containing information about how to report security issues and what versions of Requests are supported from a security point of view.

The file is placed in the `.github` directory. This will allow for it to be recognized correctly by GitHub, while not cluttering up the project root directory.

Ref: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository

Fixes #665