### PR TITLE
PHP 8.5 | FilteredIterator: do not accept objects

### DIFF
--- a/src/Utility/FilteredIterator.php
+++ b/src/Utility/FilteredIterator.php
@@ -30,13 +30,13 @@ final class FilteredIterator extends ArrayIterator {
 	/**
 	 * Create a new iterator
 	 *
-	 * @param array    $data     The array or object to be iterated on.
+	 * @param array    $data     The array to be iterated on.
 	 * @param callable $callback Callback to be called on each value
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $data argument is not iterable.
 	 */
 	public function __construct($data, $callback) {
-		if (InputValidator::is_iterable($data) === false) {
+		if (is_object($data) === true || InputValidator::is_iterable($data) === false) {
 			throw InvalidArgument::create(1, '$data', 'iterable', gettype($data));
 		}
 

--- a/tests/Utility/FilteredIterator/ConstructorTest.php
+++ b/tests/Utility/FilteredIterator/ConstructorTest.php
@@ -33,7 +33,7 @@ final class ConstructorTest extends TestCase {
 	 * @return array
 	 */
 	public static function dataValidData() {
-		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_ITERABLE);
+		return TypeProviderHelper::getSelection(TypeProviderHelper::GROUP_ARRAY);
 	}
 
 	/**
@@ -58,7 +58,7 @@ final class ConstructorTest extends TestCase {
 	 * @return array
 	 */
 	public static function dataInvalidData() {
-		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ITERABLE);
+		return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_ARRAY);
 	}
 
 	/**


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

## Context
PHP 8.5 compatibility

## Detailed Description

The tests for the `FilteredIterator::__construct()` method were failing on PHP 8.5 as we were explicitly testing the class for accepting objects.

While this _is_ still supported on PHP 8.5, it is deprecated and results in the following deprecation notices:

```
1) /home/runner/work/Requests/Requests/src/Utility/FilteredIterator.php:43
ArrayIterator::__construct(): Using an object as a backing array for ArrayIterator is deprecated, as it allows violating class constraints and invariants

Triggered by:

* WpOrg\Requests\Tests\Utility\FilteredIterator\ConstructorTest::testValidData#ArrayIterator object
  /home/runner/work/Requests/Requests/tests/Utility/FilteredIterator/ConstructorTest.php:26

* WpOrg\Requests\Tests\Utility\FilteredIterator\ConstructorTest::testValidData#Iterator object, no array access
  /home/runner/work/Requests/Requests/tests/Utility/FilteredIterator/ConstructorTest.php:26
```

This commit now makes two changes:
1. Change the `FilteredIterator::__construct()` method to no longer accept objects as a backing array.
2. No longer pass objects to the method when testing.

With that, these test failures on PHP 8.5 are fixed.

👉🏻 Note: this could be considered a **_breaking change_**, as the class accepting an object was documented behaviour. However, as this is primarily an internal class, I'm not too concerned about that.

