### PR TITLE
GH Pages: update Ruby version

### DIFF
--- a/.github/workflows/test-ghpages.yml
+++ b/.github/workflows/test-ghpages.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           # Use the version as per https://pages.github.com/versions/.
-          ruby-version: 2.7.4
+          ruby-version: 3.3.4
           bundler-cache: true
 
       - name: Test building the GH Pages site


### PR DESCRIPTION
The ruby version supported for GH Pages has been changed, so the workflow needs updating.

This was hidden away in non-descript changelog entry in the GH Pages v229 release _sigh_.

This PR updates the `gh-pages` branch for this.

Refs:
* https://pages.github.com/versions/
* https://github.com/github/pages-gem/releases