### PR TITLE
CS/QA: various minor fixes

### DIFF
--- a/examples/proxy.php
+++ b/examples/proxy.php
@@ -16,7 +16,7 @@ WpOrg\Requests\Autoload::register();
 
 // Now let's make a request via a proxy.
 $options = [
-	'proxy' => '127.0.0.1:8080', // syntax: host:port, eg 12.13.14.14:8080 or someproxy.com:3128
+	'proxy' => '127.0.0.1:8080', // Syntax: host:port, eg 12.13.14.14:8080 or someproxy.com:3128
 	// If you need to authenticate, use the following syntax:
 	// 'proxy' => array( '127.0.0.1:8080', 'username', 'password' ),
 ];

--- a/src/Auth/Basic.php
+++ b/src/Auth/Basic.php
@@ -76,9 +76,9 @@ class Basic implements Auth {
 	}
 
 	/**
-	 * Set cURL parameters before the data is sent
+	 * Set cURL parameters before the data is sent.
 	 *
-	 * @param resource|\CurlHandle $handle cURL handle
+	 * @param resource|\CurlHandle $handle The cURL handle.
 	 */
 	public function curl_before_send(&$handle) {
 		curl_setopt($handle, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
@@ -86,9 +86,9 @@ class Basic implements Auth {
 	}
 
 	/**
-	 * Add extra headers to the request before sending
+	 * Add extra headers to the request before sending.
 	 *
-	 * @param string $out HTTP header string
+	 * @param string $out HTTP header string.
 	 */
 	public function fsockopen_header(&$out) {
 		$out .= sprintf("Authorization: Basic %s\r\n", base64_encode($this->getAuthString()));

--- a/src/Capability.php
+++ b/src/Capability.php
@@ -31,7 +31,7 @@ interface Capability {
 	 *
 	 * Note: this does not automatically mean that the capability will be supported for your chosen transport!
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const ALL = [
 		self::SSL,

--- a/src/Cookie/Jar.php
+++ b/src/Cookie/Jar.php
@@ -95,7 +95,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $offset Item name
 	 * @param string $value  Item value
 	 *
-	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`)
+	 * @throws \WpOrg\Requests\Exception On attempting to use dictionary as list (`invalidset`).
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetSet($offset, $value) {

--- a/src/Ipv6.php
+++ b/src/Ipv6.php
@@ -136,7 +136,7 @@ final class Ipv6 {
 	 *           0:0:0:0:0:FFFF:129.144.52.38
 	 *
 	 * @param string $ip An IPv6 address
-	 * @return string[] [0] contains the IPv6 represented part, and [1] the IPv4 represented part
+	 * @return array<string> [0] contains the IPv6 represented part, and [1] the IPv4 represented part
 	 */
 	private static function split_v6_v4($ip) {
 		if (strpos($ip, '.') !== false) {

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -20,7 +20,7 @@ use WpOrg\Requests\Transport;
 use WpOrg\Requests\Utility\InputValidator;
 
 /**
- * cURL HTTP transport
+ * HTTP transport using libcurl.
  *
  * @package Requests\Transport
  */

--- a/tests/Cookie/IsExpiredTest.php
+++ b/tests/Cookie/IsExpiredTest.php
@@ -85,15 +85,15 @@ final class IsExpiredTest extends TestCase {
 			],
 			'Both max-age and expires keys set, max-age takes precedence, cookie not expired' => [
 				'attributes' => [
-					'max-age'       => gmmktime(0, 0, 0, 2, 1, 2022),
-					'expires'       => gmmktime(0, 0, 0, 12, 1, 2021),
+					'max-age' => gmmktime(0, 0, 0, 2, 1, 2022),
+					'expires' => gmmktime(0, 0, 0, 12, 1, 2021),
 				],
 				'expected'   => false,
 			],
 			'Both max-age and expires keys set, max-age takes precedence, cookie expired' => [
 				'attributes' => [
-					'max-age'       => gmmktime(0, 0, 0, 12, 1, 2021),
-					'expires'       => gmmktime(0, 0, 0, 2, 1, 2022),
+					'max-age' => gmmktime(0, 0, 0, 12, 1, 2021),
+					'expires' => gmmktime(0, 0, 0, 2, 1, 2022),
 				],
 				'expected'   => true,
 			],

--- a/tests/Cookie/ParseTest.php
+++ b/tests/Cookie/ParseTest.php
@@ -629,13 +629,13 @@ final class ParseTest extends TestCase {
 			$this->assertSame($expected['expired'], $cookie->is_expired(), 'Cookie expiration identification does not match expectation');
 		}
 
-		if (isset($expected_attributes) && !empty($expected_attributes)) {
+		if (is_array($expected_attributes) && !empty($expected_attributes)) {
 			foreach ($expected_attributes as $attr_key => $attr_val) {
 				$this->assertSame($attr_val, $cookie->attributes[$attr_key], "Attribute '$attr_key' should match supplied value");
 			}
 		}
 
-		if (isset($expected_flags) && !empty($expected_flags)) {
+		if (is_array($expected_flags) && !empty($expected_flags)) {
 			foreach ($expected_flags as $flag_key => $flag_val) {
 				$this->assertSame($flag_val, $cookie->flags[$flag_key], "Flag '$flag_key' should match supplied value");
 			}

--- a/tests/Response/Headers/FlattenTest.php
+++ b/tests/Response/Headers/FlattenTest.php
@@ -34,9 +34,18 @@ final class FlattenTest extends TestCase {
 	 */
 	public static function dataFlatten() {
 		return [
-			'string'            => ['text', 'text'],
-			'empty array'       => [[], ''],
-			'array with values' => [['text', 10, 'more text'], 'text,10,more text'],
+			'string' => [
+				'input'    => 'text',
+				'expected' => 'text',
+			],
+			'empty array' => [
+				'input'    => [],
+				'expected' => '',
+			],
+			'array with values' => [
+				'input'    => ['text', 10, 'more text'],
+				'expected' => 'text,10,more text',
+			],
 		];
 	}
 

--- a/tests/Response/Headers/GetIteratorTest.php
+++ b/tests/Response/Headers/GetIteratorTest.php
@@ -42,7 +42,7 @@ final class GetIteratorTest extends TestCase {
 					$this->assertSame('10', $value, 'Content-Length header does not match');
 					break;
 				default:
-					throw new Exception('Invalid offset key: ' . $name);
+					throw new Exception('Invalid offset key: ' . $name, 'type');
 			}
 		}
 	}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -98,9 +98,9 @@ abstract class TestCase extends Polyfill_TestCase {
 	/**
 	 * Helper function to convert a single-level array containing text strings to a named data provider.
 	 *
-	 * @param string[] $input Input array.
+	 * @param array<string> $input Input array.
 	 *
-	 * @return array[] Array which is usable as a test data provider with named data sets.
+	 * @return array<array> Array which is usable as a test data provider with named data sets.
 	 */
 	public static function textArrayToDataprovider($input) {
 		$data = [];

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -20,6 +20,15 @@ abstract class BaseTestCase extends TestCase {
 
 	protected $completed = [];
 
+	/**
+	 * Transport class to use for these tests.
+	 *
+	 * This property MUST be declared in the child class.
+	 *
+	 * @var string
+	 */
+	protected $transport;
+
 	public function set_up() {
 		// Intermediary variable $test_method. This can be simplified (removed) once the minimum supported PHP version is 7.0 or higher.
 		$test_method = [$this->transport, 'test'];

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -1198,7 +1198,7 @@ abstract class BaseTestCase extends TestCase {
 	/**
 	 * Get a Hooks instance that asserts correct enforcement for max_bytes.
 	 *
-	 * @return Hooks
+	 * @return \WpOrg\Requests\Hooks
 	 */
 	protected function getMaxBytesAssertionHooks() {
 		$hooks = new Hooks();

--- a/tests/TypeProviderHelper.php
+++ b/tests/TypeProviderHelper.php
@@ -16,14 +16,14 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries representing null.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_NULL = ['null'];
 
 	/**
 	 * Keys of all type entries representing a boolean.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_BOOL = [
 		'boolean false',
@@ -33,7 +33,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries representing an integer.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_INT = [
 		'integer 0',
@@ -44,7 +44,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries representing a float.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_FLOAT = [
 		'float 0.0',
@@ -55,7 +55,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries representing an integer or float.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_INT_FLOAT = [
 		'integer 0',
@@ -69,7 +69,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries representing a string.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_STRING = [
 		'empty string',
@@ -81,7 +81,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries which are stringable.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_STRINGABLE = [
 		'empty string',
@@ -94,7 +94,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries representing an array.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_ARRAY = [
 		'empty array',
@@ -105,7 +105,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries which are iterable.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_ITERABLE = [
 		'empty array',
@@ -118,7 +118,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries which have array access.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_ARRAY_ACCESSIBLE = [
 		'empty array',
@@ -131,7 +131,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries representing an object.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_OBJECT = [
 		'plain object',
@@ -144,7 +144,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries representing a resource.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_RESOURCE = [
 		'resource (open file handle)',
@@ -154,7 +154,7 @@ final class TypeProviderHelper {
 	/**
 	 * Keys of all type entries which are considered empty.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	const GROUP_EMPTY = [
 		'null',
@@ -198,9 +198,9 @@ final class TypeProviderHelper {
 	 * Retrieve an array in data provider format with a selection of all typical PHP data types
 	 * *except* the named types specified in the $except parameter.
 	 *
-	 * @param string[] ...$except One or more arrays containing the names of the types to exclude.
-	 *                            Typically, one or more of the predefined "groups" (see the constants)
-	 *                            would be used here.
+	 * @param array<string> ...$except One or more arrays containing the names of the types to exclude.
+	 *                                 Typically, one or more of the predefined "groups" (see the constants)
+	 *                                 would be used here.
 	 *
 	 * @return array<string, array<mixed>>
 	 */
@@ -213,9 +213,9 @@ final class TypeProviderHelper {
 	/**
 	 * Retrieve an array in data provider format with a selection of typical PHP data types.
 	 *
-	 * @param string[] ...$selection One or more arrays containing the names of the types to include.
-	 *                               Typically, one or more of the predefined "groups" (see the constants)
-	 *                               would be used here.
+	 * @param array<string> ...$selection One or more arrays containing the names of the types to include.
+	 *                                    Typically, one or more of the predefined "groups" (see the constants)
+	 *                                    would be used here.
 	 *
 	 * @return array<string, array<mixed>>
 	 */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -72,7 +72,7 @@ if (defined('__PHPUNIT_PHAR__')) {
 				return false;
 			}
 
-			// Strip namespace prefix 'WpOrg\\Requests\Tests\'.
+			// Strip namespace prefix 'WpOrg\Requests\Tests\'.
 			$relative_class = substr($class_name, 21);
 			$file           = realpath(__DIR__ . '/' . strtr($relative_class, '\\', '/') . '.php');
 


### PR DESCRIPTION
### CS: minor tweak

### Response\Headers\FlattenTest: minor improvement to data provider

... for readability.

### Docs: favour generic type hint syntax over array type hint syntax

... for higher specificity and improved compatibility with tools like PHPStan.

### Docs: various minor tweaks

* Punctuation and spelling fixes.

### Transport/BaseTestCase: make child class expectation explicit

The `BaseTestCase` class expects a child class to declare a `$transport` property. This makes that expectation explicit.

### Response/Headers/GetIteratorTest: minor fix

The `WpOrg\Requests\Exception::__construct()` method expects a minimum of 2 (required) parameters.

While this `default` case is basically impossible to be hit, the exception creation should still be correct.

### Cookie/ParseTest: fix an incorrect condition

As the `$expected_attributes` and `$expected_flags` variables are optional parameters, these will always be set. However, they may not be set to an array, which is what this condition should protect against.