### PR TITLE
Composer: update suggested PHP extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,9 @@
     "yoast/phpunit-polyfills": "^2.0.0"
   },
   "suggest": {
-    "ext-curl": "For improved performance"
+    "ext-curl": "For improved performance",
+    "ext-openssl": "For secure transport support",
+    "ext-zlib": "For improved performance when decompressing encoded streams"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
These PHP extensions are used conditionally within the library.

Discovered using the ComposerRequireChecker tool and manually verified.

Ref: https://github.com/maglnet/ComposerRequireChecker