### PR TITLE
GH Actions: PHP 8.4 has been released

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,10 @@ jobs:
     strategy:
       matrix:
         # Lint against the high/low versions of each PHP major + nightly.
-        php: ['5.6', '7.0', '7.4', '8.0', '8.3', '8.4']
+        php: ['5.6', '7.0', '7.4', '8.0', '8.4', '8.5']
 
     name: "Lint: PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.php == '8.5' }}
 
     steps:
       - name: Checkout code
@@ -40,7 +40,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php != '8.4' }}
+        if: ${{ matrix.php != '8.5' }}
         uses: "ramsey/composer-install@v3"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -48,7 +48,7 @@ jobs:
 
       # For PHP "nightly", we need to install with ignore platform reqs.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php == '8.4' }}
+        if: ${{ matrix.php == '8.5' }}
         uses: "ramsey/composer-install@v3"
         with:
           composer-options: "--ignore-platform-req=php+"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,18 +23,18 @@ jobs:
       # Keys:
       # - coverage: Whether to run the tests with code coverage.
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.4']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.5']
         coverage: [false]
 
         include:
           # Run code coverage on low/high PHP.
           - php: '5.6'
             coverage: true
-          - php: '8.3'
+          - php: '8.4'
             coverage: true
 
     name: "Test: PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.php == '8.5' }}
 
     steps:
       - name: Checkout code
@@ -60,7 +60,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php != '8.4' }}
+        if: ${{ matrix.php != '8.5' }}
         uses: "ramsey/composer-install@v3"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -68,7 +68,7 @@ jobs:
 
       # For PHP "nightly", we need to install with ignore platform reqs.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php == '8.4' }}
+        if: ${{ matrix.php == '8.5' }}
         uses: "ramsey/composer-install@v3"
         with:
           composer-options: "--ignore-platform-req=php+"


### PR DESCRIPTION
* Builds against PHP 8.4 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.5.

Ref: https://www.php.net/releases/8.4/en.php
