### PR TITLE
Tests: update test suite to allow for running the tests on PHPUnit 10

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@ tests/ export-ignore
 .phpcs.xml.dist export-ignore
 phpdoc.dist.xml export-ignore
 phpunit.xml.dist export-ignore
+phpunit10.xml.dist export-ignore

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -90,11 +90,17 @@ jobs:
       - name: Access localhost on port 9002
         run: curl -i http://localhost:9002
 
-      - name: Show PHPUnit version
-        run: vendor/bin/phpunit --version
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
 
-      - name: Run the unit tests
+      - name: Run the unit tests (PHPUnit < 10)
+        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         run: composer test
+
+      - name: Run the unit tests (PHPUnit 10+)
+        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        run: composer test10
 
       - name: Stop proxy server
         continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,16 +114,25 @@ jobs:
       - name: Access localhost on port 9002
         run: curl -i http://localhost:9002
 
-      - name: Show PHPUnit version
-        run: vendor/bin/phpunit --version
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
 
-      - name: Run the unit tests, no code coverage
-        if: ${{ matrix.coverage == false }}
+      - name: Run the unit tests, no code coverage (PHPUnit < 10)
+        if: ${{  matrix.coverage == false && ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         run: composer test
 
-      - name: Run the unit tests with code coverage
-        if: ${{ matrix.coverage == true }}
-        run: vendor/bin/phpunit --coverage-clover clover.xml
+      - name: Run the unit tests, no code coverage (PHPUnit 10+)
+        if: ${{  matrix.coverage == false && startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        run: composer test10
+
+      - name: Run the unit tests with code coverage (PHPUnit < 10)
+        if: ${{  matrix.coverage == true && ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        run: composer coverage -- --coverage-clover clover.xml
+
+      - name: Run the unit tests with code coverage (PHPUnit 10+)
+        if: ${{  matrix.coverage == true && startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        run: composer coverage10 -- --coverage-clover clover.xml
 
       - name: Stop proxy server
         continue-on-error: true

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -247,4 +247,9 @@
 		<exclude-pattern>/tests/*\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Using set_error_handler() in test code is fine. -->
+	<rule ref="WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -93,5 +93,14 @@
     "coverage10": [
       "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist"
     ]
+  },
+  "scripts-descriptions": {
+    "lint": "Lint PHP files to find parse errors.",
+    "checkcs": "Check the entire codebase for code-style issues.",
+    "fixcs": "Fix all auto-fixable code-style issues in the entire codebase.",
+    "test": "Run the unit tests on PHPUnit 5.x - 9.x without code coverage.",
+    "test10": "Run the unit tests on PHPUnit 10.x without code coverage.",
+    "coverage": "Run the unit tests on PHPUnit 5.x - 9.x with code coverage.",
+    "coverage10": "Run the unit tests on PHPUnit 10.x with code coverage."
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -84,8 +84,14 @@
     "test": [
       "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
     ],
+    "test10": [
+      "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist --no-coverage"
+    ],
     "coverage": [
       "@php ./vendor/phpunit/phpunit/phpunit"
+    ],
+    "coverage10": [
+      "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "php-parallel-lint/php-parallel-lint": "^1.3.2",
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
-    "yoast/phpunit-polyfills": "^1.0.0",
+    "yoast/phpunit-polyfills": "^2.0.0",
     "roave/security-advisories": "dev-latest"
   },
   "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
 	backupGlobals="true"
 	bootstrap="tests/bootstrap.php"
+	beStrictAboutTestsThatDoNotTestAnything="true"
 	convertDeprecationsToExceptions="true"
 	colors="true"
 	verbose="true"

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/10.1/phpunit.xsd"
+	backupGlobals="true"
+	bootstrap="tests/bootstrap.php"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	colors="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnIncompleteTests="true"
+	displayDetailsOnSkippedTests="true"
+	failOnWarning="true"
+	failOnNotice="true"
+	failOnDeprecation="true"
+	>
+	<testsuites>
+		<testsuite name="RequestsTests">
+			<directory suffix="Test.php">tests</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<directory suffix=".php">./src/</directory>
+		</include>
+	</source>
+
+	<coverage includeUncoveredFiles="true" ignoreDeprecatedCodeUnits="true">
+		<report>
+			<html outputDirectory="tests/coverage" lowUpperBound="35" highLowerBound="90"/>
+		</report>
+	</coverage>
+</phpunit>

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -177,6 +177,11 @@ final class Curl implements Transport {
 			$this->stream_handle = @fopen($options['filename'], 'wb');
 			if ($this->stream_handle === false) {
 				$error = error_get_last();
+				if (!is_array($error)) {
+					// Shouldn't be possible, but can happen in test situations.
+					$error = ['message' => 'Failed to open stream'];
+				}
+
 				throw new Exception($error['message'], 'fopen');
 			}
 		}

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -282,6 +282,11 @@ final class Fsockopen implements Transport {
 			$download = @fopen($options['filename'], 'wb');
 			if ($download === false) {
 				$error = error_get_last();
+				if (!is_array($error)) {
+					// Shouldn't be possible, but can happen in test situations.
+					$error = ['message' => 'Failed to open stream'];
+				}
+
 				throw new Exception($error['message'], 'fopen');
 			}
 		}

--- a/tests/Auth/Basic/BasicTest.php
+++ b/tests/Auth/Basic/BasicTest.php
@@ -44,14 +44,14 @@ final class BasicTest extends TestCase {
 		$result = json_decode($request->body);
 		$this->assertIsObject($result, 'Decoded response body is not an object');
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'authenticated',
 			$result,
 			'Property "authenticated" not available in decoded response'
 		);
 		$this->assertTrue($result->authenticated, 'Authentication failed');
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'user',
 			$result,
 			'Property "user" not available in decoded response'
@@ -91,14 +91,14 @@ final class BasicTest extends TestCase {
 		$result = json_decode($request->body);
 		$this->assertIsObject($result, 'Decoded response body is not an object');
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'authenticated',
 			$result,
 			'Property "authenticated" not available in decoded response'
 		);
 		$this->assertTrue($result->authenticated, 'Authentication failed');
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'user',
 			$result,
 			'Property "user" not available in decoded response'
@@ -141,14 +141,14 @@ final class BasicTest extends TestCase {
 		$result = json_decode($request->body);
 		$this->assertIsObject($result, 'Decoded response body is not an object');
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'authenticated',
 			$result,
 			'Property "authenticated" not available in decoded response'
 		);
 		$this->assertTrue($result->authenticated, 'Authentication failed');
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'user',
 			$result,
 			'Property "user" not available in decoded response'
@@ -189,12 +189,12 @@ final class BasicTest extends TestCase {
 		$result = json_decode($request->body);
 
 		$this->assertIsObject($result, 'Decoded response body is not an object');
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'headers',
 			$result,
 			'Property "headers" not available in decoded response'
 		);
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'Authorization',
 			$result->headers,
 			'Property "headers->Authorization" not available in decoded response'
@@ -205,7 +205,7 @@ final class BasicTest extends TestCase {
 		$this->assertArrayHasKey(1, $auth, 'Authorization header failed to be split into two parts');
 		$this->assertSame(base64_encode('user:passwd'), $auth[1], 'Unexpected authorization string in headers');
 
-		$this->assertObjectHasAttribute(
+		$this->assertObjectHasProperty(
 			'data',
 			$result,
 			'Property "data" not available in decoded response'

--- a/tests/Auth/Basic/ConstructorTest.php
+++ b/tests/Auth/Basic/ConstructorTest.php
@@ -34,7 +34,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputType() {
+	public static function dataInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_ARRAY);
 	}
 
@@ -59,7 +59,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidArgumentCount() {
+	public static function dataInvalidArgumentCount() {
 		return [
 			'empty array'                 => [[]],
 			'array with only one element' => [['user']],

--- a/tests/Autoload/AutoloadTest.php
+++ b/tests/Autoload/AutoloadTest.php
@@ -2,6 +2,7 @@
 
 namespace WpOrg\Requests\Tests\Autoload;
 
+use Exception;
 use Requests;
 use Requests_Exception_Transport_cURL;
 use Requests_Utility_FilteredIterator;
@@ -21,8 +22,17 @@ final class AutoloadTest extends TestCase {
 	 * Verify that a deprecation notice is thrown when the "old" Requests class is loaded via a require/include.
 	 */
 	public function testDeprecationNoticeThrownForOldRequestsClass() {
-		$this->expectDeprecation();
-		$this->expectDeprecationMessage(self::MSG);
+		// PHPUnit 10 compatible way to test the deprecation notice.
+		set_error_handler(
+			static function ($errno, $errstr) {
+				restore_error_handler();
+				throw new Exception($errstr, $errno);
+			},
+			E_USER_DEPRECATED
+		);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage(self::MSG);
 
 		require_once dirname(dirname(__DIR__)) . '/library/Requests.php';
 	}
@@ -31,8 +41,17 @@ final class AutoloadTest extends TestCase {
 	 * Verify that a deprecation notice is thrown when one of the other "old" Requests classes is autoloaded.
 	 */
 	public function testDeprecationNoticeThrownForOtherOldRequestsClass() {
-		$this->expectDeprecation();
-		$this->expectDeprecationMessage(self::MSG);
+		// PHPUnit 10 compatible way to test the deprecation notice.
+		set_error_handler(
+			static function ($errno, $errstr) {
+				restore_error_handler();
+				throw new Exception($errstr, $errno);
+			},
+			E_USER_DEPRECATED
+		);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage(self::MSG);
 
 		$this->assertNotEmpty(Requests_Exception_Transport_cURL::EASY);
 	}

--- a/tests/Autoload/AutoloadTest.php
+++ b/tests/Autoload/AutoloadTest.php
@@ -91,7 +91,7 @@ final class AutoloadTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataLoad() {
+	public static function dataLoad() {
 		return [
 			'Request for class not in this package should be rejected' => [
 				'class_name' => 'Unrelated\Package\ClassName',

--- a/tests/Cookie/ConstructorTest.php
+++ b/tests/Cookie/ConstructorTest.php
@@ -50,7 +50,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidStringInput() {
+	public static function dataInvalidStringInput() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
@@ -75,7 +75,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidAttributes() {
+	public static function dataInvalidAttributes() {
 		$except = array_intersect(TypeProviderHelper::GROUP_ITERABLE, TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
 		return TypeProviderHelper::getAllExcept($except);
 	}
@@ -101,7 +101,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidFlags() {
+	public static function dataInvalidFlags() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 
@@ -126,7 +126,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidReferenceTime() {
+	public static function dataInvalidReferenceTime() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_INT);
 	}
 
@@ -152,7 +152,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataMinimalArguments() {
+	public static function dataMinimalArguments() {
 		return [
 			'empty name and value' => [
 				'name'  => '',
@@ -199,7 +199,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataFlagMerging() {
+	public static function dataFlagMerging() {
 		return [
 			'empty array' => [
 				'flags'    => [],
@@ -269,7 +269,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataSetReferenceTime() {
+	public static function dataSetReferenceTime() {
 		return [
 			'null' => [
 				'time' => null,
@@ -302,7 +302,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataAttributesAreNormalized() {
+	public static function dataAttributesAreNormalized() {
 		return [
 			'empty array' => [
 				'attributes' => [],

--- a/tests/Cookie/DomainMatchesTest.php
+++ b/tests/Cookie/DomainMatchesTest.php
@@ -34,7 +34,7 @@ final class DomainMatchesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInput() {
+	public static function dataInvalidInput() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
@@ -62,7 +62,7 @@ final class DomainMatchesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataManuallySetCookie() {
+	public static function dataManuallySetCookie() {
 		$domains = [
 			'example.com',
 			'example.net',
@@ -117,7 +117,7 @@ final class DomainMatchesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataDomainMatch() {
+	public static function dataDomainMatch() {
 		return [
 			'Empty string' => [
 				'original'       => 'example.com',

--- a/tests/Cookie/DomainMatchesTest.php
+++ b/tests/Cookie/DomainMatchesTest.php
@@ -68,7 +68,7 @@ final class DomainMatchesTest extends TestCase {
 			'example.net',
 		];
 
-		return $this->textArrayToDataprovider($domains);
+		return self::textArrayToDataprovider($domains);
 	}
 
 	/**

--- a/tests/Cookie/Jar/ConstructorTest.php
+++ b/tests/Cookie/Jar/ConstructorTest.php
@@ -34,7 +34,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputType() {
+	public static function dataInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 
@@ -64,7 +64,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValidInputType() {
+	public static function dataValidInputType() {
 		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_ARRAY);
 	}
 }

--- a/tests/Cookie/Jar/NormalizeCookieTest.php
+++ b/tests/Cookie/Jar/NormalizeCookieTest.php
@@ -55,7 +55,7 @@ final class NormalizeCookieTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataNormalization() {
+	public static function dataNormalization() {
 		return [
 			'unbaked cookie (string)' => [
 				'cookie'        => self::COOKIE_VALUE,

--- a/tests/Cookie/NormalizeTest.php
+++ b/tests/Cookie/NormalizeTest.php
@@ -36,7 +36,7 @@ final class NormalizeTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataNormalizeAttributes() {
+	public static function dataNormalizeAttributes() {
 		return [
 			/*
 			 * Test cases specific to the normalize() method.
@@ -275,7 +275,7 @@ final class NormalizeTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataNormalizeAttributesExpiresUnsupportedType() {
+	public static function dataNormalizeAttributesExpiresUnsupportedType() {
 		$types = TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, TypeProviderHelper::GROUP_STRING);
 
 		$data = [];
@@ -296,7 +296,7 @@ final class NormalizeTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataNormalizeAttributesMaxAgeUnsupportedType() {
+	public static function dataNormalizeAttributesMaxAgeUnsupportedType() {
 		$types = TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, TypeProviderHelper::GROUP_STRING);
 
 		$data = [];
@@ -317,7 +317,7 @@ final class NormalizeTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataNormalizeAttributesDomainUnsupportedType() {
+	public static function dataNormalizeAttributesDomainUnsupportedType() {
 		$types = TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 
 		$data = [];

--- a/tests/Cookie/ParseTest.php
+++ b/tests/Cookie/ParseTest.php
@@ -55,7 +55,7 @@ final class ParseTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidStringInput() {
+	public static function dataInvalidStringInput() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
@@ -401,7 +401,7 @@ final class ParseTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataParsingHeaderWithOrigin() {
+	public static function dataParsingHeaderWithOrigin() {
 		return [
 			// Varying origin path.
 			'Origin: http://example.com (no trailing slash for path)' => [

--- a/tests/Cookie/PathMatchesTest.php
+++ b/tests/Cookie/PathMatchesTest.php
@@ -44,7 +44,7 @@ final class PathMatchesTest extends TestCase {
 			'/test/',
 		];
 
-		return $this->textArrayToDataprovider($paths);
+		return self::textArrayToDataprovider($paths);
 	}
 
 	/**

--- a/tests/Cookie/PathMatchesTest.php
+++ b/tests/Cookie/PathMatchesTest.php
@@ -36,7 +36,7 @@ final class PathMatchesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataManuallySetCookie() {
+	public static function dataManuallySetCookie() {
 		$paths = [
 			'',
 			'/',
@@ -72,7 +72,7 @@ final class PathMatchesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataPathMatchUndesiredInputTypes() {
+	public static function dataPathMatchUndesiredInputTypes() {
 		$data      = [];
 		$all_types = TypeProviderHelper::getAll();
 		foreach ($all_types as $key => $value) {
@@ -111,7 +111,7 @@ final class PathMatchesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataPathMatch() {
+	public static function dataPathMatch() {
 		return [
 			'Exact match: "/"' => [
 				'original' => '/',

--- a/tests/Cookie/UriMatchesTest.php
+++ b/tests/Cookie/UriMatchesTest.php
@@ -272,6 +272,6 @@ final class UriMatchesTest extends TestCase {
 			'http://example.net/test/',
 		];
 
-		return $this->textArrayToDataprovider($urls);
+		return self::textArrayToDataprovider($urls);
 	}
 }

--- a/tests/Cookie/UriMatchesTest.php
+++ b/tests/Cookie/UriMatchesTest.php
@@ -68,7 +68,7 @@ final class UriMatchesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataUrlMatch() {
+	public static function dataUrlMatch() {
 		return [
 			// Domain handling.
 			'Domain handling: same domain name, same TLD' => [
@@ -211,7 +211,7 @@ final class UriMatchesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataUrlMatchSecure() {
+	public static function dataUrlMatchSecure() {
 		return [
 			'Secure matching: off, scheme: http' => [
 				'secure'    => false,
@@ -261,7 +261,7 @@ final class UriMatchesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataManuallySetCookie() {
+	public static function dataManuallySetCookie() {
 		$urls = [
 			'http://example.com',
 			'http://example.com/',

--- a/tests/Exception/Http/HttpTest.php
+++ b/tests/Exception/Http/HttpTest.php
@@ -39,7 +39,7 @@ final class HttpTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataException() {
+	public static function dataException() {
 		return [
 			'null (or not passed)' => [
 				'expected_msg'    => 'Unknown',
@@ -72,7 +72,7 @@ final class HttpTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataGetClass() {
+	public static function dataGetClass() {
 		$default = StatusUnknown::class;
 
 		return [

--- a/tests/Exception/Http/StatusUnknownTest.php
+++ b/tests/Exception/Http/StatusUnknownTest.php
@@ -33,7 +33,7 @@ final class StatusUnknownTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataException() {
+	public static function dataException() {
 		$response_with_status              = new Response();
 		$response_with_status->status_code = 12345;
 

--- a/tests/Exception/Transport/Curl/CurlTest.php
+++ b/tests/Exception/Transport/Curl/CurlTest.php
@@ -50,7 +50,7 @@ final class CurlTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataException() {
+	public static function dataException() {
 		return [
 			'Everything set to null (or not passed)' => [
 				'expected_msg'    => '-1 Unknown',

--- a/tests/Hooks/DispatchTest.php
+++ b/tests/Hooks/DispatchTest.php
@@ -50,7 +50,7 @@ class DispatchTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidHookname() {
+	public static function dataInvalidHookname() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
@@ -75,7 +75,7 @@ class DispatchTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidParameters() {
+	public static function dataInvalidParameters() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 

--- a/tests/Hooks/DispatchTest.php
+++ b/tests/Hooks/DispatchTest.php
@@ -2,7 +2,6 @@
 
 namespace WpOrg\Requests\Tests\Hooks;
 
-use stdClass;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Hooks;
 use WpOrg\Requests\Tests\TestCase;
@@ -181,9 +180,7 @@ class DispatchTest extends TestCase {
 	 * @return void
 	 */
 	public function testDispatchWithSingleRegisteredHook() {
-		$mock = $this->getMockBuilder(stdClass::class)
-			->setMethods(['callback'])
-			->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['callback']);
 
 		$mock->expects($this->once())
 			->method('callback');
@@ -199,9 +196,7 @@ class DispatchTest extends TestCase {
 	 * @return void
 	 */
 	public function testDispatchWithMultipleRegisteredHooks() {
-		$mock = $this->getMockBuilder(stdClass::class)
-			->setMethods(['callback_a', 'callback_b', 'callback_c'])
-			->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['callback_a', 'callback_b', 'callback_c']);
 
 		$mock->expects($this->never())
 			->method('callback_a');

--- a/tests/Hooks/RegisterTest.php
+++ b/tests/Hooks/RegisterTest.php
@@ -51,7 +51,7 @@ class RegisterTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidHookname() {
+	public static function dataInvalidHookname() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
@@ -76,11 +76,11 @@ class RegisterTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidCallback() {
+	public static function dataInvalidCallback() {
 		return [
 			'null'                  => [null],
 			'non-existent function' => ['functionname'],
-			'non-existent method'   => [[$this, 'dummyCallbackDoesNotExist']],
+			'non-existent method'   => [[__CLASS__, 'dummyCallbackDoesNotExist']],
 			'empty array'           => [[]],
 			'plain object'          => [new stdClass(), 'method'],
 		];
@@ -107,7 +107,7 @@ class RegisterTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidPriority() {
+	public static function dataInvalidPriority() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, ['numeric string']);
 	}
 

--- a/tests/IdnaEncoder/IdnaEncoderTest.php
+++ b/tests/IdnaEncoder/IdnaEncoderTest.php
@@ -38,7 +38,7 @@ final class IdnaEncoderTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputType() {
+	public static function dataInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -62,7 +62,7 @@ final class IdnaEncoderTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataEncoding() {
+	public static function dataEncoding() {
 		return [
 			'empty string' => [
 				'data'     => '',
@@ -242,7 +242,7 @@ final class IdnaEncoderTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidUnicode() {
+	public static function dataInvalidUnicode() {
 		return [
 			'Five-byte character'                    => ["\xfb\xb6\xb6\xb6\xb6"],
 			'Six-byte character'                     => ["\xfd\xb6\xb6\xb6\xb6\xb6"],

--- a/tests/Ipv6/CheckIpv6Test.php
+++ b/tests/Ipv6/CheckIpv6Test.php
@@ -39,7 +39,7 @@ final class CheckIpv6Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputType() {
+	public static function dataInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -61,7 +61,7 @@ final class CheckIpv6Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValidInputType() {
+	public static function dataValidInputType() {
 		return [
 			'string'     => ['::1'],
 			'stringable' => [new StringableObject('0:1234:dc0:41:216:3eff:fe67:3e01')],

--- a/tests/Ipv6/CompressTest.php
+++ b/tests/Ipv6/CompressTest.php
@@ -39,7 +39,7 @@ final class CompressTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputType() {
+	public static function dataInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -61,7 +61,7 @@ final class CompressTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValidInputType() {
+	public static function dataValidInputType() {
 		return [
 			'string'     => ['::1'],
 			'stringable' => [new StringableObject('0:1234:dc0:41:216:3eff:fe67:3e01')],

--- a/tests/Ipv6/UncompressTest.php
+++ b/tests/Ipv6/UncompressTest.php
@@ -39,7 +39,7 @@ final class UncompressTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputType() {
+	public static function dataInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -61,7 +61,7 @@ final class UncompressTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValidInputType() {
+	public static function dataValidInputType() {
 		return [
 			'string'     => ['::1'],
 			'stringable' => [new StringableObject('0:1234:dc0:41:216:3eff:fe67:3e01')],

--- a/tests/Iri/ConstructorTest.php
+++ b/tests/Iri/ConstructorTest.php
@@ -34,7 +34,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInput() {
+	public static function dataInvalidInput() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_STRINGABLE);
 	}
 

--- a/tests/Iri/IriTest.php
+++ b/tests/Iri/IriTest.php
@@ -42,6 +42,7 @@
 
 namespace WpOrg\Requests\Tests\Iri;
 
+use Exception;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Tests\TestCase;
 
@@ -391,7 +392,18 @@ final class IriTest extends TestCase
 
 	public function testNonexistantProperty()
 	{
-		$this->expectNotice('Undefined property: WpOrg\Requests\Iri::nonexistant_prop');
+		// PHPUnit 10 compatible way to test the notice.
+		set_error_handler(
+			static function ($errno, $errstr) {
+				restore_error_handler();
+				throw new Exception($errstr, $errno);
+			},
+			E_USER_NOTICE
+		);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Undefined property: WpOrg\Requests\Iri::nonexistant_prop');
+
 		$iri = new Iri();
 		$this->assertFalse(isset($iri->nonexistant_prop));
 		$should_fail = $iri->nonexistant_prop;

--- a/tests/Port/GetTest.php
+++ b/tests/Port/GetTest.php
@@ -34,7 +34,7 @@ final class GetTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataGetPortThrowsExceptionOnInvalidInputType() {
+	public static function dataGetPortThrowsExceptionOnInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
@@ -59,7 +59,7 @@ final class GetTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataGetPortThrowsExceptionOnUnsupportedPortType() {
+	public static function dataGetPortThrowsExceptionOnUnsupportedPortType() {
 		return [
 			'type not supported' => ['FTP'],
 			'empty string'       => [''],
@@ -85,7 +85,7 @@ final class GetTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataGetPort() {
+	public static function dataGetPort() {
 		return [
 			'lowercase type' => [
 				'input'    => 'https',

--- a/tests/Proxy/Http/ConstructorTest.php
+++ b/tests/Proxy/Http/ConstructorTest.php
@@ -33,7 +33,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidParameterType() {
+	public static function dataInvalidParameterType() {
 		return TypeProviderHelper::getAllExcept(
 			TypeProviderHelper::GROUP_NULL,
 			TypeProviderHelper::GROUP_STRING,

--- a/tests/Requests/DecodeChunkedTest.php
+++ b/tests/Requests/DecodeChunkedTest.php
@@ -41,7 +41,7 @@ final class DecodeChunkedTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataChunked() {
+	public static function dataChunked() {
 		return [
 			[
 				'body'     => "25\r\nThis is the data in the first chunk\r\n\r\n1A\r\nand this is the second one\r\n0\r\n",
@@ -98,7 +98,7 @@ final class DecodeChunkedTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataNotActuallyChunked() {
+	public static function dataNotActuallyChunked() {
 		return [
 			'empty string'                         => [''],
 			'invalid chunk size'                   => ['Hello! This is a non-chunked response!'],

--- a/tests/Requests/DecompressionTest.php
+++ b/tests/Requests/DecompressionTest.php
@@ -54,7 +54,7 @@ final class DecompressionTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataDecompressNotCompressed() {
+	public static function dataDecompressNotCompressed() {
 		return [
 			'not compressed: empty string' => [
 				'expected'   => '',
@@ -76,8 +76,8 @@ final class DecompressionTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataCompatibleInflateNotCompressed() {
-		$data = $this->dataDecompressNotCompressed();
+	public static function dataCompatibleInflateNotCompressed() {
+		$data = self::dataDecompressNotCompressed();
 		foreach ($data as $key => $value) {
 			$data[$key]['expected'] = false;
 		}
@@ -90,7 +90,7 @@ final class DecompressionTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataGzip() {
+	public static function dataGzip() {
 		return [
 			/*
 			 * Test data generated using CLI command:
@@ -119,7 +119,7 @@ final class DecompressionTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataDeflate() {
+	public static function dataDeflate() {
 		return [
 			// TODO: What is this byte stream representing? Looks like GZIP header with ZLIB compressed data...
 			'deflate: foobar' => [
@@ -142,7 +142,7 @@ final class DecompressionTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataDeflateWithoutHeaders() {
+	public static function dataDeflateWithoutHeaders() {
 		return [
 			/*
 			 * Test data generated using CLI command:
@@ -232,7 +232,7 @@ final class DecompressionTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputType() {
+	public static function dataInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 }

--- a/tests/Requests/FlattenTest.php
+++ b/tests/Requests/FlattenTest.php
@@ -34,7 +34,7 @@ final class FlattenTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidData() {
+	public static function dataInvalidData() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ITERABLE);
 	}
 
@@ -61,7 +61,7 @@ final class FlattenTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataFlatten() {
+	public static function dataFlatten() {
 		$to_flatten = ['key1' => 'value1', 'key2' => 'value2'];
 
 		return [

--- a/tests/Requests/RequestsTest.php
+++ b/tests/Requests/RequestsTest.php
@@ -37,7 +37,7 @@ final class RequestsTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataRequestInvalidUrl() {
+	public static function dataRequestInvalidUrl() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -64,7 +64,7 @@ final class RequestsTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidTypeNotString() {
+	public static function dataInvalidTypeNotString() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
 	}
 
@@ -109,7 +109,7 @@ final class RequestsTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataRequestMultipleInvalidRequests() {
+	public static function dataRequestMultipleInvalidRequests() {
 		$except = array_intersect(TypeProviderHelper::GROUP_ITERABLE, TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
 		return TypeProviderHelper::getAllExcept($except);
 	}
@@ -137,7 +137,7 @@ final class RequestsTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidTypeNotArray() {
+	public static function dataInvalidTypeNotArray() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 

--- a/tests/Requests/SetCertificatePathTest.php
+++ b/tests/Requests/SetCertificatePathTest.php
@@ -35,7 +35,7 @@ final class SetCertificatePathTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidData() {
+	public static function dataInvalidData() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_BOOL, TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -59,7 +59,7 @@ final class SetCertificatePathTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValidData() {
+	public static function dataValidData() {
 		return [
 			'boolean false'     => [false],
 			'boolean true'      => [true],

--- a/tests/Response/DecodeBodyTest.php
+++ b/tests/Response/DecodeBodyTest.php
@@ -37,7 +37,7 @@ final class DecodeBodyTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidJsonResponse() {
+	public static function dataInvalidJsonResponse() {
 		$data = [
 			'text string, not JSON (syntax error)'       => ['Invalid JSON'],
 			'invalid JSON: single quotes (syntax error)' => ["{ 'bar': 'baz' }"],

--- a/tests/Response/Headers/ArrayAccessTest.php
+++ b/tests/Response/Headers/ArrayAccessTest.php
@@ -50,7 +50,7 @@ final class ArrayAccessTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataCaseInsensitiveArrayAccess() {
+	public static function dataCaseInsensitiveArrayAccess() {
 		return [
 			'access using case as set' => ['Content-Type'],
 			'access using lowercase'   => ['content-type'],
@@ -104,7 +104,7 @@ final class ArrayAccessTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataOffsetSetDoesNotTryToLowercaseNonStringKeys() {
+	public static function dataOffsetSetDoesNotTryToLowercaseNonStringKeys() {
 		return [
 			'integer key'       => [10],
 			'boolean false key' => [false, 0],
@@ -150,7 +150,7 @@ final class ArrayAccessTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataOffsetGetReturnsNullForNonRegisteredHeader() {
+	public static function dataOffsetGetReturnsNullForNonRegisteredHeader() {
 		return [
 			// This test case also tests that no "passing null to non-nullable" deprecation is thrown in PHP 8.1.
 			'null'                       => [null],

--- a/tests/Response/Headers/FlattenTest.php
+++ b/tests/Response/Headers/FlattenTest.php
@@ -32,7 +32,7 @@ final class FlattenTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataFlatten() {
+	public static function dataFlatten() {
 		return [
 			'string'            => ['text', 'text'],
 			'empty array'       => [[], ''],
@@ -62,7 +62,7 @@ final class FlattenTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidValue() {
+	public static function dataInvalidValue() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING, TypeProviderHelper::GROUP_ARRAY);
 	}
 }

--- a/tests/Response/Headers/GetValuesTest.php
+++ b/tests/Response/Headers/GetValuesTest.php
@@ -34,7 +34,7 @@ final class GetValuesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidOffset() {
+	public static function dataInvalidOffset() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING, TypeProviderHelper::GROUP_INT);
 	}
 
@@ -63,7 +63,7 @@ final class GetValuesTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataGetValues() {
+	public static function dataGetValues() {
 		return [
 			'using case as set, single entry header' => [
 				'key'      => 'Content-Type',

--- a/tests/Response/IsRedirectTest.php
+++ b/tests/Response/IsRedirectTest.php
@@ -32,7 +32,7 @@ final class IsRedirectTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataIsRedirect() {
+	public static function dataIsRedirect() {
 		$data = [];
 
 		$codes = [300, 301, 302, 303];
@@ -69,7 +69,7 @@ final class IsRedirectTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataNotRedirect() {
+	public static function dataNotRedirect() {
 		$data = [];
 
 		$data['Non-blocking request: status code: false (default value)'] = [false];

--- a/tests/Session/ConstructorTest.php
+++ b/tests/Session/ConstructorTest.php
@@ -34,7 +34,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidUrl() {
+	public static function dataInvalidUrl() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL, TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -91,7 +91,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidTypeNotArray() {
+	public static function dataInvalidTypeNotArray() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 

--- a/tests/Session/ConstructorTest.php
+++ b/tests/Session/ConstructorTest.php
@@ -105,6 +105,8 @@ final class ConstructorTest extends TestCase {
 	 * @return void
 	 */
 	public function testValidUrl($input) {
+		$this->skipOnUnavailableHttpbinHost();
+
 		$this->assertInstanceOf(Session::class, new Session($input));
 	}
 
@@ -113,11 +115,11 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValidUrl() {
+	public static function dataValidUrl() {
 		return [
 			'null'              => [null],
-			'string'            => [$this->httpbin('/')],
-			'stringable object' => [new Iri($this->httpbin('/'))],
+			'string'            => [self::getHttpbinUrl('/')],
+			'stringable object' => [new Iri(self::getHttpbinUrl('/'))],
 		];
 	}
 }

--- a/tests/Session/RequestMultipleTest.php
+++ b/tests/Session/RequestMultipleTest.php
@@ -35,7 +35,7 @@ final class RequestMultipleTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidRequests() {
+	public static function dataInvalidRequests() {
 		$except = array_intersect(TypeProviderHelper::GROUP_ITERABLE, TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
 		return TypeProviderHelper::getAllExcept($except);
 	}
@@ -62,7 +62,7 @@ final class RequestMultipleTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidOptions() {
+	public static function dataInvalidOptions() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 

--- a/tests/Ssl/MatchDomainTest.php
+++ b/tests/Ssl/MatchDomainTest.php
@@ -33,7 +33,7 @@ final class MatchDomainTest extends SslTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputType() {
+	public static function dataInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 

--- a/tests/Ssl/SslTestCase.php
+++ b/tests/Ssl/SslTestCase.php
@@ -44,7 +44,7 @@ abstract class SslTestCase extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataMatch() {
+	public static function dataMatch() {
 		return [
 			'top-level domain (stringable object)' => [
 				'host'      => new StringableObject('example.com'),
@@ -66,7 +66,7 @@ abstract class SslTestCase extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataNoMatch() {
+	public static function dataNoMatch() {
 		return [
 			// Check that we need at least 3 components.
 			'not a domain; wildcard reference' => [

--- a/tests/Ssl/VerifyCertificateTest.php
+++ b/tests/Ssl/VerifyCertificateTest.php
@@ -33,7 +33,7 @@ final class VerifyCertificateTest extends SslTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputHost() {
+	public static function dataInvalidInputHost() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -58,7 +58,7 @@ final class VerifyCertificateTest extends SslTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputCert() {
+	public static function dataInvalidInputCert() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
 	}
 
@@ -87,7 +87,7 @@ final class VerifyCertificateTest extends SslTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataMatchViaCertificate() {
+	public static function dataMatchViaCertificate() {
 		return [
 			'top-level domain; missing SAN, fallback to CN' => [
 				'host'      => 'example.com',
@@ -142,7 +142,7 @@ final class VerifyCertificateTest extends SslTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataNoMatchViaCertificate() {
+	public static function dataNoMatchViaCertificate() {
 		return [
 			'top-level domain; missing SAN, fallback to invalid CN' => [
 				'host'      => 'example.net',
@@ -207,7 +207,7 @@ final class VerifyCertificateTest extends SslTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataWithInvalidCertificates() {
+	public static function dataWithInvalidCertificates() {
 		return [
 			'empty array' => [
 				'host'        => 'example.com',

--- a/tests/Ssl/VerifyReferenceNameTest.php
+++ b/tests/Ssl/VerifyReferenceNameTest.php
@@ -34,7 +34,7 @@ final class VerifyReferenceNameTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidInputType() {
+	public static function dataInvalidInputType() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -57,7 +57,7 @@ final class VerifyReferenceNameTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataVerifyReferenceName() {
+	public static function dataVerifyReferenceName() {
 		return [
 			'empty string' => [
 				'reference' => '',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace WpOrg\Requests\Tests;
 
 use Exception;
+use stdClass;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Tests\TypeProviderHelper;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase as Polyfill_TestCase;
@@ -123,5 +124,33 @@ abstract class TestCase extends Polyfill_TestCase {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Helper method to retrieve a mock object based on stdClass with select methods mocked.
+	 *
+	 * The `setMethods()` method was silently deprecated in PHPUnit 8.3 and removed in PHPUnit 10.
+	 *
+	 * Note: the `getMockBuilder()` and `addMethods()` methods are also soft deprecated as of
+	 * PHPUnit 10.x, and are expected to be hard deprecated in PHPUnit 11 and removed in PHPUnit 12.
+	 * Dealing with that is something for a later iteration of the test suite.
+	 * {@link https://github.com/WordPress/Requests/issues/814}
+	 *
+	 * @param array $methods The names of the methods to mock.
+	 *
+	 * @return \PHPUnit\Framework\MockObject\MockObject
+	 */
+	protected function getMockedStdClassWithMethods($methods) {
+		$mock = $this->getMockBuilder(stdClass::class);
+
+		if (\method_exists($mock, 'addMethods')) {
+			// PHPUnit 8.3.0+.
+			return $mock->addMethods($methods)
+				->getMock();
+		}
+
+		// PHPUnit < 8.3.0.
+		return $mock->setMethods($methods)
+			->getMock();
 	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -59,7 +59,7 @@ abstract class TestCase extends Polyfill_TestCase {
 	 *
 	 * @return array
 	 */
-	public function transportProvider() {
+	public static function transportProvider() {
 		$data = [];
 
 		foreach (Requests::DEFAULT_TRANSPORTS as $transport) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,7 +33,7 @@ abstract class TestCase extends Polyfill_TestCase {
 	}
 
 	/**
-	 * Retrieve a URL to use for testing.
+	 * Retrieve a URL to use for testing and mark the test as skipped if the server for that URL is unavailable.
 	 *
 	 * @param string $suffix The query path to add to the base URL.
 	 * @param bool   $ssl    Whether to get the URL using the `http` or the `https` protocol.
@@ -42,6 +42,19 @@ abstract class TestCase extends Polyfill_TestCase {
 	 * @return string
 	 */
 	public function httpbin($suffix = '', $ssl = false) {
+		$this->skipOnUnavailableHttpbinHost($ssl);
+
+		return self::getHttpbinUrl($suffix, $ssl);
+	}
+
+	/**
+	 * Check if a test which depends on a certain server type to be available should run or not.
+	 *
+	 * @param bool $ssl Whether the URL under tests will be using the `http` or the `https` protocol.
+	 *
+	 * @return void
+	 */
+	public function skipOnUnavailableHttpbinHost($ssl = false) {
 		if ($ssl === false && REQUESTS_TEST_SERVER_HTTP_AVAILABLE === false) {
 			$this->markTestSkipped(sprintf('Host %s not available. This needs investigation', REQUESTS_TEST_HOST_HTTP));
 		}
@@ -49,7 +62,18 @@ abstract class TestCase extends Polyfill_TestCase {
 		if ($ssl === true && REQUESTS_TEST_SERVER_HTTPS_AVAILABLE === false) {
 			$this->markTestSkipped(sprintf('Host %s not available. This needs investigation', REQUESTS_TEST_HOST_HTTPS));
 		}
+	}
 
+	/**
+	 * Retrieve a URL to use for testing.
+	 *
+	 * @param string $suffix The query path to add to the base URL.
+	 * @param bool   $ssl    Whether to get the URL using the `http` or the `https` protocol.
+	 *                       Defaults to `false`, which will result in a URL using `http`.
+	 *
+	 * @return string
+	 */
+	public static function getHttpbinUrl($suffix = '', $ssl = false) {
 		$host = $ssl ? 'https://' . \REQUESTS_TEST_HOST_HTTPS : 'http://' . \REQUESTS_TEST_HOST_HTTP;
 		return rtrim($host, '/') . '/' . ltrim($suffix, '/');
 	}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -77,7 +77,7 @@ abstract class TestCase extends Polyfill_TestCase {
 	 *
 	 * @return array[] Array which is usable as a test data provider with named data sets.
 	 */
-	public function textArrayToDataprovider($input) {
+	public static function textArrayToDataprovider($input) {
 		$data = [];
 		foreach ($input as $value) {
 			if (!is_string($value)) {

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -220,7 +220,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataRequestInvalidUrl() {
+	public static function dataRequestInvalidUrl() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -278,7 +278,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataIncorrectDataTypeAccepted() {
+	public static function dataIncorrectDataTypeAccepted() {
 		return [
 			'null' => [null, ''],
 		];
@@ -309,7 +309,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataIncorrectDataTypeException() {
+	public static function dataIncorrectDataTypeException() {
 		return TypeProviderHelper::getAllExcept(
 			TypeProviderHelper::GROUP_NULL,
 			TypeProviderHelper::GROUP_STRING,
@@ -359,7 +359,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataRequestMultipleReturnsEmptyArrayWhenRequestsIsEmpty() {
+	public static function dataRequestMultipleReturnsEmptyArrayWhenRequestsIsEmpty() {
 		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_EMPTY);
 	}
 
@@ -388,7 +388,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataRequestMultipleInvalidRequests() {
+	public static function dataRequestMultipleInvalidRequests() {
 		$except = array_intersect(TypeProviderHelper::GROUP_ITERABLE, TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
 		return TypeProviderHelper::getAllExcept($except, TypeProviderHelper::GROUP_EMPTY);
 	}
@@ -418,7 +418,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidTypeNotArray() {
+	public static function dataInvalidTypeNotArray() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 
@@ -917,7 +917,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataSNISupport() {
+	public static function dataSNISupport() {
 		return [
 			'Without options' => [
 				'options' => [],

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -2,7 +2,6 @@
 
 namespace WpOrg\Requests\Tests\Transport;
 
-use stdClass;
 use WpOrg\Requests\Capability;
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\Http\StatusUnknown;
@@ -1117,7 +1116,7 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testProgressCallback() {
-		$mock = $this->getMockBuilder(stdClass::class)->setMethods(['progress'])->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['progress']);
 		$mock->expects($this->atLeastOnce())->method('progress');
 		$hooks = new Hooks();
 		$hooks->register('request.progress', [$mock, 'progress']);
@@ -1130,9 +1129,7 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	public function testAfterRequestCallback() {
-		$mock = $this->getMockBuilder(stdClass::class)
-			->setMethods(['after_request'])
-			->getMock();
+		$mock = $this->getMockedStdClassWithMethods(['after_request']);
 
 		$mock->expects($this->atLeastOnce())
 			->method('after_request')

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -917,7 +917,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataSNISupport($options) {
+	public function dataSNISupport() {
 		return [
 			'Without options' => [
 				'options' => [],

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -262,10 +262,10 @@ abstract class BaseTestCase extends TestCase {
 	public function testIncorrectDataTypeAcceptedPOST($data, $expected) {
 		$request = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions());
 		$this->assertIsObject($request, 'POST request did not return an object');
-		$this->assertObjectHasAttribute('status_code', $request, 'POST request object does not have a "status_code" property');
+		$this->assertObjectHasProperty('status_code', $request, 'POST request object does not have a "status_code" property');
 		$this->assertSame(200, $request->status_code, 'POST request status code is not 200');
 
-		$this->assertObjectHasAttribute('body', $request, 'POST request object does not have a "body" property');
+		$this->assertObjectHasProperty('body', $request, 'POST request object does not have a "body" property');
 		$result = json_decode($request->body, true);
 
 		$this->assertIsArray($result, 'Json decoded POST request body is not an array');

--- a/tests/Utility/CaseInsensitiveDictionary/ArrayAccessTest.php
+++ b/tests/Utility/CaseInsensitiveDictionary/ArrayAccessTest.php
@@ -116,7 +116,7 @@ class ArrayAccessTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataAccessValidEntries() {
+	public static function dataAccessValidEntries() {
 		$data = [];
 
 		foreach (self::DATASET_REVERSED as $key => $value) {
@@ -171,7 +171,7 @@ class ArrayAccessTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataAccessInvalidEntry() {
+	public static function dataAccessInvalidEntry() {
 		return [
 			'string key'  => ['Non-existant entry'],
 			'integer key' => [25],

--- a/tests/Utility/FilteredIterator/ConstructorTest.php
+++ b/tests/Utility/FilteredIterator/ConstructorTest.php
@@ -32,7 +32,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValidData() {
+	public static function dataValidData() {
 		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_ITERABLE);
 	}
 
@@ -57,7 +57,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidData() {
+	public static function dataInvalidData() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ITERABLE);
 	}
 
@@ -87,10 +87,10 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValidCallback() {
+	public static function dataValidCallback() {
 		return [
 			'existing PHP native function' => ['strtolower'],
-			'dummy callback method'        => [[$this, 'dummyCallback']],
+			'dummy callback method'        => [[__CLASS__, 'dummyCallback']],
 		];
 	}
 
@@ -120,7 +120,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalidCallback() {
+	public static function dataInvalidCallback() {
 		return [
 			'null'                  => [null],
 			'non-existent function' => ['functionname'],
@@ -133,5 +133,5 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function dummyCallback() {}
+	public static function dummyCallback() {}
 }

--- a/tests/Utility/FilteredIterator/CurrentTest.php
+++ b/tests/Utility/FilteredIterator/CurrentTest.php
@@ -37,7 +37,7 @@ final class CurrentTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataCallbackIsAppliedIfValid() {
+	public static function dataCallbackIsAppliedIfValid() {
 		$original = [
 			'key1' => 'lowercase',
 			'key2' => 'UPPER CASE',

--- a/tests/Utility/FilteredIterator/SerializationTest.php
+++ b/tests/Utility/FilteredIterator/SerializationTest.php
@@ -47,7 +47,7 @@ final class SerializationTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataSerializeDeserializeObjects() {
+	public static function dataSerializeDeserializeObjects() {
 		return [
 			'FilteredIterator object with one value, callback: md5' => [
 				'value' => new FilteredIterator([1], 'md5'),

--- a/tests/Utility/InputValidator/HasArrayAccessTest.php
+++ b/tests/Utility/InputValidator/HasArrayAccessTest.php
@@ -29,7 +29,7 @@ final class HasArrayAccessTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValid() {
+	public static function dataValid() {
 		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
 	}
 
@@ -51,7 +51,7 @@ final class HasArrayAccessTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalid() {
+	public static function dataInvalid() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY_ACCESSIBLE);
 	}
 }

--- a/tests/Utility/InputValidator/IsCurlHandleTest.php
+++ b/tests/Utility/InputValidator/IsCurlHandleTest.php
@@ -47,7 +47,7 @@ final class IsCurlHandleTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValid() {
+	public static function dataValid() {
 		if (isset(self::$curl_handle) === false) {
 			self::$curl_handle = curl_init('http://httpbin.org/anything');
 		}
@@ -75,7 +75,7 @@ final class IsCurlHandleTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalid() {
+	public static function dataInvalid() {
 		return TypeProviderHelper::getAll();
 	}
 }

--- a/tests/Utility/InputValidator/IsIterableTest.php
+++ b/tests/Utility/InputValidator/IsIterableTest.php
@@ -29,7 +29,7 @@ final class IsIterableTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValid() {
+	public static function dataValid() {
 		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_ITERABLE);
 	}
 
@@ -51,7 +51,7 @@ final class IsIterableTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalid() {
+	public static function dataInvalid() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ITERABLE);
 	}
 }

--- a/tests/Utility/InputValidator/IsNumericArrayKeyTest.php
+++ b/tests/Utility/InputValidator/IsNumericArrayKeyTest.php
@@ -29,7 +29,7 @@ final class IsNumericArrayKeyTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValid() {
+	public static function dataValid() {
 		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_INT, ['numeric string']);
 	}
 
@@ -51,7 +51,7 @@ final class IsNumericArrayKeyTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalid() {
+	public static function dataInvalid() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, ['numeric string']);
 	}
 }

--- a/tests/Utility/InputValidator/IsStringOrStringableTest.php
+++ b/tests/Utility/InputValidator/IsStringOrStringableTest.php
@@ -29,7 +29,7 @@ final class IsStringOrStringableTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValid() {
+	public static function dataValid() {
 		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 
@@ -51,7 +51,7 @@ final class IsStringOrStringableTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalid() {
+	public static function dataInvalid() {
 		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRINGABLE);
 	}
 }

--- a/tests/Utility/InputValidator/IsStringableObjectTest.php
+++ b/tests/Utility/InputValidator/IsStringableObjectTest.php
@@ -29,7 +29,7 @@ final class IsStringableObjectTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataValid() {
+	public static function dataValid() {
 		return TypeProviderHelper::getSelection(['Stringable object']);
 	}
 
@@ -51,7 +51,7 @@ final class IsStringableObjectTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataInvalid() {
+	public static function dataInvalid() {
 		return TypeProviderHelper::getAllExcept(['Stringable object']);
 	}
 }


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [x] Code quality improvement

## Context

Update the test suite to allow for running the tests on PHPUnit 10.

## Detailed Description

### Composer: update the PHPUnit Polyfills

A PHPUnit 10 compatible version of the PHPUnit Polyfills has been released, so let's start using it.

Ref:
* https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/2.0.0

### Transport/BaseTestCase::dataSNISupport(): remove unused and unnecessary method parameter

Data providers cannot take arguments, so this `$options` parameter is useless and should never have been declared. PHPUnit 10 will flag it, so let's remove it.

### TestCase::textArrayToDataprovider(): make static

This method is used exclusively by data providers and as of PHPUnit 10, data providers should be static methods, so this method needs to be `static` too.

### TestCase::transportProvider(): make static

This method is used exclusively as a data providers and as of PHPUnit 10, data providers should be static methods, so this method needs to be `static` too.

### TestCase: split httpbin() method and make Session\ConstructorTest::dataValidUrl() method static

As of PHPUnit 10, data providers are (again) expected to be `static` methods.

One of the data providers is using the `httpbin()` method, but as the `httpbin()` method needs `$this` to handle the test skipping, the method cannot be made static.

This commit splits the `httpbin()` method into three methods:
* A `skipOnUnavailableHttpbinHost()` method which contains the test skip check.
* A `static` `getHttpbinUrl()` method which builds the URL.
* The original `httpbin()` method which now calls the two new methods to maintain the same functionality as before.

By splitting the method in this way, we prevent having to change all method calls to the `httpbin()` method throughout the test suite and can still fix the data provider method using the `httpbin()` method to not use `$this` (which allows to make it `static`).

### Tests: make dataproviders static

As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite to respect that.

Includes removing the use of `$this` from select data providers.

### Tests: replace assertObjectHasAttribute() with `assertObjectHasProperty()`

The `assertObjectHasAttribute()` method has been deprecated in PHPUnit 9 and removed in PHPUnit 10.

PHPUnit 10.1 introduces a replacement `assertObjectHasProperty()` method, which is polyfilled by the PHPUnit Polyfills.

This switches all uses of the old method to the new method name.

### Tests: work around for MockBuilder::setMethods() removal

Please note:
* The `getMockBuilder()` method is also deprecated now, so replacing with another method call on the `MockBuilder` class will only work in the short/medium term and in a future iteration, this will have to be refactored again.
* The `addMethods()` method has been (soft) deprecated in PHPUnit 10.1 and is expected to be removed in PHPUnit 12.

Also see #814

Refs:
* sebastianbergmann/phpunit#3687#issuecomment-492537584
* sebastianbergmann/phpunit#3770
* sebastianbergmann/phpunit#3769
* sebastianbergmann/phpunit#4775

### Tests: work around for removal of expectDeprecation et al

PHPUnit will no longer stop a test on deprecations/notices/warnings.
This also means that the PHPUnit native way to expect deprecations/notices/warnings etc is no longer supported.

This implements a work-around for the limited cases in which that functionality was used in this test suite.

Refs:
* https://phpunit.de/announcements/phpunit-10.html
* sebastianbergmann/phpunit#5062

### Curl/Fsockopen: add some extra defensive coding

The `error_get_last()` function can return `null` if no error occurred, in which case, the `throw new Exception()` statement will run into two new errors:
* `Trying to access array offset on value of type null` for accessing `$error['message']`.
* ... which then leads to a `Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated`.

This commit adds some defensive coding to handle the hypothetical situation that `error_get_last()` would return `null` when a file could not be opened.

Note: this is actually a bug in PHPUnit 10 which breaks `error_get_last()`.
We should be able to remove the extra defensive coding once the upstream bug has been fixed.

Upstream bug report: sebastianbergmann/phpunit#5428

### PHPUnit: add separate configuration for PHPUnit 10

PHPUnit 10 makes significant changes to the configuration file.

Most notably:
* In PHPUnit 9.3, the manner of specifying the code coverage configuration has changed.
* In PHPUnit 10.0, a significant number of attributes of the `<phpunit>` element were removed or renamed.
* In PHPUnit 10.1, the manner of specifying code coverage has changed again.

While there is a `--migrate-configuration` option available in PHPUnit, that doesn't get us a well enough converted configuration file, so instead use a separate `phpunit10.xml.dist` file for running the tests on PHPUnit 10 with an optimal configuration.

Includes:
* Ignoring the new file for package archives.
* Adding separate scripts to the `composer.json` file to make how to run the tests on PHPUnit 10 more obvious for contributors.
* Updating the GH Actions workflows to take the new configuration file into account when appropriate.