### PR TITLE
GH Actions/test: use the latest Python version for mitmproxy

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Setup proxy server
         run: pip3 install mitmproxy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Setup proxy server
         run: pip3 install mitmproxy


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

## Detailed Description
Python 3.14 is supported by mitmproxy since mitmproxy 12.2.0 (released Oct 15, 2025).

Refs:
* [Python 3.14 changelog](https://docs.python.org/release/3.14.0/whatsnew/changelog.html#changelog)
* [mitmproxy changelog](https://github.com/mitmproxy/mitmproxy/blob/main/CHANGELOG.md#15-october-2025-mitmproxy-1220)

