### PR TITLE
CurlTest::testDoesntOverwriteExpectHeaderIfManuallySet(): skip test on PHP 5.6

### DIFF
--- a/tests/Transport/Curl/CurlTest.php
+++ b/tests/Transport/Curl/CurlTest.php
@@ -39,6 +39,7 @@ final class CurlTest extends BaseTestCase {
 
 	/**
 	 * @small
+	 * @requires PHP 7.0.0
 	 */
 	public function testDoesntOverwriteExpectHeaderIfManuallySet() {
 		$headers = [


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.


## Detailed Description

For some unphantomable reason this test is now structurally failing on PHP 5.6 with Xdebug turned off.

@schlessera spend some time trying to debug this and trying to figure out why the test only fails on PHP 5.6 and only in the `quicktest` workflow, not in the `test` workflow, without a definitive conclusion.

Considering that support for PHP < 7.2 will be dropped in the near future - see ticket #983 -, let's not spend any more time on this and just skip this test on PHP 5.6 (as flaky).
