### PR TITLE
GH Actions/lint: stop linting against PHP 8.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # Lint against the high/low versions of each PHP major + nightly.
-        php: ['5.6', '7.0', '7.4', '8.0', '8.2', '8.3', '8.4']
+        php: ['5.6', '7.0', '7.4', '8.0', '8.3', '8.4']
 
     name: "Lint: PHP ${{ matrix.php }}"
     continue-on-error: ${{ matrix.php == '8.4' }}


### PR DESCRIPTION
The lint workflow in principle only lints against the high/low PHP version for each major (+ nightly) as the tests already run against all PHP versions anyway.

What with the release of PHP 8.3, the linting against PHP 8.2 can now be removed.