### PR TITLE
CS: start using PHPCompatibility 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   "require-dev": {
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
     "php-parallel-lint/php-parallel-lint": "^1.4.0",
-    "phpcompatibility/php-compatibility": "^9.3.5",
+    "phpcompatibility/php-compatibility": "^10.0.0@dev",
     "requests/test-server": "dev-main",
     "wp-coding-standards/wpcs": "^3.1",
     "yoast/phpunit-polyfills": "^2.0.5"
@@ -54,6 +54,8 @@
     "ext-zlib": "For improved performance when decompressing encoded streams",
     "art4/requests-psr18-adapter": "For using Requests as a PSR-18 HTTP Client"
   },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "autoload": {
     "psr-4": {
       "WpOrg\\Requests\\": "src/"

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -128,6 +128,7 @@ final class Curl implements Transport {
 	 */
 	public function __destruct() {
 		if (is_resource($this->handle)) {
+			// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated,Generic.PHP.DeprecatedFunctions.Deprecated
 			curl_close($this->handle);
 		}
 	}
@@ -324,6 +325,7 @@ final class Curl implements Transport {
 
 				curl_multi_remove_handle($multihandle, $done['handle']);
 				if (is_resource($done['handle'])) {
+					// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated,Generic.PHP.DeprecatedFunctions.Deprecated
 					curl_close($done['handle']);
 				}
 

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -147,9 +147,11 @@ final class Fsockopen implements Transport {
 			// Ref: https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#stream_context_set_option
 			if (function_exists('stream_context_set_options')) {
 				// PHP 8.3+.
+				// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.stream_context_set_optionsFound
 				stream_context_set_options($context, ['ssl' => $context_options]);
 			} else {
 				// PHP < 8.3.
+				// phpcs:ignore PHPCompatibility.FunctionUse.OptionalToRequiredFunctionParameters
 				stream_context_set_option($context, ['ssl' => $context_options]);
 			}
 		} else {

--- a/tests/Utility/InputValidator/IsCurlHandleTest.php
+++ b/tests/Utility/InputValidator/IsCurlHandleTest.php
@@ -23,6 +23,7 @@ final class IsCurlHandleTest extends TestCase {
 	 */
 	public static function tear_down_after_test() {
 		if (isset(self::$curl_handle) && is_resource(self::$curl_handle)) {
+			// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated,Generic.PHP.DeprecatedFunctions.Deprecated
 			curl_close(self::$curl_handle);
 		}
 


### PR DESCRIPTION
Long anticipated, finally here: PHPCompatibility 10.0.0-alpha1 :tada:

PHPCompatibility 10.0.0 brings huge improvements in both what is being detected (> 50 new sniffs), as well as the detection accuracy for pre-existing sniffs.

Even though still "unstable", it is stable enough for our purposes and the advantages of using it outweight the disadvantage of it being an unstable version. By setting the `minimum-stability` and `prefer-stable` settings in the `composer.json`, we can ensure that we don't get the `dev-develop` branch, but rather get a `10.0.0` tag, unstable or not.

And what with the improved detection, a number of php incompatibilities previously not flagged, are not flagged, even though we already handle them correctly via conditions. So this commit also adds a few selective ignore comments for those few situations where they are needed.

Ref:
* https://github.com/PHPCompatibility/PHPCompatibility/wiki/Upgrading-to-PHPCompatibility-10.0
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/10.0.0-alpha1