### PR TITLE
GH Actions/update-website: fix workflow

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -99,7 +99,7 @@ jobs:
         id: get_pr_info
         env:
           REF_NAME: ${{ github.ref_name }}
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          TAG_NAME: ${{ github.event.push.ref }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "REF=$REF_NAME" >> "$GITHUB_OUTPUT"
@@ -126,6 +126,7 @@ jobs:
           path: artifacts
 
       - name: Create the new branch
+        if: github.event_name == 'pull_request'
         env:
           REF_NAME: feature/auto-ghpages-update-${{ steps.get_pr_info.outputs.REF }}
         run: git checkout -b "$REF_NAME"


### PR DESCRIPTION
Follow up on PR #999, which broke the workflow for submitting a PR when a new release is tagged.