### PR TITLE
Fsockopen: anticipate on PHP 8.4 deprecation of `stream_context_set_option()` overloaded signature

### DIFF
--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -141,7 +141,15 @@ final class Fsockopen implements Transport {
 				$verifyname                          = false;
 			}
 
-			stream_context_set_option($context, ['ssl' => $context_options]);
+			// Handle the PHP 8.4 deprecation (PHP 9.0 removal) of the function signature we use for stream_context_set_option().
+			// Ref: https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#stream_context_set_option
+			if (function_exists('stream_context_set_options')) {
+				// PHP 8.3+.
+				stream_context_set_options($context, ['ssl' => $context_options]);
+			} else {
+				// PHP < 8.3.
+				stream_context_set_option($context, ['ssl' => $context_options]);
+			}
 		} else {
 			$remote_socket = 'tcp://' . $host;
 		}


### PR DESCRIPTION
PHP 8.4 will deprecate the two parameter signature of the `stream_context_set_option()` function.
PHP 8.3 will introduce a replacement function `stream_context_set_options()` (take note of the `s` at the end!) for the two parameter signature.

This commit adds a toggle to the `Fsockopen::request()` method to call the correct PHP function based on its availability.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#stream_context_set_option
* https://www.php.net/stream_context_set_option
* (docs for the new function are not yet available)