### PR TITLE
GH Actions/update-website: stop submitting test PRs on workflow update

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -125,6 +125,11 @@ jobs:
           name: website-updates
           path: artifacts
 
+      - name: Create the new branch
+        env:
+          REF_NAME: feature/auto-ghpages-update-${{ steps.get_pr_info.outputs.REF }}
+        run: git checkout -b "$REF_NAME"
+
       # Different version of phpDocumentor may add/remove files for CSS/JS etc.
       # Similarly, a new Requests major may remove classes.
       # So we always need to make sure that the old version of the API docs are
@@ -167,6 +172,7 @@ jobs:
         run: git status -vv --untracked=all
 
       - name: Create pull request
+        if: github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
         with:
           base: gh-pages
@@ -187,12 +193,6 @@ jobs:
           draft: ${{ steps.get_pr_info.outputs.DRAFT }}
 
       # Test that the site builds correctly.
-      - name: Checkout the newly created branch
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          ref: feature/auto-ghpages-update-${{ steps.get_pr_info.outputs.REF }}
-          persist-credentials: false
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@d697be2f83c6234b20877c3b5eac7a7f342f0d0c # v1.269.0
         with:


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.


## Detailed Description

Currently, the `update-website` workflow doesn't deploy the website straight away. Instead it opens a PR with the files which will be changed to allow for review of the website changes before deploying the updated website (by merging the PR).

To that end, the workflow is run:
* Whenever a tag is created.
* When a pull request changes any of the files directly involved in updating the website.
* When manually requested.

What with the frequent Dependabot updates, this has become quite noisy for the "pull request which changes the workflow" trigger.

To that end, this commit blocks the opening of the PR when the workflow/doc building files are changed, while still running the rest of the workflow to verify that the workflow wasn't broken by the changes.

It also introduces a new step to create the branch holding the changes in the local environment.
This was previously done via the "create PR" step, which will now be skipped, while we still need the branch for verifying Ruby can build the GH Pages site.

As the branch should now be checked-out already before we even get to the part of the workflow verifying the site can be build via GH Pages, we can also remove the separate `actions/checkout` step.
