### PR TITLE
Allow integer values for a Cookie() name

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -82,8 +82,8 @@ class Cookie {
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $reference_time argument is not an integer or null.
 	 */
 	public function __construct($name, $value, $attributes = [], $flags = [], $reference_time = null) {
-		if (is_string($name) === false) {
-			throw InvalidArgument::create(1, '$name', 'string', gettype($name));
+		if (is_string($name) === false && is_int($name) === false) {
+			throw InvalidArgument::create(1, '$name', 'string|int', gettype($name));
 		}
 
 		if (is_string($value) === false) {


### PR DESCRIPTION
Fixes #845 so that an exception isn't thrown for legitimate numeric cookie names.

There are two changes:

1. Modify the check for $name, to allow both string and integer cookie names.
2. Change the exception thrown to indicate a string OR int is permitted.

## Pull Request Type

- [X] I have checked there is no other PR open for the same change.

This is a:
- [X] Bug fix

## Context
Currently, multiple plugins, and possibly even WP core are throwing errors if someone has a cookie with a numeric name. Would love to see this issue go away, so that folks don't have to resort to deleting cookies in the dev tools of their browser.

## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [ ] My code follows the style guidelines of this project.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!
I.e. code style complies with the project standard, the unit tests pass, code coverage has not gone down.

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make reviewing your changes easier for the maintainers.
============================================================================================
-->
