### PR TITLE
New `InputValidator::is_valid_rfc2616_token()` method

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -206,6 +206,13 @@
 		</properties>
 	</rule>
 
+	<!-- In contrast to WPCS (40%), we allow a slightly higher percentage. -->
+	<rule ref="Squiz.PHP.CommentedOutCode">
+		<properties>
+			<property name="maxPercentage" value="50"/>
+		</properties>
+	</rule>
+
 
 	<!--
 	#############################################################################

--- a/src/Utility/InputValidator.php
+++ b/src/Utility/InputValidator.php
@@ -114,7 +114,7 @@ final class InputValidator {
 	 * Verify that a received input parameter is a valid "token name" according to the
 	 * specification in RFC 2616 (HTTP/1.1).
 	 *
-	 * The short version is: 1 or more ascii characters, CTRL chars and separators not allowed.
+	 * The short version is: 1 or more ASCII characters, CTRL chars and separators not allowed.
 	 * For the long version, see the specs in the RFC.
 	 *
 	 * @link https://datatracker.ietf.org/doc/html/rfc2616#section-2.2

--- a/src/Utility/InputValidator.php
+++ b/src/Utility/InputValidator.php
@@ -109,4 +109,27 @@ final class InputValidator {
 
 		return false;
 	}
+
+	/**
+	 * Verify that a received input parameter is a valid "token name" according to the
+	 * specification in RFC 2616 (HTTP/1.1).
+	 *
+	 * The short version is: 1 or more ascii characters, CTRL chars and separators not allowed.
+	 * For the long version, see the specs in the RFC.
+	 *
+	 * @link https://datatracker.ietf.org/doc/html/rfc2616#section-2.2
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param mixed $input Input parameter to verify.
+	 *
+	 * @return bool
+	 */
+	public static function is_valid_rfc2616_token($input) {
+		if (!is_int($input) && !is_string($input)) {
+			return false;
+		}
+
+		return (preg_match('@^[0-9A-Za-z!#$%&\'*+.^_`|~-]+$@', $input) === 1);
+	}
 }

--- a/src/Utility/InputValidator.php
+++ b/src/Utility/InputValidator.php
@@ -130,6 +130,6 @@ final class InputValidator {
 			return false;
 		}
 
-		return (preg_match('@^[0-9A-Za-z!#$%&\'*+.^_`|~-]+$@', $input) === 1);
+		return preg_match('@^[0-9A-Za-z!#$%&\'*+.^_`|~-]+$@', $input) === 1;
 	}
 }

