### PR TITLE
CS: always clarify operator precedence when mixing boolean operators

### DIFF
--- a/src/IdnaEncoder.php
+++ b/src/IdnaEncoder.php
@@ -223,18 +223,18 @@ class IdnaEncoder {
 			}
 
 			if (// Non-shortest form sequences are invalid
-				$length > 1 && $character <= 0x7F
-				|| $length > 2 && $character <= 0x7FF
-				|| $length > 3 && $character <= 0xFFFF
+				($length > 1 && $character <= 0x7F)
+				|| ($length > 2 && $character <= 0x7FF)
+				|| ($length > 3 && $character <= 0xFFFF)
 				// Outside of range of ucschar codepoints
 				// Noncharacters
 				|| ($character & 0xFFFE) === 0xFFFE
-				|| $character >= 0xFDD0 && $character <= 0xFDEF
+				|| ($character >= 0xFDD0 && $character <= 0xFDEF)
 				|| (
 					// Everything else not in ucschar
-					$character > 0xD7FF && $character < 0xF900
+					($character > 0xD7FF && $character < 0xF900)
 					|| $character < 0x20
-					|| $character > 0x7E && $character < 0xA0
+					|| ($character > 0x7E && $character < 0xA0)
 					|| $character > 0xEFFFD
 				)
 			) {

--- a/src/Ipv6.php
+++ b/src/Ipv6.php
@@ -163,7 +163,7 @@ final class Ipv6 {
 		list($ipv6, $ipv4) = self::split_v6_v4($ip);
 		$ipv6              = explode(':', $ipv6);
 		$ipv4              = explode('.', $ipv4);
-		if (count($ipv6) === 8 && count($ipv4) === 1 || count($ipv6) === 6 && count($ipv4) === 4) {
+		if ((count($ipv6) === 8 && count($ipv4) === 1) || (count($ipv6) === 6 && count($ipv4) === 4)) {
 			foreach ($ipv6 as $ipv6_part) {
 				// The section can't be empty
 				if ($ipv6_part === '') {


### PR DESCRIPTION
Test failure on PHPUnit 10.x can be ignored. This will be fixed by the next (upcoming) PR.