### PR TITLE
GH Actions: update doc generation workflow

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           ini-values: display_errors=On
           coverage: none
           tools: phpdoc


### PR DESCRIPTION
phpDocumentor 3.4.0 has been released and has a minimum supported PHP version of PHP 8.1.

This updates the workflow to take that into account.

Ref: https://github.com/phpDocumentor/phpDocumentor/releases/tag/v3.4.0


Note: milestoning this PR for 2.0.x as it will be needed for the website build.