### PR TITLE
GH Actions: upgrade to Codecov v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,10 +146,9 @@ jobs:
 
       - name: Send coverage report to Codecov
         if: ${{ success() && matrix.coverage == true }}
-        uses: Wandalen/wretry.action@master
+        uses: codecov/codecov-action@v4
         with:
-          action: codecov/codecov-action@v3
-          with: |
-            files: ./clover.xml
-            fail_ci_if_error: true
-            verbose: true
+          token: "${{ secrets.CODECOV_TOKEN }}"
+          files: ./clover.xml
+          fail_ci_if_error: true
+          verbose: true


### PR DESCRIPTION
The CodeCov v4 update makes a token for uploading code coverage a requirement. This is problematic for forks, though they try to work around this. In practice, they are failing hard though on all counts.

However, as uploading via the v3 action runner by now is failing _every single run_, it seems we have no choice but to update.

I've regenerated a token and added a `CODECOV_TOKEN` secret to the repo.

For PRs directly on this repo, that should be sufficient and should also remove the need for the `wretry.action`. For PRs from forks, it will be hit and miss. We'll have to see.

Refs:
* https://github.com/codecov/codecov-action/releases
* https://github.com/codecov/codecov-action/releases/tag/v4.0.0
* https://docs.codecov.com/docs/adding-the-codecov-token#github-actions