### PR TITLE
GH Actions/quicktest: fix proxy cancelling

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -107,8 +107,8 @@ jobs:
       - name: Stop proxy server
         continue-on-error: true
         run: |
-          PORT=9002 scripts/stop.sh
-          PORT=9003 scripts/stop.sh
+          PORT=9002 scripts/proxy/stop.sh
+          PORT=9003 scripts/proxy/stop.sh
 
       - name: Stop test server
         continue-on-error: true


### PR DESCRIPTION
Follow up on #928 which moved the proxy related scripts, but contained an error in the new path for the proxy server stop commands in the `quicktest` workflow.