### PR TITLE
GH Actions: update Python version to 3.13

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Setup proxy server
         run: pip3 install mitmproxy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Setup proxy server
         run: pip3 install mitmproxy


### PR DESCRIPTION
## Detailed Description

Mitmproxy now supports Python 3.13, so let's use it..

Ref: https://github.com/mitmproxy/mitmproxy/blob/main/CHANGELOG.md
