### PR TITLE
PHP 8.5 | Tests: prevent deprecation notice for Reflection*::setAccessible()

### DIFF
--- a/tests/Cookie/Jar/ConstructorTest.php
+++ b/tests/Cookie/Jar/ConstructorTest.php
@@ -52,9 +52,9 @@ final class ConstructorTest extends TestCase {
 
 		$reflection = new ReflectionObject($obj);
 		$property   = $reflection->getProperty('cookies');
-		$property->setAccessible(true);
+		(\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
 		$property_value = $property->getValue($obj);
-		$property->setAccessible(false);
+		(\PHP_VERSION_ID < 80100) && $property->setAccessible(false);
 
 		$this->assertSame($input, $property_value, 'Cookies property has not been set to expected value');
 	}

--- a/tests/Requests/HasCapabilitiesTest.php
+++ b/tests/Requests/HasCapabilitiesTest.php
@@ -23,13 +23,13 @@ final class HasCapabilitiesTest extends TestCase {
 
 	public function testFailsForUnsupportedCapabilities() {
 		$transports = new ReflectionProperty(Requests::class, 'transports');
-		$transports->setAccessible(true);
+		(\PHP_VERSION_ID < 80100) && $transports->setAccessible(true);
 		$transports->setValue(null, [TestTransportMock::class]);
 
 		$result = Requests::has_capabilities(['time-travel' => true]);
 
 		$transports->setValue(null, []);
-		$transports->setAccessible(false);
+		(\PHP_VERSION_ID < 80100) && $transports->setAccessible(false);
 
 		$this->assertFalse($result);
 	}

--- a/tests/Utility/FilteredIterator/ConstructorTest.php
+++ b/tests/Utility/FilteredIterator/ConstructorTest.php
@@ -75,9 +75,9 @@ final class ConstructorTest extends TestCase {
 
 		$reflection = new ReflectionObject($obj);
 		$property   = $reflection->getProperty('callback');
-		$property->setAccessible(true);
+		(\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
 		$callback_value = $property->getValue($obj);
-		$property->setAccessible(false);
+		(\PHP_VERSION_ID < 80100) && $property->setAccessible(false);
 
 		$this->assertSame($input, $callback_value, 'Callback property has not been set');
 	}
@@ -108,9 +108,9 @@ final class ConstructorTest extends TestCase {
 
 		$reflection = new ReflectionObject($obj);
 		$property   = $reflection->getProperty('callback');
-		$property->setAccessible(true);
+		(\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
 		$callback_value = $property->getValue($obj);
-		$property->setAccessible(false);
+		(\PHP_VERSION_ID < 80100) && $property->setAccessible(false);
 
 		$this->assertNull($callback_value, 'Callback property has been set to invalid callback');
 	}

--- a/tests/Utility/FilteredIterator/SerializationTest.php
+++ b/tests/Utility/FilteredIterator/SerializationTest.php
@@ -30,7 +30,7 @@ final class SerializationTest extends TestCase {
 			$new_value  = unserialize($serialized);
 			$reflection = new ReflectionClass(FilteredIterator::class);
 			$property   = $reflection->getProperty('callback');
-			$property->setAccessible(true);
+			(\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
 			$callback_value = $property->getValue($new_value);
 			$this->assertNull($callback_value, 'Callback is not null');
 		} else {


### PR DESCRIPTION
Since PHP 8.1, calling the `Reflection*::setAccessible()` methods is no longer necessary as reflected properties/methods/etc will always be accessible. However, the method calls are still needed for PHP < 8.1.

As of PHP 8.5, calling the `Reflection*::setAccessible()` methods is now formally deprecated and will yield a deprecation notice, which will fail test runs. As of PHP 9.0, the `setAccessible()` method(s) will be removed.

With the latter in mind, this commit prevents the deprecation notice by making the calls to `setAccessible()` conditional.

Silencing the deprecation would mean, this would need to be "fixed" again come PHP 9.0, while the current solution should be stable, including for PHP 9.0.

Ref: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations