### PR TITLE
GH Actions: update for the release of PHP 8.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,10 @@ jobs:
     strategy:
       matrix:
         # Lint against the high/low versions of each PHP major + nightly.
-        php: ['5.6', '7.0', '7.4', '8.0', '8.4', '8.5']
+        php: ['5.6', '7.0', '7.4', '8.0', '8.5', '8.6']
 
     name: "Lint: PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.5' }}
+    continue-on-error: ${{ matrix.php == '8.6' }}
 
     steps:
       - name: Checkout code
@@ -39,19 +39,12 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-      - name: Install Composer dependencies - normal
-        if: ${{ matrix.php != '8.5' }}
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
         with:
+          # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }}
           # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      # For PHP "nightly", we need to install with ignore platform reqs.
-      - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php == '8.5' }}
-        uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
-        with:
-          composer-options: "--ignore-platform-req=php+"
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,18 +23,18 @@ jobs:
       # Keys:
       # - coverage: Whether to run the tests with code coverage.
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.5']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.6']
         coverage: [false]
 
         include:
           # Run code coverage on low/high PHP.
           - php: '5.6'
             coverage: true
-          - php: '8.4'
+          - php: '8.5'
             coverage: true
 
     name: "Test: PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.5' }}
+    continue-on-error: ${{ matrix.php == '8.6' }}
 
     steps:
       - name: Checkout code
@@ -59,19 +59,12 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-      - name: Install Composer dependencies - normal
-        if: ${{ matrix.php != '8.5' }}
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
         with:
+          # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }}
           # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      # For PHP "nightly", we need to install with ignore platform reqs.
-      - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php == '8.5' }}
-        uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
-        with:
-          composer-options: "--ignore-platform-req=php+"
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Setup problem matcher to provide annotations for PHPUnit


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.


## Detailed Description

Update for the release of PHP 8.5 which is expected to be released today.

* Builds against PHP 8.5 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.5).
* Add _allowed to fail_ build against PHP 8.6.

