### PR TITLE
GH Actions/test: automatically retry failed CodeCov uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,8 +146,10 @@ jobs:
 
       - name: Send coverage report to Codecov
         if: ${{ success() && matrix.coverage == true }}
-        uses: codecov/codecov-action@v3
+        uses: Wandalen/wretry.action@master
         with:
-          files: ./clover.xml
-          fail_ci_if_error: true
-          verbose: true
+          action: codecov/codecov-action@v3
+          with: |
+            files: ./clover.xml
+            fail_ci_if_error: true
+            verbose: true


### PR DESCRIPTION
We've been seeing quite some upload failures for CodeCov over the past few months. There are a couple of issues open in their repo for this. In the mean time, let's try an limit the annoyance of having to restart builds by automatically retrying the upload when it fails.

The action runner used for this defaults to 2 retry attempts with a 0 second delay. This can be tweaked later if needs be.

Ref: https://github.com/Wandalen/wretry.action