### PR TITLE
GH Actions: bump ruby/setup-ruby

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -194,7 +194,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71 # v1.268.0
+        uses: ruby/setup-ruby@d697be2f83c6234b20877c3b5eac7a7f342f0d0c # v1.269.0
         with:
           # Use the version as per https://pages.github.com/versions/.
           ruby-version: 3.3.4


### PR DESCRIPTION
Updates `ruby/setup-ruby` from 1.268.0 to 1.269.0
- [Release notes](https://github.com/ruby/setup-ruby/releases)
- [Changelog](https://github.com/ruby/setup-ruby/blob/master/release.rb)
- [Commits](https://github.com/ruby/setup-ruby/compare/8aeb6ff8030dd539317f8e1769a044873b56ea71...d697be2f83c6234b20877c3b5eac7a7f342f0d0c)

Cherrypicked from #1001