### PR TITLE
Replace Heroku test-server with Render alternative

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -75,8 +75,8 @@ jobs:
           echo "REQUESTS_HTTP_PROXY_AUTH_USER=test" >> $GITHUB_ENV
           echo "REQUESTS_HTTP_PROXY_AUTH_PASS=pass" >> $GITHUB_ENV
 
-      - name: Ensure the HTTPS test instance on Heroku is spun up
-        run: curl -s -I http://requests-php-tests.herokuapp.com/ > /dev/null
+      - name: Ensure the HTTPS test instance on Render is spun up
+        run: curl -s -I https://requests-test-server.onrender.com/ > /dev/null
 
       - name: Check mitmproxy version
         run: mitmdump --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
           echo "REQUESTS_HTTP_PROXY_AUTH_PASS=pass" >> $GITHUB_ENV
 
       - name: Ensure the HTTPS test instance on Heroku is spun up
-        run: curl -s -I http://requests-php-tests.herokuapp.com/ > /dev/null
+        run: curl -s -I http://requests-test-server.onrender.com/ > /dev/null
 
       - name: Check mitmproxy version
         run: mitmdump --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
           echo "REQUESTS_HTTP_PROXY_AUTH_USER=test" >> $GITHUB_ENV
           echo "REQUESTS_HTTP_PROXY_AUTH_PASS=pass" >> $GITHUB_ENV
 
-      - name: Ensure the HTTPS test instance on Heroku is spun up
+      - name: Ensure the HTTPS test instance on Render is spun up
         run: curl -s -I https://requests-test-server.onrender.com/ > /dev/null
 
       - name: Check mitmproxy version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
           echo "REQUESTS_HTTP_PROXY_AUTH_PASS=pass" >> $GITHUB_ENV
 
       - name: Ensure the HTTPS test instance on Heroku is spun up
-        run: curl -s -I http://requests-test-server.onrender.com/ > /dev/null
+        run: curl -s -I https://requests-test-server.onrender.com/ > /dev/null
 
       - name: Check mitmproxy version
         run: mitmdump --version

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -9,6 +9,10 @@ final class EnvironmentTest extends TestCase {
 	/**
 	 * Tests whether the HTTP test server is available.
 	 *
+	 * This makes sure that the build actually fails when the HTTP test
+	 * server is not available, as all tests relying on it further down
+	 * the line will just be marked as skipped.
+	 *
 	 * @return void
 	 */
 	public function testHttpTestServerAvailable() {
@@ -17,6 +21,10 @@ final class EnvironmentTest extends TestCase {
 
 	/**
 	 * Tests whether the HTTPS test server is available.
+	 *
+	 * This makes sure that the build actually fails when the HTTPS test
+	 * server is not available, as all tests relying on it further down
+	 * the line will just be marked as skipped.
 	 *
 	 * @return void
 	 */

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WpOrg\Requests\Tests;
+
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Iri;
+use WpOrg\Requests\Requests;
+use WpOrg\Requests\Response\Headers;
+use WpOrg\Requests\Tests\Fixtures\RawTransportMock;
+use WpOrg\Requests\Tests\Fixtures\TransportMock;
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
+
+final class EnvironmentTest extends TestCase {
+
+	/**
+	 * Tests whether the HTTP test server is available.
+	 *
+	 * @return void
+	 */
+	public function testHttpTestServerAvailable() {
+		$this->assertTrue(\REQUESTS_TEST_SERVER_HTTP_AVAILABLE);
+	}
+
+	/**
+	 * Tests whether the HTTPS test server is available.
+	 *
+	 * @return void
+	 */
+	public function testHttpsTestServerAvailable() {
+		$this->assertTrue(\REQUESTS_TEST_SERVER_HTTPS_AVAILABLE);
+	}
+}

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -2,15 +2,7 @@
 
 namespace WpOrg\Requests\Tests;
 
-use WpOrg\Requests\Exception;
-use WpOrg\Requests\Exception\InvalidArgument;
-use WpOrg\Requests\Iri;
-use WpOrg\Requests\Requests;
-use WpOrg\Requests\Response\Headers;
-use WpOrg\Requests\Tests\Fixtures\RawTransportMock;
-use WpOrg\Requests\Tests\Fixtures\TransportMock;
 use WpOrg\Requests\Tests\TestCase;
-use WpOrg\Requests\Tests\TypeProviderHelper;
 
 final class EnvironmentTest extends TestCase {
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,7 +11,7 @@ function define_from_env($name, $fallback = false) {
 	}
 }
 
-define_from_env('REQUESTS_TEST_HOST', 'requests-php-tests.herokuapp.com');
+define_from_env('REQUESTS_TEST_HOST', 'requests-test-server.onrender.com');
 define_from_env('REQUESTS_TEST_HOST_HTTP', REQUESTS_TEST_HOST);
 define_from_env('REQUESTS_TEST_HOST_HTTPS', REQUESTS_TEST_HOST);
 


### PR DESCRIPTION
Fixes #784 

## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [x] Code quality improvement

## Context

As detailed in https://github.com/WordPress/Requests/issues/784, Heroku has stopped offering a free plan and we need to switch to an alternative.

We have so far opted to try https://render.com/ and it seems to work as a valid replacement within its free tier.

## Detailed Description

This PR only changes the URL to use for testing to switch from `requests-php-tests.herokuapp.com` to `requests-test-server.onrender.com`.

## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [ ] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!
I.e. code style complies with the project standard, the unit tests pass, code coverage has not gone down.

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make reviewing your changes easier for the maintainers.
============================================================================================
-->
