### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -492,7 +492,22 @@ class Cookie {
 	 * @param int|null                         $time    Reference time for expiration calculation
 	 * @return array
 	 */
-	public static function parse_from_headers(Headers $headers, Iri $origin = null, $time = null) {
+	public static function parse_from_headers(Headers $headers, $origin, $time = null) {
+		// Mimic a \WpOrg\Requests\Iri|null type-check for $origin.
+		// Change to a type declaration when PHP >= 7.1 is the base requirement.
+		if ($origin !== null && !$origin instanceof \WpOrg\Requests\Iri) {
+			if (\PHP_VERSION_ID >= 70000) {
+				throw new \TypeError(
+					'WpOrg\Requests\Cookie::parse_from_headers(): Argument #2 ($origin) must be of type WpOrg\Requests\Iri, ' . gettype($origin) . ' given'
+				);
+			}
+			trigger_error(
+				'Argument 2 passed to WpOrg\Requests\Cookie::parse_from_headers() must be an instance of WpOrg\Requests\Iri, ' . gettype($origin) . ' given',
+				E_USER_ERROR
+			);
+			exit();
+		}
+
 		$cookie_headers = $headers->getValues('Set-Cookie');
 		if (empty($cookie_headers)) {
 			return [];

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -491,26 +491,17 @@ class Cookie {
 	 * @param \WpOrg\Requests\Iri|null         $origin  URI for comparing cookie origins
 	 * @param int|null                         $time    Reference time for expiration calculation
 	 * @return array
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $origin argument is not null or an instance of the Iri class.
 	 */
-	public static function parse_from_headers(Headers $headers, $origin, $time = null) {
-		// Mimic a \WpOrg\Requests\Iri|null type-check for $origin.
-		// Change to a type declaration when PHP >= 7.1 is the base requirement.
-		if ($origin !== null && !$origin instanceof \WpOrg\Requests\Iri) {
-			if (\PHP_VERSION_ID >= 70000) {
-				throw new \TypeError(
-					'WpOrg\Requests\Cookie::parse_from_headers(): Argument #2 ($origin) must be of type WpOrg\Requests\Iri, ' . gettype($origin) . ' given'
-				);
-			}
-			trigger_error(
-				'Argument 2 passed to WpOrg\Requests\Cookie::parse_from_headers() must be an instance of WpOrg\Requests\Iri, ' . gettype($origin) . ' given',
-				E_USER_ERROR
-			);
-			exit();
-		}
-
+	public static function parse_from_headers(Headers $headers, $origin = null, $time = null) {
 		$cookie_headers = $headers->getValues('Set-Cookie');
 		if (empty($cookie_headers)) {
 			return [];
+		}
+
+		if ($origin !== null && !($origin instanceof Iri)) {
+			throw InvalidArgument::create(2, '$origin', Iri::class . ' or null', gettype($origin));
 		}
 
 		$cookies = [];

--- a/tests/Cookie/ParseTest.php
+++ b/tests/Cookie/ParseTest.php
@@ -77,6 +77,37 @@ final class ParseTest extends TestCase {
 	}
 
 	/**
+	 * Verify parsing of cookies fails with an exception if the $origin parameter is passed anything but `null`
+	 * or an instance of Iri.
+	 *
+	 * @dataProvider dataParseFromHeadersInvalidOrigin
+	 *
+	 * @covers ::parse_from_headers
+	 *
+	 * @param mixed $input Invalid parameter input.
+	 *
+	 * @return void
+	 */
+	public function testParseFromHeadersInvalidOrigin($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('Argument #2 ($origin) must be of type WpOrg\Requests\Iri or null');
+
+		$headers               = new Headers();
+		$headers['Set-Cookie'] = 'name=value';
+
+		Cookie::parse_from_headers($headers, $input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public static function dataParseFromHeadersInvalidOrigin() {
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_NULL);
+	}
+
+	/**
 	 * Tests receiving an exception when the parse_from_headers() method received an invalid input type as `$reference_time`.
 	 *
 	 * Note: this exception is thrown from the constructor on the call to new static() and is more extensively


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [x] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [x] Code quality improvement

## Context

Fixes all issues that emit deprecation notices on PHP 8.4 for implicit nullable parameter type declarations.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [x] The (new/existing) tests cover this PR 100%.
- [x] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.
