### PR TITLE
Docs: improve file docblocks

### DIFF
--- a/build/ghpages/UpdateMarkdown.php
+++ b/build/ghpages/UpdateMarkdown.php
@@ -1,5 +1,17 @@
 <?php
 /**
+ * Requests for PHP, an HTTP library.
+ *
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
+
+namespace WpOrg\Requests\GHPages;
+
+use RuntimeException;
+
+/**
  * Update the markdown based documentation files.
  *
  * {@internal This functionality has a minimum PHP requirement of PHP 7.2.}
@@ -14,11 +26,6 @@
  * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.voidFound
  * @phpcs:disable PHPCompatibility.FunctionUse.NewFunctionParameters.dirname_levelsFound
  */
-
-namespace WpOrg\Requests\GHPages;
-
-use RuntimeException;
-
 class UpdateMarkdown {
 
 	/**

--- a/build/ghpages/update-docgen-config.php
+++ b/build/ghpages/update-docgen-config.php
@@ -1,16 +1,11 @@
 #!/usr/bin/env php
 <?php
 /**
- * Update the phpDocumentor configuration file.
+ * Requests for PHP, an HTTP library.
  *
- * {@internal This functionality has a minimum PHP requirement of PHP 7.2.}
- *
- * @internal
- *
- * @package Requests
- * @subpackage GHPages
- *
- * @phpcs:disable PHPCompatibility.FunctionUse.NewFunctionParameters.dirname_levelsFound
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\GHPages;
@@ -19,6 +14,17 @@ use WpOrg\Requests\Autoload;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
 
+/**
+ * Update the phpDocumentor configuration file.
+ *
+ * {@internal This functionality has a minimum PHP requirement of PHP 7.2.}
+ *
+ * @internal
+ *
+ * @package Requests\GHPages
+ *
+ * @phpcs:disable PHPCompatibility.FunctionUse.NewFunctionParameters.dirname_levelsFound
+ */
 $requests_phpdoc_version_updater = static function () {
 	// Include Requests.
 	$project_root = dirname(__DIR__, 2);

--- a/build/ghpages/update-markdown-docs.php
+++ b/build/ghpages/update-markdown-docs.php
@@ -1,14 +1,18 @@
 #!/usr/bin/env php
 <?php
 /**
+ * Requests for PHP, an HTTP library.
+ *
  * Update the markdown based documentation files.
  *
  * {@internal This functionality has a minimum PHP requirement of PHP 7.2.}
  *
  * @internal
  *
- * @package Requests
- * @subpackage GHPages
+ * @package   Requests\GHPages
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\GHPages;

--- a/examples/basic-auth.php
+++ b/examples/basic-auth.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 // First, include the Requests Autoloader.
 require_once dirname(__DIR__) . '/src/Autoload.php';

--- a/examples/cookie.php
+++ b/examples/cookie.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 // First, include the Requests Autoloader.
 require_once dirname(__DIR__) . '/src/Autoload.php';

--- a/examples/cookie_jar.php
+++ b/examples/cookie_jar.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 // First, include the Requests Autoloader.
 require_once dirname(__DIR__) . '/src/Autoload.php';

--- a/examples/get.php
+++ b/examples/get.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 // First, include the Requests Autoloader.
 require_once dirname(__DIR__) . '/src/Autoload.php';

--- a/examples/multiple.php
+++ b/examples/multiple.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 // First, include the Requests Autoloader.
 require_once dirname(__DIR__) . '/src/Autoload.php';

--- a/examples/post.php
+++ b/examples/post.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 // First, include the Requests Autoloader.
 require_once dirname(__DIR__) . '/src/Autoload.php';

--- a/examples/preload-aliases.php
+++ b/examples/preload-aliases.php
@@ -1,6 +1,14 @@
 <?php
-
 /**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
+
+/*
  * If you need to run the Requests v2.x library with another framework/CMS that still ships v1.x,
  * use the following to preload the class aliases before the actual implementations of Requests v1.x. get loaded.
  *

--- a/examples/proxy.php
+++ b/examples/proxy.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 // First, include the Requests Autoloader.
 require_once dirname(__DIR__) . '/src/Autoload.php';

--- a/examples/session.php
+++ b/examples/session.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 // First, include the Requests Autoloader.
 require_once dirname(__DIR__) . '/src/Autoload.php';

--- a/examples/timeout.php
+++ b/examples/timeout.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 // First, include the Requests Autoloader.
 require_once dirname(__DIR__) . '/src/Autoload.php';

--- a/library/Deprecated.php
+++ b/library/Deprecated.php
@@ -1,5 +1,7 @@
 <?php
 /**
+ * Requests for PHP, an HTTP library.
+ *
  * Backwards compatibility layer for Requests.
  *
  * Allows for Composer to autoload the old PSR-0 classes via the custom autoloader.
@@ -10,6 +12,10 @@
  * @package Requests
  *
  * @deprecated 2.0.0 Use the PSR-4 class names instead.
+ *
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 if (class_exists('WpOrg\Requests\Autoload') === false) {

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -22,6 +22,12 @@ if (!defined('REQUESTS_SILENCE_PSR0_DEPRECATIONS') || REQUESTS_SILENCE_PSR0_DEPR
 
 	// Prevent the deprecation notice from being thrown twice.
 	if (!defined('REQUESTS_SILENCE_PSR0_DEPRECATIONS')) {
+
+		/**
+		 * Constant to silence deprecation notices about use of the old PSR-0 based class names.
+		 *
+		 * @var bool
+		 */
 		define('REQUESTS_SILENCE_PSR0_DEPRECATIONS', true);
 	}
 }

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -1,14 +1,10 @@
 <?php
 /**
- * Requests for PHP
+ * Requests for PHP, an HTTP library.
  *
- * Inspired by Requests for Python.
- *
- * Based on concepts from SimplePie_File, RequestCore and WP_Http.
- *
- * @package Requests
- *
- * @deprecated 2.0.0
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 /*

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Authentication provider interface
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Authentication
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Auth/Basic.php
+++ b/src/Auth/Basic.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Basic Authentication provider
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Authentication
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Auth;

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -1,11 +1,14 @@
 <?php
 /**
+ * Requests for PHP, an HTTP library.
+ *
  * Autoloader for Requests for PHP.
  *
  * Include this file if you'd like to avoid having to create your own autoloader.
  *
- * @package Requests
- * @since   2.0.0
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;
@@ -27,6 +30,7 @@ if (class_exists('WpOrg\Requests\Autoload') === false) {
 	 * For the PSR-0 Requests 1.x BC-layer, requested classes will be treated case-insensitively.
 	 *
 	 * @package Requests
+	 * @since   2.0.0
 	 */
 	final class Autoload {
 

--- a/src/Capability.php
+++ b/src/Capability.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Capability interface declaring the known capabilities.
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Utilities
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;
@@ -13,6 +15,7 @@ namespace WpOrg\Requests;
  * This is used as the authoritative source for which capabilities can be queried.
  *
  * @package Requests\Utilities
+ * @since   2.0.0
  */
 interface Capability {
 

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Cookie storage object
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Cookies
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Cookie holder object
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Cookies
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Cookie;

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for HTTP requests
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Exception/ArgumentCount.php
+++ b/src/Exception/ArgumentCount.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 namespace WpOrg\Requests\Exception;
 

--- a/src/Exception/Http.php
+++ b/src/Exception/Http.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception based on HTTP response
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception;

--- a/src/Exception/Http/Status304.php
+++ b/src/Exception/Http/Status304.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 304 Not Modified responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status305.php
+++ b/src/Exception/Http/Status305.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 305 Use Proxy responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status306.php
+++ b/src/Exception/Http/Status306.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 306 Switch Proxy responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status400.php
+++ b/src/Exception/Http/Status400.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 400 Bad Request responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status401.php
+++ b/src/Exception/Http/Status401.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 401 Unauthorized responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status402.php
+++ b/src/Exception/Http/Status402.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 402 Payment Required responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status403.php
+++ b/src/Exception/Http/Status403.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 403 Forbidden responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status404.php
+++ b/src/Exception/Http/Status404.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 404 Not Found responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status405.php
+++ b/src/Exception/Http/Status405.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 405 Method Not Allowed responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status406.php
+++ b/src/Exception/Http/Status406.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 406 Not Acceptable responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status407.php
+++ b/src/Exception/Http/Status407.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 407 Proxy Authentication Required responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status408.php
+++ b/src/Exception/Http/Status408.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 408 Request Timeout responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status409.php
+++ b/src/Exception/Http/Status409.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 409 Conflict responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status410.php
+++ b/src/Exception/Http/Status410.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 410 Gone responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status411.php
+++ b/src/Exception/Http/Status411.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 411 Length Required responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status412.php
+++ b/src/Exception/Http/Status412.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 412 Precondition Failed responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status413.php
+++ b/src/Exception/Http/Status413.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 413 Request Entity Too Large responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status414.php
+++ b/src/Exception/Http/Status414.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 414 Request-URI Too Large responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status415.php
+++ b/src/Exception/Http/Status415.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 415 Unsupported Media Type responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status416.php
+++ b/src/Exception/Http/Status416.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 416 Requested Range Not Satisfiable responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status417.php
+++ b/src/Exception/Http/Status417.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 417 Expectation Failed responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status418.php
+++ b/src/Exception/Http/Status418.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Exception for 418 I'm A Teapot responses
+ * Requests for PHP, an HTTP library.
  *
- * @link https://tools.ietf.org/html/rfc2324
- *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status428.php
+++ b/src/Exception/Http/Status428.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Exception for 428 Precondition Required responses
+ * Requests for PHP, an HTTP library.
  *
- * @link https://tools.ietf.org/html/rfc6585
- *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status429.php
+++ b/src/Exception/Http/Status429.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Exception for 429 Too Many Requests responses
+ * Requests for PHP, an HTTP library.
  *
- * @link https://tools.ietf.org/html/draft-nottingham-http-new-status-04
- *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status431.php
+++ b/src/Exception/Http/Status431.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Exception for 431 Request Header Fields Too Large responses
+ * Requests for PHP, an HTTP library.
  *
- * @link https://tools.ietf.org/html/rfc6585
- *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status500.php
+++ b/src/Exception/Http/Status500.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 500 Internal Server Error responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status501.php
+++ b/src/Exception/Http/Status501.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 501 Not Implemented responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status502.php
+++ b/src/Exception/Http/Status502.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 502 Bad Gateway responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status503.php
+++ b/src/Exception/Http/Status503.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 503 Service Unavailable responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status504.php
+++ b/src/Exception/Http/Status504.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 504 Gateway Timeout responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status505.php
+++ b/src/Exception/Http/Status505.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for 505 HTTP Version Not Supported responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/Status511.php
+++ b/src/Exception/Http/Status511.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Exception for 511 Network Authentication Required responses
+ * Requests for PHP, an HTTP library.
  *
- * @link https://tools.ietf.org/html/rfc6585
- *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/Http/StatusUnknown.php
+++ b/src/Exception/Http/StatusUnknown.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Exception for unknown status responses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Http;

--- a/src/Exception/InvalidArgument.php
+++ b/src/Exception/InvalidArgument.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 namespace WpOrg\Requests\Exception;
 

--- a/src/Exception/Transport.php
+++ b/src/Exception/Transport.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Transport Exception
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception;

--- a/src/Exception/Transport/Curl.php
+++ b/src/Exception/Transport/Curl.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * CURL Transport Exception.
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Exceptions
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Exception\Transport;

--- a/src/HookManager.php
+++ b/src/HookManager.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Event dispatcher
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\EventDispatcher
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Handles adding and dispatching events
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\EventDispatcher
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
 
 namespace WpOrg\Requests;
 

--- a/src/Ipv6.php
+++ b/src/Ipv6.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Class to validate and to work with IPv6 addresses
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Utilities
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Iri.php
+++ b/src/Iri.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * IRI parser/serialiser/normaliser
+ * IRI, part of Requests for PHP, an HTTP library.
  *
- * @package Requests\Utilities
+ * @copyright 2007-2009 Geoffrey Sneddon and Steve Minutillo
+ * @license   https://opensource.org/licenses/bsd-license.php
+ * @link      http://hg.gsnedders.com/iri/
  */
 
 namespace WpOrg\Requests;

--- a/src/Port.php
+++ b/src/Port.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Port utilities for Requests
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Utilities
- * @since   2.0.0
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;
@@ -12,6 +13,8 @@ use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
 
 /**
+ * Port utilities for Requests
+ *
  * Find the correct port depending on the Request type.
  *
  * @package Requests\Utilities

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Proxy connection interface
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Proxy
- * @since   1.6
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Proxy/Http.php
+++ b/src/Proxy/Http.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * HTTP Proxy connection interface
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Proxy
- * @since   1.6
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Proxy;

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -1,12 +1,10 @@
 <?php
 /**
- * Requests for PHP
+ * Requests for PHP, an HTTP library.
  *
- * Inspired by Requests for Python.
- *
- * Based on concepts from SimplePie_File, RequestCore and WP_Http.
- *
- * @package Requests
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * HTTP response class
+ * Requests for PHP, an HTTP library.
  *
- * Contains a response from \WpOrg\Requests\Requests::request()
- *
- * @package Requests
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Case-insensitive dictionary, suitable for HTTP headers
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Response;

--- a/src/Session.php
+++ b/src/Session.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Session handler for persistent requests and default parameters
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\SessionHandler
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Ssl.php
+++ b/src/Ssl.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * SSL utilities for Requests
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Utilities
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Base HTTP transport
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Transport
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests;

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * cURL HTTP transport
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Transport
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Transport;

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * fsockopen HTTP transport
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Transport
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Transport;

--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Case-insensitive dictionary, suitable for HTTP headers
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Utilities
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Utility;

--- a/src/Utility/FilteredIterator.php
+++ b/src/Utility/FilteredIterator.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Iterator for arrays requiring filtered values
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Utilities
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Utility;

--- a/src/Utility/InputValidator.php
+++ b/src/Utility/InputValidator.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Input validation utilities.
+ * Requests for PHP, an HTTP library.
  *
- * @package Requests\Utilities
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
  */
 
 namespace WpOrg\Requests\Utility;
@@ -15,6 +17,7 @@ use Traversable;
  * Input validation utilities.
  *
  * @package Requests\Utilities
+ * @since   2.0.0
  */
 final class InputValidator {
 


### PR DESCRIPTION

## Detailed Description

### Docs: improve file docblocks

As things were, the file-level docblocks for most files contained the exact same information as the class-level docblocks for the class contained within the file.

This kind of duplication is redundant.

This commit updates the file-level docblocks to contain generic identifier information about the package the file belongs to.

Additionally:
* If the file does not contain a class, the generic identifier information has been added to the pre-existing file-level docblock.
* If the file docblock contains information which applies to the file, not the class, the generic identifier information has been added to the pre-existing file-level docblock.
* If the file docblock contained information which applies to the class, not the file, this information has been moved to the class docblock.
* A few missing `@since` tags were added in class docblocks for classes introduced in the 2.0.0 release.

### Docs/Examples: add file level docblocks

... linking the examples to this repo/package.

These file-level docblocks include a `@package` tag to make it clear that these are example code snippets.

### Docs/GHPages: add file level docblocks

* When the file contained a docblock about the functionality AND contained a structural element, move the pre-existing docblock to the structural element.
* When this is not the case, merge the information from the pre-existing docblock with the standardized file-level docblock.

### Docs: add docblock for global constant 