### PR TITLE
Release 2.0.9

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -53,15 +53,21 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Setup proxy server
         run: pip3 install mitmproxy
+
+      - name: Check mitmproxy version
+        run: mitmdump --version
 
       - name: Start test server
         run: |
           PORT=8080 vendor/bin/start.sh
           echo "REQUESTS_TEST_HOST_HTTP=localhost:8080" >> $GITHUB_ENV
+
+      - name: Ping localhost domain
+        run: ping -c1 localhost
 
       - name: Start proxy server
         run: |
@@ -74,12 +80,6 @@ jobs:
 
       - name: Ensure the HTTPS test instance on Render is spun up
         run: curl -s -I https://requests-test-server.onrender.com/ > /dev/null
-
-      - name: Check mitmproxy version
-        run: mitmdump --version
-
-      - name: Ping localhost domain
-        run: ping -c1 localhost
 
       - name: Access localhost on port 8080
         run: curl -i http://localhost:8080

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,15 +67,21 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Setup proxy server
         run: pip3 install mitmproxy
+
+      - name: Check mitmproxy version
+        run: mitmdump --version
 
       - name: Start test server
         run: |
           PORT=8080 vendor/bin/start.sh
           echo "REQUESTS_TEST_HOST_HTTP=localhost:8080" >> $GITHUB_ENV
+
+      - name: Ping localhost domain
+        run: ping -c1 localhost
 
       - name: Start proxy server
         run: |
@@ -88,12 +94,6 @@ jobs:
 
       - name: Ensure the HTTPS test instance on Render is spun up
         run: curl -s -I https://requests-test-server.onrender.com/ > /dev/null
-
-      - name: Check mitmproxy version
-        run: mitmdump --version
-
-      - name: Ping localhost domain
-        run: ping -c1 localhost
 
       - name: Access localhost on port 8080
         run: curl -i http://localhost:8080

--- a/.github/workflows/update-cacert.yml
+++ b/.github/workflows/update-cacert.yml
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Restore etags cache for certificate files
         uses: actions/cache@v2

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -49,7 +49,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ steps.base_branch.outputs.BRANCH }}
 
@@ -111,7 +111,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
 
@@ -183,7 +183,7 @@ jobs:
 
       # Test that the site builds correctly.
       - name: Checkout the newly created branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: feature/auto-ghpages-update-${{ steps.get_pr_info.outputs.REF }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.0.9
+-----
+
+### Overview of changes
+- Hotfix: Rollback changes from PR [#657]. [#839] Props [@tomsommer][gh-tomsommer] & [@laszlof][gh-laszlof]
+
+[#839]: https://github.com/WordPress/Requests/pull/839
+
 2.0.8
 -----
 
@@ -1015,6 +1023,7 @@ Initial release!
 [gh-jrfnl]: https://github.com/jrfnl
 [gh-KasperFranz]: https://github.com/KasperFranz
 [gh-kwuerl]: https://github.com/kwuerl
+[gh-laszlof]: https://github.com/laszlof
 [gh-laurentmartelli]: https://github.com/laurentmartelli
 [gh-mbabker]: https://github.com/mbabker
 [gh-mircobabini]: https://github.com/mircobabini
@@ -1039,6 +1048,7 @@ Initial release!
 [gh-TimothyBJacobs]: https://github.com/TimothyBJacobs
 [gh-tnorthcutt]: https://github.com/tnorthcutt
 [gh-todeveni]: https://github.com/todeveni
+[gh-tomsommer]: https://github.com/tomsommer
 [gh-tonebender]: https://github.com/tonebender
 [gh-twdnhfr]: https://github.com/twdnhfr
 [gh-TysonAndre]: https://github.com/TysonAndre

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -148,7 +148,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.0.8';
+	const VERSION = '2.0.9';
 
 	/**
 	 * Selected transport name

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -25,7 +25,6 @@ use WpOrg\Requests\Utility\InputValidator;
 final class Curl implements Transport {
 	const CURL_7_10_5 = 0x070A05;
 	const CURL_7_16_2 = 0x071002;
-	const CURL_7_22_0 = 0x071600;
 
 	/**
 	 * Raw HTTP data
@@ -364,7 +363,7 @@ final class Curl implements Transport {
 		$options['hooks']->dispatch('curl.before_request', [&$this->handle]);
 
 		// Force closing the connection for old versions of cURL (<7.22).
-		if ($this->version < self::CURL_7_22_0 && !isset($headers['Connection'])) {
+		if (!isset($headers['Connection'])) {
 			$headers['Connection'] = 'close';
 		}
 


### PR DESCRIPTION
PR for tracking changes for the 2.0.9 release.

Target release date: **Wednesday November 8th 2023**.

- [x] Check if any dependencies need updating.
- [x] Update the version constant in `src/Requests.php` - PR #841.
- [x] Add changelog for the release - PR #841
- [x] Merge this PR.
- [x] Make sure all CI builds are green.
- [x] Tag the release against `stable` and push the tag.
- [x] Review the automatically created PR with the GH Pages docs update.
- [x] Create a release from the tag (careful, GH defaults to `develop`!) & copy & paste the changelog to it.
    Make sure to copy the links to the issues and the links to the GH usernames from the bottom of the changelog!
- [x] Merge the GH Pages PR.
    Note: it is important to do this **after** the release as otherwise the information about the latest release
    in the site will not be updated correctly from the GitHub API.
- [x] Verify that the website regenerated correctly and is in working order.
- [x] Close the milestone.
- [x] Open a new milestone for the next release.
- [x] If any open PRs/issues which were milestoned for the release did not make it into the release, update their milestone.
- [ ] Tweet about the release.
- [x] Post about it in the WP #core Slack channel.
- [x] Open a Trac ticket for WordPress Core to update their copy.
- [ ] Submit for "Month in WordPress": https://make.wordpress.org/community/month-in-wordpress-submissions/