### PR TITLE
Allow sub-second timeouts where feasible

### DIFF
--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -439,11 +439,24 @@ final class Curl implements Transport {
 
 		// cURL requires a minimum timeout of 1 second when using the system
 		// DNS resolver, as it uses `alarm()`, which is second resolution only.
-		// There's no way to detect which DNS resolver is being used from our
-		// end, so we need to round up regardless of the supplied timeout.
 		//
 		// https://github.com/curl/curl/blob/4f45240bc84a9aa648c8f7243be7b79e9f9323a5/lib/hostip.c#L606-L609
-		$timeout = max($options['timeout'], 1);
+		$using_asynch_dns = false;
+		if (defined('CURL_VERSION_ASYNCHDNS')) {
+			$curl_version = curl_version();
+			// phpcs:ignore PHPCompatibility.Constants.NewConstants.curl_version_asynchdnsFound
+			if (CURL_VERSION_ASYNCHDNS & $curl_version['features']) {
+				$using_asynch_dns = true;
+			}
+		}
+
+		if ($using_asynch_dns) {
+			// It should be safe to use any timeout, even if less than 1 second.
+			$timeout = $options['timeout'];
+		} else {
+			// If the timeout is less than 1 second, we need to round up.
+			$timeout = max($options['timeout'], 1);
+		}
 
 		if (is_int($timeout) || $this->version < self::CURL_7_16_2) {
 			curl_setopt($this->handle, CURLOPT_TIMEOUT, ceil($timeout));


### PR DESCRIPTION
This implements the suggestion made in #264 to check for `CURL_VERSION_ASYNCHDNS` to determine whether timeouts of less than 1 second will work.

See also: https://core.trac.wordpress.org/ticket/63547

<!--
Thank you for creating this pull request!

Provide a general summary of your changes in the Title above.
And please provide enough information in the description below, so that others can review your pull request (PR).
-->

## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [x] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [ ] Code quality improvement

## Context
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
What should be mentioned about this PR in the changelog?
-->

The goal is to allow timeouts of less than one second on systems where this is feasible.  This might not be possible for all systems, but it should be achievable for on machines with cURL which has been built with support for asynchronous DNS lookups.

## Detailed Description

This PR simply adds the check for `CURL_VERSION_ASYNCHDNS` previously discussed in #264, to allow timeouts of less than 1 second on systems where this will work, i.e., those not using the (synchronous) system resolver.

Note that the conversation in #264 went on to discuss some other things, which this PR does not attempt to address.  This PR only adds the check for `CURL_VERSION_ASYNCHDNS`.

## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [x] The (new/existing) tests cover this PR 100%.
- [x] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!
I.e. code style complies with the project standard, the unit tests pass, code coverage has not gone down.

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make reviewing your changes easier for the maintainers.
============================================================================================
-->
