### PR TITLE
SessionTest::testURLResolution(): fix test

### DIFF
--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -7,13 +7,13 @@ use WpOrg\Requests\Tests\TestCase;
 
 final class SessionTest extends TestCase {
 	public function testURLResolution() {
-		$session = new Session($this->httpbin('/'));
+		$session = new Session($this->httpbin('/', true));
 
 		// Set the cookies up
 		$response = $session->get('/get');
 		$this->assertTrue($response->success, 'Session property "success" is not equal to true');
 		$this->assertSame(
-			$this->httpbin('/get'),
+			$this->httpbin('/get', true),
 			$response->url,
 			'Session property "url" is not equal to the expected get URL'
 		);
@@ -22,7 +22,7 @@ final class SessionTest extends TestCase {
 		$this->assertNotNull($data, 'Decoded response body is null');
 		$this->assertArrayHasKey('url', $data, 'Response data array does not have key "url"');
 		$this->assertSame(
-			$this->httpbin('/get'),
+			$this->httpbin('/get', true),
 			$data['url'],
 			'The value of the "url" key in the response data array is not equal to the expected get URL'
 		);


### PR DESCRIPTION
The Render server redirects to `https`, so as things were, we'd have a scheme mismatch in the tests.

By making it explicit that we are requesting an `https` URL and expecting the response from that, the test should pass again (locally).