### PR TITLE
Docs: always use fully qualified names

### DIFF
--- a/docs/authentication-custom.md
+++ b/docs/authentication-custom.md
@@ -2,7 +2,7 @@ Custom Authentication
 =====================
 
 Custom authentication handlers are designed to be straight-forward to write.
-In order to write a handler, you'll need to implement the `WpOrg\Requests\Auth`
+In order to write a handler, you'll need to implement the `\WpOrg\Requests\Auth`
 interface.
 
 An instance of this handler can then be passed to Requests via the `auth`
@@ -13,14 +13,14 @@ authenticates the call if said header is set to `Yummy`. (I don't know of any
 services that do this; perhaps this is a market waiting to be tapped?)
 
 ```php
-class MySoftware_Auth_Hotdog implements WpOrg\Requests\Auth {
+class MySoftware_Auth_Hotdog implements \WpOrg\Requests\Auth {
     protected $password;
 
     public function __construct($password) {
         $this->password = $password;
     }
 
-    public function register(WpOrg\Requests\Hooks &$hooks) {
+    public function register(\WpOrg\Requests\Hooks &$hooks) {
         $hooks->register('requests.before_request', array($this, 'before_request'));
     }
 
@@ -34,9 +34,9 @@ We then use this in our request calls like this:
 
 ```php
 $options = array(
-    'auth' => new MySoftware_Auth_Hotdog('yummy')
+    'auth' => new \MySoftware_Auth_Hotdog('yummy')
 );
-$response = WpOrg\Requests\Requests::get('http://hotdogbin.org/admin', array(), $options);
+$response = \WpOrg\Requests\Requests::get('http://hotdogbin.org/admin', array(), $options);
 ```
 
 For more information on how to register and use hooks, see the [hooking

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -9,9 +9,9 @@ A Basic authenticated call can be made like this:
 
 ```php
 $options = array(
-    'auth' => new WpOrg\Requests\Auth\Basic(array('user', 'password'))
+    'auth' => new \WpOrg\Requests\Auth\Basic(array('user', 'password'))
 );
-WpOrg\Requests\Requests::get('https://httpbin.org/basic-auth/user/password', array(), $options);
+\WpOrg\Requests\Requests::get('https://httpbin.org/basic-auth/user/password', array(), $options);
 ```
 
 As Basic authentication is usually what you want when you specify a username
@@ -21,14 +21,14 @@ and password, you can also just pass in an array as a shorthand:
 $options = array(
     'auth' => array('user', 'password')
 );
-WpOrg\Requests\Requests::get('https://httpbin.org/basic-auth/user/password', array(), $options);
+\WpOrg\Requests\Requests::get('https://httpbin.org/basic-auth/user/password', array(), $options);
 ```
 
 Note that `POST`/`PUT` requests take a `$data` parameter, so you need to pass that
 before `$options`:
 
 ```php
-WpOrg\Requests\Requests::post('https://httpbin.org/basic-auth/user/password', array(), null, $options);
+\WpOrg\Requests\Requests::post('https://httpbin.org/basic-auth/user/password', array(), null, $options);
 ```
 
 ***

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -172,10 +172,10 @@ In order to register your own hooks, you need to instantiate `WpOrg\Requests\Hoo
 and pass the object in via the `'hooks'` option.
 
 ```php
-$hooks = new WpOrg\Requests\Hooks();
+$hooks = new \WpOrg\Requests\Hooks();
 $hooks->register('requests.after_request', 'mycallback');
 
-$request = WpOrg\Requests\Requests::get('https://httpbin.org/get', array(), array('hooks' => $hooks));
+$request = \WpOrg\Requests\Requests::get('https://httpbin.org/get', array(), array('hooks' => $hooks));
 ```
 
 ***

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -9,7 +9,7 @@ To make requests through an open proxy, specify the following options:
 $options = array(
     'proxy' => '127.0.0.1:3128'
 );
-WpOrg\Requests\Requests::get('https://httpbin.org/ip', array(), $options);
+\WpOrg\Requests\Requests::get('https://httpbin.org/ip', array(), $options);
 ```
 
 If your proxy needs you to authenticate, the option will become an array like
@@ -19,7 +19,7 @@ in the following example:
 $options = array(
     'proxy' => array( '127.0.0.1:3128', 'my_username', 'my_password' )
 );
-WpOrg\Requests\Requests::get('https://httpbin.org/ip', array(), $options);
+\WpOrg\Requests\Requests::get('https://httpbin.org/ip', array(), $options);
 ```
 
 ***

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -16,11 +16,11 @@ no changes are needed.
 ```php
 // OLD: Using the custom autoloader in Requests 1.x.
 require_once 'path/to/Requests/library/Requests.php';
