### PR TITLE
Dependabot: attempt to enable for orphan `gh-pages` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,26 @@
 
 version: 2
 updates:
+  # Handle updates for the default branch.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "develop"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "GH Actions:"
+    labels:
+      - "Type: testing/chores/QA"
+
+  # Handle updates for the orphan gh-pages branch.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "gh-pages"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "GH Pages/Actions:"
     labels:
       - "Type: testing/chores/QA"


### PR DESCRIPTION
While only a minimal one, the GH Pages branch does contain a GH Actions workflow and it would be nice if dependencies in that workflow would be kept up to date.

The above solution was found via reading up on various discussions about this topic and hopefully _should_ work.

There is one caveat though, adding the `target_branch` to each section, means that the configuration in the `dependabot.yml` file will no longer be used for security updates. I'm not too concerned about that as I've yet to see the first security related PR from Dependabot in any of the projects I'm involved with.

Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#target-branch-
