### PR TITLE
.gitignore: minor tweak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,10 @@ build/ghpages/vendor
 .phpcs.xml
 phpcs.xml
 
-# Ignore PHPUnit results cache file.
+# Ignore PHPUnit results cache file and local config overrides.
 .phpunit.result.cache
+phpunit.xml
+phpunit10.xml
 
 # Ignore temporary files for ghpages builds.
 phpdoc.xml


### PR DESCRIPTION
Ignore local PHPUnit config override files by default, including a potential `phpunit10.xml` override file for the PHPUnit 10 `phpunit10.xml.dist` config file.