-Requests::register_autoloader();
+\Requests::register_autoloader();
 
 // NEW: Using the custom autoloader in Requests 2.x.
 require_once 'path/to/Requests/src/Autoload.php';
-WpOrg\Requests\Autoload::register();
+\WpOrg\Requests\Autoload::register();
 ```
 
 For backward compatibility reasons, the Requests 1.x manner to call the autoloader

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -10,7 +10,7 @@ default parameters for these.
 Let's simulate communicating with GitHub.
 
 ```php
-$session = new WpOrg\Requests\Session('https://api.github.com/');
+$session = new \WpOrg\Requests\Session('https://api.github.com/');
 $session->headers['X-ContactAuthor'] = 'rmccue';
 $session->useragent = 'My-Awesome-App';
 
@@ -42,7 +42,7 @@ verification using the certificate authority list provided by the server environ
 ```php
 // Use server-provided certificate authority list.
 $options  = array('verify' => true);
-$response = WpOrg\Requests\Requests::get('https://httpbin.org/', array(), $options);
+$response = \WpOrg\Requests\Requests::get('https://httpbin.org/', array(), $options);
 ```
 
 The actual behavior depends on the transport being used, but in general should be based on the [`openssl` PHP ini settings].
@@ -56,7 +56,7 @@ You can do so by using the `'verify'` option with a filepath string:
 $options = array(
     'verify' => '/path/to/cacert.pem'
 );
-$response = WpOrg\Requests\Requests::get('https://httpbin.org/', array(), $options);
+$response = \WpOrg\Requests\Requests::get('https://httpbin.org/', array(), $options);
 ```
 
 As a fallback, Requests bundles certificates from the [Mozilla certificate authority list],
@@ -65,7 +65,7 @@ This fallback is used when the `'verify'` option is not provided at all:
 
 ```php
 // Use fallback certificate authority list.
-$response = WpOrg\Requests\Requests::get('https://httpbin.org/');
+$response = \WpOrg\Requests\Requests::get('https://httpbin.org/');
 ```
 
 :warning: **_Note however that this fallback should only be used for servers that are not properly
@@ -81,8 +81,9 @@ access to a transport with SSL capabilities with the following call:
 
 ```php
 use WpOrg\Requests\Capability;
+use WpOrg\Requests\Requests;
 
-$ssl_available = WpOrg\Requests\Requests::test(array(Capability::SSL => true));
+$ssl_available = Requests::test(array(Capability::SSL => true));
 ```
 
 ### Security Note

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,7 @@ One of the most basic things you can do with HTTP is make a GET request.
 Let's grab GitHub's public events:
 
 ```php
-$response = WpOrg\Requests\Requests::get('https://api.github.com/events');
+$response = \WpOrg\Requests\Requests::get('https://api.github.com/events');
 ```
 
 `$response` is now a **WpOrg\Requests\Response** object. Response objects are what
@@ -38,7 +38,7 @@ If you want to add custom headers to the request, simply pass them in as an
 associative array as the second parameter:
 
 ```php
-$response = WpOrg\Requests\Requests::get('https://api.github.com/events', array('X-Requests' => 'Is Awesome!'));
+$response = \WpOrg\Requests\Requests::get('https://api.github.com/events', array('X-Requests' => 'Is Awesome!'));
 ```
 
 
@@ -47,7 +47,7 @@ Make a POST Request
 Making a POST request is very similar to making a GET:
 
 ```php
-$response = WpOrg\Requests\Requests::post('https://httpbin.org/post');
+$response = \WpOrg\Requests\Requests::post('https://httpbin.org/post');
 ```
 
 You'll probably also want to pass in some data. You can pass in either a
@@ -58,7 +58,7 @@ internally) as the third parameter (after the URL and headers):
 
 ```php
 $data = array('key1' => 'value1', 'key2' => 'value2');
-$response = WpOrg\Requests\Requests::post('https://httpbin.org/post', array(), $data);
+$response = \WpOrg\Requests\Requests::post('https://httpbin.org/post', array(), $data);
 var_dump($response->body);
 ```
 
@@ -93,7 +93,7 @@ sending it:
 $url = 'https://api.github.com/some/endpoint';
 $headers = array('Content-Type' => 'application/json');
 $data = array('some' => 'data');
-$response = WpOrg\Requests\Requests::post($url, $headers, json_encode($data));
+$response = \WpOrg\Requests\Requests::post($url, $headers, json_encode($data));
 ```
 
 Note that if you don't manually specify a Content-Type header, Requests has


### PR DESCRIPTION
... unless the example code is namespaced, in which case: use import use statements.