### PR TITLE
Composer: update PHPUnit Polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "requests/test-server": "dev-main",
     "roave/security-advisories": "dev-latest",
     "wp-coding-standards/wpcs": "^3.1",
-    "yoast/phpunit-polyfills": "^2.0.1"
+    "yoast/phpunit-polyfills": "^2.0.5"
   },
   "suggest": {
     "ext-curl": "For improved performance",


### PR DESCRIPTION
## Detailed Description

Update PHPUnit Polyfills to a PHP 8.5 compatible version.

Ref: https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/2.0.5

---

**Mind**: this will need to be included in any further 2.0.x releases, but when backporting, the version needed should be `^1.1.5`.