--- a/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
+++ b/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
@@ -41,8 +41,7 @@ final class IsValidRfc2616TokenTest extends TestCase {
 	 * token = 1*<any CHAR except CTLs or separators>
 	 *
 	 * Disabling PHPCS checks for consistency with RFC 2616:
-	 * phpcs:disable Squiz.PHP.CommentedOutCode.Found
-	 * phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+	 * @phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
 	 *
 	 * @return array<string>
 	 */

--- a/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
+++ b/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
@@ -85,7 +85,7 @@ final class IsValidRfc2616TokenTest extends TestCase {
 
 		return [
 			'string containing all valid token characters' => [
-				'input' => implode(self::getValidTokenCharacters()),
+				'input' => implode('', self::getValidTokenCharacters()),
 			],
 			'string with a typical cookie name' => [
 				'input' => 'requests-testcookie',
@@ -132,7 +132,7 @@ final class IsValidRfc2616TokenTest extends TestCase {
 				'input' => '',
 			],
 			'string containing all invalid ASCII characters' => [
-				'input' => implode($invalid_ascii_characters),
+				'input' => implode('', $invalid_ascii_characters),
 			],
 			'string containing control character at start' => [
 				'input' => chr(6) . 'some text',

--- a/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
+++ b/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
@@ -83,6 +83,11 @@ final class IsValidRfc2616TokenTest extends TestCase {
 	 * @return array
 	 */
 	public static function dataInvalidValues() {
+		$all_control = chr(127); // DEL.
+		for ($char = 0; $char <= 31; $char++) {
+			$all_control .= chr($char);
+		}
+
 		$invalid_ascii_characters = array_diff(
 			array_map('chr', range(0, 127)),
 			self::getValidTokenCharacters()
@@ -91,6 +96,9 @@ final class IsValidRfc2616TokenTest extends TestCase {
 		return [
 			'empty string' => [
 				'input' => '',
+			],
+			'string containing only control characters / all control characters' => [
+				'input' => $all_control,
 			],
 			'string containing all invalid ASCII characters' => [
 				'input' => implode('', $invalid_ascii_characters),
@@ -124,6 +132,9 @@ final class IsValidRfc2616TokenTest extends TestCase {
 			],
 			'string containing non-ascii characters - ௫' => [
 				'input' => '௫', // Tamil digit five.
+			],
+			'string containing all invalid ASCII characters' => [
+				'input' => implode('', $invalid_ascii_characters),
 			],
 		];
 	}

--- a/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
+++ b/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
@@ -58,7 +58,7 @@ final class IsValidRfc2616TokenTest extends TestCase {
 		// HT = <US-ASCII HT, horizontal-tab (9)>
 		$rfc_ht = chr(9);
 
-		// separators = "(" | ")" | "<" | ">" | "@"
+		// Separators = "(" | ")" | "<" | ">" | "@"
 		//            | "," | ";" | ":" | "\" | <">
 		//            | "/" | "[" | "]" | "?" | "="
 		//            | "{" | "}" | SP | HT
@@ -69,7 +69,7 @@ final class IsValidRfc2616TokenTest extends TestCase {
 			'{', '}', $rfc_sp, $rfc_ht,
 		];
 
-		// token characters = <any CHAR except CTLs or separators>
+		// Token characters = <any CHAR except CTLs or separators>
 		return array_diff($rfc_char, $rfc_ctl, $rfc_separators);
 	}
 

--- a/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
+++ b/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
@@ -100,9 +100,6 @@ final class IsValidRfc2616TokenTest extends TestCase {
 			'string containing only control characters / all control characters' => [
 				'input' => $all_control,
 			],
-			'string containing all invalid ASCII characters' => [
-				'input' => implode('', $invalid_ascii_characters),
-			],
 			'string containing control character at start' => [
 				'input' => chr(6) . 'some text',
 			],

--- a/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
+++ b/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Utility\InputValidator;
+
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
+use WpOrg\Requests\Utility\InputValidator;
+
+/**
+ * @covers \WpOrg\Requests\Utility\InputValidator::is_valid_rfc2616_token
+ */
+final class IsValidRfc2616TokenTest extends TestCase {
+
+	/**
+	 * Test whether a received input parameter is correctly identified as a valid RFC 2616 token.
+	 *
+	 * @dataProvider dataValidIntegers
+	 * @dataProvider dataValidStrings
+	 *
+	 * @param mixed $input Input parameter to verify.
+	 *
+	 * @return void
+	 */
+	public function testValid($input) {
+		$this->assertTrue(InputValidator::is_valid_rfc2616_token($input));
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public static function dataValidIntegers() {
+		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_INT);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public static function dataValidStrings() {
+		$all_valid_ascii = '!#$%&\'*+-.'; // Valid chars in ASCII 33-47 range.
+		// No valid chars in ASCII 58-64 range.
+		$all_valid_ascii .= '^_`'; // Valid chars in ASCII 91-96 range.
+		$all_valid_ascii .= '|~'; // Valid chars in ASCII 123-126 range.
+
+		for ($char = 48; $char <= 57; $char++) {
+			// Chars 0-9.
+			$all_valid_ascii .= chr($char);
+		}
+
+		for ($char = 65; $char <= 90; $char++) {
+			// Chars A-Z.
+			$all_valid_ascii .= chr($char);
+		}
+
+		for ($char = 97; $char <= 122; $char++) {
+			// Chars a-z.
+			$all_valid_ascii .= chr($char);
+		}
+
+		return [
+			'string containing only valid ascii characters / all valid ascii characters' => [
+				'input' => $all_valid_ascii,
+			],
+			'string with a typical cookie name' => [
+				'input' => 'requests-testcookie',
+			],
+		];
+	}
+
+	/**
+	 * Test whether a received input parameter is correctly identified as NOT a valid RFC 2616 token.
+	 *
+	 * @dataProvider dataInvalidTypes
+	 * @dataProvider dataInvalidValues
+	 *
+	 * @param mixed $input Input parameter to verify.
+	 *
+	 * @return void
+	 */
+	public function testInvalid($input) {
+		$this->assertFalse(InputValidator::is_valid_rfc2616_token($input));
+	}
+
+	/**
+	 * Data Provider for invalid data types.
+	 *
+	 * @return array
+	 */
+	public static function dataInvalidTypes() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT, TypeProviderHelper::GROUP_STRING);
+	}
+
+	/**
+	 * Data Provider for valid data types containing invalid values.
+	 *
+	 * @return array
+	 */
+	public static function dataInvalidValues() {
+		$all_control = chr(127); // DEL.
+		for ($char = 0; $char <= 31; $char++) {
+			$all_control .= chr($char);
+		}
+
+		return [
+			'empty string' => [
+				'input' => '',
+			],
+			'string containing only control characters / all control characters' => [
+				'input' => $all_control,
+			],
+			'string containing control character at start' => [
+				'input' => chr(6) . 'some text',
+			],
+			'string containing control characters in text' => [
+				'input' => "some\ntext\rwith\tcontrol\echaracters\fin\vit",
+			],
+			'string containing control character at end' => [
+				'input' => 'some text' . chr(127),
+			],
+			'string containing only separator characters / all separator characters' => [
+				'input' => '()<>@,;:\\"/[]?={} 	',
+			],
+			'string containing separator character at start' => [
+				'input' => '=value',
+			],
+			'string containing separator characters in text' => [
+				'input' => 'words "with" spaces and quotes',
+			],
+			'string containing separator character at end' => [
+				'input' => 'punctuated;',
+			],
+			'string containing separator characters - leading and trailing whitespace' => [
+				'input' => '	words    ',
+			],
+			'string containing non-ascii characters - Iñtërnâtiônàlizætiøn' => [
+				'input' => 'Iñtërnâtiônàlizætiøn',
+			],
+			'string containing non-ascii characters - ௫' => [
+				'input' => '௫', // Tamil digit five.
+			],
+		];
+	}
+}

--- a/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
+++ b/tests/Utility/InputValidator/IsValidRfc2616TokenTest.php
@@ -35,45 +35,6 @@ final class IsValidRfc2616TokenTest extends TestCase {
 	}
 
 	/**
-	 * Get an array of valid RFC 2616 token characters.
-	 *
-	 * Valid token as per RFC 2616 section 2.2:
-	 * token = 1*<any CHAR except CTLs or separators>
-	 *
-	 * Disabling PHPCS checks for consistency with RFC 2616:
-	 * @phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-	 *
-	 * @return array<string>
-	 */
-	private static function getValidTokenCharacters() {
-		// CHAR = <any US-ASCII character (octets 0 - 127)>
-		$rfc_char = array_map('chr', range(0, 127));
-
-		// CTL = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
-		$rfc_ctl = array_map('chr', array_merge(range(0, 31), [127]));
-
-		// SP = <US-ASCII SP, space (32)>
-		$rfc_sp = chr(32);
-
-		// HT = <US-ASCII HT, horizontal-tab (9)>
-		$rfc_ht = chr(9);
-
-		// Separators = "(" | ")" | "<" | ">" | "@"
-		//            | "," | ";" | ":" | "\" | <">
-		//            | "/" | "[" | "]" | "?" | "="
-		//            | "{" | "}" | SP | HT
-		$rfc_separators = [
-			'(', ')', '<', '>', '@',
-			',', ';', ':', '\\', '"',
-			'/', '[', ']', '?', '=',
-			'{', '}', $rfc_sp, $rfc_ht,
-		];
-
-		// Token characters = <any CHAR except CTLs or separators>
-		return array_diff($rfc_char, $rfc_ctl, $rfc_separators);
-	}
-
-	/**
 	 * Data Provider.
 	 *
 	 * Valid strings are valid tokens as per RFC 2616 section 2.2:
@@ -165,5 +126,44 @@ final class IsValidRfc2616TokenTest extends TestCase {
 				'input' => '௫', // Tamil digit five.
 			],
 		];
+	}
+
+	/**
+	 * Get an array of valid RFC 2616 token characters.
+	 *
+	 * Valid token as per RFC 2616 section 2.2:
+	 * token = 1*<any CHAR except CTLs or separators>
+	 *
+	 * Disabling PHPCS checks for consistency with RFC 2616:
+	 * @phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+	 *
+	 * @return array<string>
+	 */
+	private static function getValidTokenCharacters() {
+		// CHAR = <any US-ASCII character (octets 0 - 127)>
+		$rfc_char = array_map('chr', range(0, 127));
+
+		// CTL = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+		$rfc_ctl = array_map('chr', array_merge(range(0, 31), [127]));
+
+		// SP = <US-ASCII SP, space (32)>
+		$rfc_sp = chr(32);
+
+		// HT = <US-ASCII HT, horizontal-tab (9)>
+		$rfc_ht = chr(9);
+
+		// Separators = "(" | ")" | "<" | ">" | "@"
+		//            | "," | ";" | ":" | "\" | <">
+		//            | "/" | "[" | "]" | "?" | "="
+		//            | "{" | "}" | SP | HT
+		$rfc_separators = [
+			'(', ')', '<', '>', '@',
+			',', ';', ':', '\\', '"',
+			'/', '[', ']', '?', '=',
+			'{', '}', $rfc_sp, $rfc_ht,
+		];
+
+		// Token characters = <any CHAR except CTLs or separators>
+		return array_diff($rfc_char, $rfc_ctl, $rfc_separators);
 	}
 }


### PR DESCRIPTION
## Pull Request Type

This is a:
- [ ] Bug fix
- [x] New feature
- [ ] Documentation improvement
- [ ] Code quality improvement

## Context

The new method is intended to be used as a helper to allow for making solving #845 / #847 more straight-forward.

## Detailed Description

This new method validates that an arbitrary input parameter can be considered valid for use as a "token" as per the RFC 2616 specification.

Includes tests.

Ref: https://datatracker.ietf.org/doc/html/rfc2616#section-2.2