### PR TITLE
PHP 8.3 | HasCapabilitiesTest: fix deprecation notices for ReflectionProperty::setValue()

### DIFF
--- a/tests/Requests/HasCapabilitiesTest.php
+++ b/tests/Requests/HasCapabilitiesTest.php
@@ -24,11 +24,11 @@ final class HasCapabilitiesTest extends TestCase {
 	public function testFailsForUnsupportedCapabilities() {
 		$transports = new ReflectionProperty(Requests::class, 'transports');
 		$transports->setAccessible(true);
-		$transports->setValue([TestTransportMock::class]);
+		$transports->setValue(null, [TestTransportMock::class]);
 
 		$result = Requests::has_capabilities(['time-travel' => true]);
 
-		$transports->setValue([]);
+		$transports->setValue(null, []);
 		$transports->setAccessible(false);
 
 		$this->assertFalse($result);


### PR DESCRIPTION
The `ReflectionProperty::setValue()` method supports three method signatures, two of which are deprecated as of PHP 8.3.

This adjusts the call to `ReflectionProperty::setValue()` in the `HasCapabilitiesTest` to pass `null` as the "object" for setting the value of a static property to make the method call cross-version compatible.

Ref: https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#reflectionpropertysetvalue
