### PR TITLE
Fix tests for expired and revoked SSL certificates

### DIFF
--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -845,17 +845,19 @@ abstract class BaseTestCase extends TestCase {
 		}
 
 		$this->expectException(Exception::class);
-		Requests::get('https://testssl-expire.disig.sk/index.en.html', [], $this->getOptions());
+		Requests::get('https://expired.badssl.com/', [], $this->getOptions());
 	}
 
 	public function testRevokedHTTPS() {
+		$this->markTestSkipped('Certificate revocation checking is not enabled by default in PHP. See issue #966.');
+
 		if ($this->skip_https) {
 			$this->markTestSkipped('SSL support is not available.');
 			return;
 		}
 
 		$this->expectException(Exception::class);
-		Requests::get('https://testssl-revoked.disig.sk/index.en.html', [], $this->getOptions());
+		Requests::get('https://revoked.badssl.com/', [], $this->getOptions());
 	}
 
 	/**

--- a/tests/Transport/Curl/CurlTest.php
+++ b/tests/Transport/Curl/CurlTest.php
@@ -18,13 +18,13 @@ final class CurlTest extends BaseTestCase {
 
 	public function testExpiredHTTPS() {
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('certificate subject name');
+		$this->expectExceptionMessage('certificate has expired');
 		parent::testExpiredHTTPS();
 	}
 
 	public function testRevokedHTTPS() {
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('certificate subject name');
+		$this->expectExceptionMessage('certificate has been revoked');
 		parent::testRevokedHTTPS();
 	}
 

--- a/tests/Transport/Fsockopen/FsockopenTest.php
+++ b/tests/Transport/Fsockopen/FsockopenTest.php
@@ -18,13 +18,13 @@ final class FsockopenTest extends BaseTestCase {
 
 	public function testExpiredHTTPS() {
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('SSL certificate did not match the requested domain name');
+		$this->expectExceptionMessage('certificate verify failed');
 		parent::testExpiredHTTPS();
 	}
 
 	public function testRevokedHTTPS() {
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('SSL certificate did not match the requested domain name');
+		$this->expectExceptionMessage('certificate verify failed');
 		parent::testRevokedHTTPS();
 	}
 


### PR DESCRIPTION
The tests for expired or revoked SSL certificates were failing for both Curl and FsockOpen because the test site we had been using has changed (https://testssl-expire.disig.sk/index.en.html).

This PR switches the test site to use expired/revoked.badssl.com, which is more of an industry standard.

The exception message to expect needed to be changed as well to make the expired test pass.

The revoked test has been set to be skipped, as it turns out that revocation checking is disabled by default for PHP's cURL.

See #966
