### PR TITLE
Allow integers as cookie names

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -75,15 +75,15 @@ class Cookie {
 	 *                                                                                `'persistent'` and `'host-only'`.
 	 * @param int|null                                                $reference_time Reference time for relative calculations.
 	 *
-	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $name argument is not a string.
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $name argument is not an integer or string that conforms to RFC 2616.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $value argument is not a string.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $attributes argument is not an array or iterable object with array access.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $flags argument is not an array.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $reference_time argument is not an integer or null.
 	 */
 	public function __construct($name, $value, $attributes = [], $flags = [], $reference_time = null) {
-		if (is_int($name) === false && is_string($name) === false) {
-			throw InvalidArgument::create(1, '$name', 'integer|string', gettype($name));
+		if (InputValidator::is_valid_rfc2616_token($name) === false) {
+			throw InvalidArgument::create(1, '$name', 'integer|string and conform to RFC 2616', gettype($name));
 		}
 
 		if (is_string($value) === false) {
@@ -439,8 +439,8 @@ class Cookie {
 			throw InvalidArgument::create(1, '$cookie_header', 'string', gettype($cookie_header));
 		}
 
-		if (is_int($name) === false && is_string($name) === false) {
-			throw InvalidArgument::create(2, '$name', 'integer|string', gettype($name));
+		if (InputValidator::is_valid_rfc2616_token($name) === false) {
+			throw InvalidArgument::create(2, '$name', 'integer|string and conform to RFC 2616', gettype($name));
 		}
 
 		$parts   = explode(';', $cookie_header);

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -67,7 +67,7 @@ class Cookie {
 	/**
 	 * Create a new cookie object
 	 *
-	 * @param string                                                  $name           The name of the cookie.
+	 * @param int|string                                              $name           The name of the cookie.
 	 * @param string                                                  $value          The value for the cookie.
 	 * @param array|\WpOrg\Requests\Utility\CaseInsensitiveDictionary $attributes     Associative array of attribute data
 	 * @param array                                                   $flags          The flags for the cookie.
@@ -82,8 +82,8 @@ class Cookie {
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $reference_time argument is not an integer or null.
 	 */
 	public function __construct($name, $value, $attributes = [], $flags = [], $reference_time = null) {
-		if (is_string($name) === false) {
-			throw InvalidArgument::create(1, '$name', 'string', gettype($name));
+		if (is_int($name) === false && is_string($name) === false) {
+			throw InvalidArgument::create(1, '$name', 'integer|string', gettype($name));
 		}
 
 		if (is_string($value) === false) {
@@ -102,7 +102,7 @@ class Cookie {
 			throw InvalidArgument::create(5, '$reference_time', 'integer|null', gettype($reference_time));
 		}
 
-		$this->name       = $name;
+		$this->name       = (string) $name;
 		$this->value      = $value;
 		$this->attributes = $attributes;
 		$default_flags    = [
@@ -426,9 +426,9 @@ class Cookie {
 	 * is an intentional deviation from RFC 2109 and RFC 2616. RFC 6265
 	 * specifies some of this handling, but not in a thorough manner.
 	 *
-	 * @param string   $cookie_header  Cookie header value (from a Set-Cookie header)
-	 * @param string   $name
-	 * @param int|null $reference_time
+	 * @param int|string $cookie_header  Cookie header value (from a Set-Cookie header)
+	 * @param string     $name
+	 * @param int|null   $reference_time
 	 * @return \WpOrg\Requests\Cookie Parsed cookie object
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $cookie_header argument is not a string.
@@ -439,8 +439,8 @@ class Cookie {
 			throw InvalidArgument::create(1, '$cookie_header', 'string', gettype($cookie_header));
 		}
 
-		if (is_string($name) === false) {
-			throw InvalidArgument::create(2, '$name', 'string', gettype($name));
+		if (is_int($name) === false && is_string($name) === false) {
+			throw InvalidArgument::create(2, '$name', 'integer|string', gettype($name));
 		}
 
 		$parts   = explode(';', $cookie_header);

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -82,7 +82,7 @@ class Cookie {
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $reference_time argument is not an integer or null.
 	 */
 	public function __construct($name, $value, $attributes = [], $flags = [], $reference_time = null) {
-		if (InputValidator::is_valid_rfc2616_token($name) === false) {
+		if ($name !== '' && InputValidator::is_valid_rfc2616_token($name) === false) {
 			throw InvalidArgument::create(1, '$name', 'integer|string and conform to RFC 2616', gettype($name));
 		}
 
@@ -439,7 +439,11 @@ class Cookie {
 			throw InvalidArgument::create(1, '$cookie_header', 'string', gettype($cookie_header));
 		}
 
-		if (InputValidator::is_valid_rfc2616_token($name) === false) {
+		if (is_string($name)) {
+			$name = trim($name);
+		}
+
+		if ($name !== '' && InputValidator::is_valid_rfc2616_token($name) === false) {
 			throw InvalidArgument::create(2, '$name', 'integer|string and conform to RFC 2616', gettype($name));
 		}
 
@@ -462,6 +466,10 @@ class Cookie {
 
 		$name  = trim($name);
 		$value = trim($value);
+
+		if ($name !== '' && InputValidator::is_valid_rfc2616_token($name) === false) {
+			throw InvalidArgument::create(2, '$name', 'integer|string and conform to RFC 2616', gettype($name));
+		}
 
 		// Attribute keys are handled case-insensitively
 		$attributes = new CaseInsensitiveDictionary();

--- a/tests/Cookie/ConstructorTest.php
+++ b/tests/Cookie/ConstructorTest.php
@@ -24,7 +24,7 @@ final class ConstructorTest extends TestCase {
 	 */
 	public function testInvalidName($input) {
 		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($name) must be of type integer|string');
+		$this->expectExceptionMessage('Argument #1 ($name) must be of type integer|string and conform to RFC 2616');
 
 		new Cookie($input, 'value');
 	}
@@ -35,7 +35,7 @@ final class ConstructorTest extends TestCase {
 	 * @return array
 	 */
 	public static function dataInvalidName() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT,TypeProviderHelper::GROUP_STRING);
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, TypeProviderHelper::GROUP_STRING);
 	}
 
 	/**

--- a/tests/Cookie/ConstructorTest.php
+++ b/tests/Cookie/ConstructorTest.php
@@ -16,7 +16,7 @@ final class ConstructorTest extends TestCase {
 	/**
 	 * Tests receiving an exception when the constructor received an invalid input type as `$name`.
 	 *
-	 * @dataProvider dataInvalidStringInput
+	 * @dataProvider dataInvalidName
 	 *
 	 * @param mixed $input Invalid parameter input.
 	 *
@@ -24,9 +24,18 @@ final class ConstructorTest extends TestCase {
 	 */
 	public function testInvalidName($input) {
 		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #1 ($name) must be of type string');
+		$this->expectExceptionMessage('Argument #1 ($name) must be of type integer|string');
 
 		new Cookie($input, 'value');
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public static function dataInvalidName() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT,TypeProviderHelper::GROUP_STRING);
 	}
 
 	/**

--- a/tests/Cookie/ConstructorTest.php
+++ b/tests/Cookie/ConstructorTest.php
@@ -35,7 +35,9 @@ final class ConstructorTest extends TestCase {
 	 * @return array
 	 */
 	public static function dataInvalidName() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, TypeProviderHelper::GROUP_STRING);
+		$data = TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, TypeProviderHelper::GROUP_STRING);
+		$data['Valid string, but not a valid RFC 2616 token'] = ["some\ntext\rwith\tcontrol\echaracters\fin\vit"];
+		return $data;
 	}
 
 	/**

--- a/tests/Cookie/ParseTest.php
+++ b/tests/Cookie/ParseTest.php
@@ -33,9 +33,18 @@ final class ParseTest extends TestCase {
 	}
 
 	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public static function dataInvalidStringInput() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
+	}
+
+	/**
 	 * Tests receiving an exception when the parse() method received an invalid input type as `$name`.
 	 *
-	 * @dataProvider dataInvalidStringInput
+	 * @dataProvider dataParseInvalidName
 	 *
 	 * @covers ::parse
 	 *
@@ -45,7 +54,7 @@ final class ParseTest extends TestCase {
 	 */
 	public function testParseInvalidName($input) {
 		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #2 ($name) must be of type string');
+		$this->expectExceptionMessage('Argument #2 ($name) must be of type integer|string');
 
 		Cookie::parse('test', $input);
 	}
@@ -55,8 +64,8 @@ final class ParseTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public static function dataInvalidStringInput() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_STRING);
+	public static function dataParseInvalidName() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT,TypeProviderHelper::GROUP_STRING);
 	}
 
 	/**

--- a/tests/Cookie/ParseTest.php
+++ b/tests/Cookie/ParseTest.php
@@ -54,7 +54,7 @@ final class ParseTest extends TestCase {
 	 */
 	public function testParseInvalidName($input) {
 		$this->expectException(InvalidArgument::class);
-		$this->expectExceptionMessage('Argument #2 ($name) must be of type integer|string');
+		$this->expectExceptionMessage('Argument #2 ($name) must be of type integer|string and conform to RFC 2616');
 
 		Cookie::parse('test', $input);
 	}
@@ -65,7 +65,7 @@ final class ParseTest extends TestCase {
 	 * @return array
 	 */
 	public static function dataParseInvalidName() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT,TypeProviderHelper::GROUP_STRING);
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, TypeProviderHelper::GROUP_STRING);
 	}
 
 	/**

--- a/tests/Cookie/ParseTest.php
+++ b/tests/Cookie/ParseTest.php
@@ -65,7 +65,9 @@ final class ParseTest extends TestCase {
 	 * @return array
 	 */
 	public static function dataParseInvalidName() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, TypeProviderHelper::GROUP_STRING);
+		$data = TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, TypeProviderHelper::GROUP_STRING);
+		$data['Valid string, but not a valid RFC 2616 token'] = ["some\ntext\rwith\tcontrol\echaracters\fin\vit"];
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/WordPress/Requests/issues/845 so that an exception isn't thrown for legitimate numeric cookie names.

Changes for both the constructor and parse() methods:
- Modifies the check(s) for $name, to allow both string and integer cookie names.
- Changes the exception thrown to indicate a string OR int is permitted.
- Updates doc blocks to allow cookie names to be integers.
- Modifies unit tests for $name parameter to allow strings and integers, and to validate the updated exception messages.

I have kept Cookie->name as a string, and cast $name to a string within the constructor, just in case some (external) code would be doing a strict comparison against the name, and expecting a string value. If that's not desirable, I can revert that change.

## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [x] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [ ] Code quality improvement

## Context
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
What should be mentioned about this PR in the changelog?
-->
Currently, multiple plugins, and possibly even WP core are throwing errors if someone has a cookie with a numeric name. Would love to see this issue go away, so that folks don't have to resort to deleting cookies in the dev tools of their browser.

## Detailed Description
This issue typically comes up in plugins that are executing 'async' requests, such that the existing cookies ($_COOKIES) are copied into the 'cookies' parameter for a GET/POST request. One could sanitize the numeric key names at that point, but PHP will cast the indices back to integers, and then an exception will still be thrown.

## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added unit tests to accompany this PR.
- [x] The (new/existing) tests cover this PR 100%.
- [x] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.


<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!
I.e. code style complies with the project standard, the unit tests pass, code coverage has not gone down.

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make reviewing your changes easier for the maintainers.
============================================================================================
-->
