### PR TITLE
GH Actions/test: use the latest Python version for mitmproxy

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Setup proxy server
         run: pip3 install mitmproxy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Setup proxy server
         run: pip3 install mitmproxy


### PR DESCRIPTION
Python 3.12 (released Oct 2nd, 2023) has been supported by mitmproxy since mitmproxy 10.1.2 (released Nov 3rd, 2023).

Refs:
* [Python 3.11 changelog](https://docs.python.org/release/3.11.9/whatsnew/changelog.html#python-3-11-9)
* [Python 3.12 changelog](https://docs.python.org/release/3.12.3/whatsnew/changelog.html#python-3-12-2)
* [mitmproxy changelog](https://github.com/mitmproxy/mitmproxy/blob/main/CHANGELOG.md#03-november-2023-mitmproxy-1012)

