### PR TITLE
GH Actions: improve "don't run on forks" condition

### DIFF
--- a/.github/workflows/update-cacert.yml
+++ b/.github/workflows/update-cacert.yml
@@ -29,7 +29,7 @@ jobs:
   certificate-check:
     name: "Check for updated certificate bundle"
     # Don't run the cron job on forks.
-    if: ${{ github.event_name != 'schedule' || github.repository == 'WordPress/Requests' }}
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Detailed Description

Remove the condition containing a hard-coded repository name in favour of a more generic condition which should safeguard that the cron job doesn't run on forks just the same.
