### PR TITLE
PHP 8.5 | Fix various "Using null as an array offset" deprecation notices

### DIFF
--- a/src/Iri.php
+++ b/src/Iri.php
@@ -216,7 +216,7 @@ class Iri {
 			$return = null;
 		}
 
-		if ($return === null && isset($this->normalization[$this->scheme][$name])) {
+		if ($return === null && isset($this->scheme, $this->normalization[$this->scheme][$name])) {
 			return $this->normalization[$this->scheme][$name];
 		}
 		else {
@@ -671,26 +671,28 @@ class Iri {
 	}
 
 	protected function scheme_normalization() {
-		if (isset($this->normalization[$this->scheme]['iuserinfo']) && $this->iuserinfo === $this->normalization[$this->scheme]['iuserinfo']) {
-			$this->iuserinfo = null;
-		}
-		if (isset($this->normalization[$this->scheme]['ihost']) && $this->ihost === $this->normalization[$this->scheme]['ihost']) {
-			$this->ihost = null;
-		}
-		if (isset($this->normalization[$this->scheme]['port']) && $this->port === $this->normalization[$this->scheme]['port']) {
-			$this->port = null;
-		}
-		if (isset($this->normalization[$this->scheme]['ipath']) && $this->ipath === $this->normalization[$this->scheme]['ipath']) {
-			$this->ipath = '';
+		if (isset($this->scheme, $this->normalization[$this->scheme])) {
+			if (isset($this->normalization[$this->scheme]['iuserinfo']) && $this->iuserinfo === $this->normalization[$this->scheme]['iuserinfo']) {
+				$this->iuserinfo = null;
+			}
+			if (isset($this->normalization[$this->scheme]['ihost']) && $this->ihost === $this->normalization[$this->scheme]['ihost']) {
+				$this->ihost = null;
+			}
+			if (isset($this->normalization[$this->scheme]['port']) && $this->port === $this->normalization[$this->scheme]['port']) {
+				$this->port = null;
+			}
+			if (isset($this->normalization[$this->scheme]['ipath']) && $this->ipath === $this->normalization[$this->scheme]['ipath']) {
+				$this->ipath = '';
+			}
+			if (isset($this->normalization[$this->scheme]['iquery']) && $this->iquery === $this->normalization[$this->scheme]['iquery']) {
+				$this->iquery = null;
+			}
+			if (isset($this->normalization[$this->scheme]['ifragment']) && $this->ifragment === $this->normalization[$this->scheme]['ifragment']) {
+				$this->ifragment = null;
+			}
 		}
 		if (isset($this->ihost) && empty($this->ipath)) {
 			$this->ipath = '/';
-		}
-		if (isset($this->normalization[$this->scheme]['iquery']) && $this->iquery === $this->normalization[$this->scheme]['iquery']) {
-			$this->iquery = null;
-		}
-		if (isset($this->normalization[$this->scheme]['ifragment']) && $this->ifragment === $this->normalization[$this->scheme]['ifragment']) {
-			$this->ifragment = null;
 		}
 	}
 

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -37,7 +37,7 @@ class Headers extends CaseInsensitiveDictionary {
 			$offset = strtolower($offset);
 		}
 
-		if (!isset($this->data[$offset])) {
+		if (!isset($offset, $this->data[$offset])) {
 			return null;
 		}
 

--- a/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/Utility/CaseInsensitiveDictionary.php
@@ -51,6 +51,10 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 			$offset = strtolower($offset);
 		}
 
+		if ($offset === null) {
+			$offset = '';
+		}
+
 		return isset($this->data[$offset]);
 	}
 
@@ -64,6 +68,10 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	public function offsetGet($offset) {
 		if (is_string($offset)) {
 			$offset = strtolower($offset);
+		}
+
+		if ($offset === null) {
+			$offset = '';
 		}
 
 		if (!isset($this->data[$offset])) {
@@ -91,6 +99,10 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 			$offset = strtolower($offset);
 		}
 
+		if ($offset === null) {
+			$offset = '';
+		}
+
 		$this->data[$offset] = $value;
 	}
 
@@ -103,6 +115,10 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	public function offsetUnset($offset) {
 		if (is_string($offset)) {
 			$offset = strtolower($offset);
+		}
+
+		if ($offset === null) {
+			$offset = '';
 		}
 
 		unset($this->data[$offset]);


### PR DESCRIPTION
## Detailed Description

### PHP 8.5 | Iri: fix two "Using null as an array offset" deprecation notices

Fixes deprecation notices which occur if `$this->scheme` is `null`.

Fixed now via some extra defensive coding.

This change is already covered via the existing tests.

Ref: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists

### PHP 8.5 | Response/Headers: fix a "Using null as an array offset" deprecation notice

Fixes deprecation notices which occur if `$offset` is `null`.

Fixed now via some extra defensive coding.

This change is already covered via the existing tests.

Ref: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists

### PHP 8.5 | Utility/CaseInsensitiveDictionary: fix another set of "Using null as an array offset" deprecation notices

Fixes deprecation notices which occur if `$offset` is `null`.

Fixed now via some extra defensive coding.

This change is already covered via the existing tests.

Ref: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists

