### PR TITLE
Composer: remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
     "php-parallel-lint/php-parallel-lint": "^1.4.0",
     "phpcompatibility/php-compatibility": "^9.3.5",
     "requests/test-server": "dev-main",
-    "roave/security-advisories": "dev-latest",
     "wp-coding-standards/wpcs": "^3.1",
     "yoast/phpunit-polyfills": "^2.0.1"
   },


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.


## Detailed Description
The `roave/security-advisories` package was an inventive method to block installation of known insecure versions of other dependencies (via a `conflict` annotation).

As of Composer 2.9, using the `roave/security-advisories` package for this purpose is no longer needed as Composer will now natively block installation of known insecure versions of dependencies.

And while not all contributors to this repo may be using Composer 2.9+ (yet), Composer 2.9+ **_will_** be used in CI and CI failing on Composer blocking an insecure dependency offers the same level of protection as the package previously offered.

Refs:
* https://blog.packagist.com/composer-2-9/
* https://github.com/composer/composer/releases/tag/2.9.0

