### PR TITLE
GH Actions: allow test runs to succeed on fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
         run: vendor/bin/stop.sh
 
       - name: Send coverage report to Codecov
-        if: ${{ success() && matrix.coverage == true }}
+        if: ${{ success() && matrix.coverage == true && github.event.repository.fork == false }}
         uses: codecov/codecov-action@v5
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

## Detailed Description

As things were, test runs on forks (when the `stable` branch in the fork is updated) would always fail on the "upload code coverage reports" step, as forks (justifiably) don't have access to the `CODECOV_TOKEN`.

Fixed now by updating the conditions to run that step.
