### PR TITLE
Release 2.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+2.0.9
+-----
+
+### Overview of changes
+- Hotfix: Rollback changes from PR [#657]. [#839] Props [@tomsommer][gh-tomsommer] & [@laszlof][gh-laszlof]
+- Docs: improve file docblocks [#834]
+- GH Actions: fix failing test workflows [#836]
+
+[#839]: https://github.com/WordPress/Requests/pull/839
+[#834]: https://github.com/WordPress/Requests/pull/834
+[#836]: https://github.com/WordPress/Requests/pull/836
+
 2.0.8
 -----
 
@@ -1015,6 +1027,7 @@ Initial release!
 [gh-jrfnl]: https://github.com/jrfnl
 [gh-KasperFranz]: https://github.com/KasperFranz
 [gh-kwuerl]: https://github.com/kwuerl
+[gh-laszlof]: https://github.com/laszlof
 [gh-laurentmartelli]: https://github.com/laurentmartelli
 [gh-mbabker]: https://github.com/mbabker
 [gh-mircobabini]: https://github.com/mircobabini
@@ -1039,6 +1052,7 @@ Initial release!
 [gh-TimothyBJacobs]: https://github.com/TimothyBJacobs
 [gh-tnorthcutt]: https://github.com/tnorthcutt
 [gh-todeveni]: https://github.com/todeveni
+[gh-tomsommer]: https://github.com/tomsommer
 [gh-tonebender]: https://github.com/tonebender
 [gh-twdnhfr]: https://github.com/twdnhfr
 [gh-TysonAndre]: https://github.com/TysonAndre

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -146,7 +146,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.0.8';
+	const VERSION = '2.0.9';
 
 	/**
 	 * Selected transport name


### PR DESCRIPTION
:warning: **DO NOT MERGE (YET)** :warning:

PR for tracking changes for the 2.0.9 release.

Target release date: **Wednesday November 8th 2023**.

- [x] Check if any dependencies need updating.
- [x] Update the version constant in `src/Requests.php` - PR #xxx.
- [x] Add changelog for the release - PR #xxx
- [ ] Merge this PR.
- [ ] Make sure all CI builds are green.
- [ ] Tag the release against `stable` and push the tag.
- [ ] Review the automatically created PR with the GH Pages docs update.
- [ ] Create a release from the tag (careful, GH defaults to `develop`!) & copy & paste the changelog to it.
    Make sure to copy the links to the issues and the links to the GH usernames from the bottom of the changelog!
- [ ] Merge the GH Pages PR.
    Note: it is important to do this **after** the release as otherwise the information about the latest release
    in the site will not be updated correctly from the GitHub API.
- [ ] Verify that the website regenerated correctly and is in working order.
- [ ] Close the milestone.
- [ ] Open a new milestone for the next release.
- [ ] If any open PRs/issues which were milestoned for the release did not make it into the release, update their milestone.
- [ ] Tweet about the release.
- [ ] Post about it in the WP #core Slack channel.
- [ ] Open a Trac ticket for WordPress Core to update their copy.
- [ ] Submit for "Month in WordPress": https://make.wordpress.org/community/month-in-wordpress-submissions/