### PR TITLE
Requests.php: always set body text from response

### DIFF
--- a/src/Requests.php
+++ b/src/Requests.php
@@ -739,9 +739,7 @@ class Requests {
 			$headers = substr($return->raw, 0, $pos);
 			// Headers will always be separated from the body by two new lines - `\n\r\n\r`.
 			$body = substr($return->raw, $pos + 4);
-			if (!empty($body)) {
-				$return->body = $body;
-			}
+			$return->body = $body;
 		}
 
 		// Pretend CRLF = LF for compatibility (RFC 2616, section 19.3)

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -739,7 +739,9 @@ class Requests {
 			$headers = substr($return->raw, 0, $pos);
 			// Headers will always be separated from the body by two new lines - `\n\r\n\r`.
 			$body = substr($return->raw, $pos + 4);
-			$return->body = $body;
+			if ($body !== false) {
+				$return->body = $body;
+			}
 		}
 
 		// Pretend CRLF = LF for compatibility (RFC 2616, section 19.3)


### PR DESCRIPTION
This fixes a bug in which response body text satisfying PHP "empty()" is not returned to the caller.

As substr() always returns a string, there is no need for the guard condition here.  This has been removed accordingly, resolving the issue.

<!--
Thank you for creating this pull request!

Provide a general summary of your changes in the Title above.
And please provide enough information in the description below, so that others can review your pull request (PR).
-->

## Pull Request Type

- [ ] I have checked there is no other PR open for the same change.

This is a:
- [X] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [ ] Code quality improvement

## Context
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
What should be mentioned about this PR in the changelog?
-->

In dealing with a third-party API we found that empty responses were sometimes returned when we were expecting the non-empty response "0".  Requests turned out to be at fault.

Expected behaviour: the response string "0" is returned.
Observed behaviour: no response is returned.

## Detailed Description

In limited circumstances, the response body text is not correctly returned to the caller.  PHP empty() treats some unintuitive things as empty, including the string "0".

## Quality assurance

- [ ] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [ ] My code follows the style guidelines of this project.

This is a breaking change but is likely to be of minimal impact.

A unit test could be added for requests returning the response string "0".

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!
I.e. code style complies with the project standard, the unit tests pass, code coverage has not gone down.

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make reviewing your changes easier for the maintainers.
============================================================================================
-->
