### PR TITLE
PHPUnit: add clover code coverage config to config file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,11 +123,11 @@ jobs:
 
       - name: Run the unit tests with code coverage (PHPUnit < 10)
         if: ${{  matrix.coverage == true && ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
-        run: composer coverage -- --coverage-clover clover.xml
+        run: composer coverage
 
       - name: Run the unit tests with code coverage (PHPUnit 10+)
         if: ${{  matrix.coverage == true && startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
-        run: composer coverage10 -- --coverage-clover clover.xml
+        run: composer coverage10
 
       - name: Stop proxy server
         continue-on-error: true
@@ -144,6 +144,6 @@ jobs:
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
-          files: ./clover.xml
+          files: ./tests/coverage/clover.xml
           fail_ci_if_error: true
           verbose: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,7 @@
 
 	<logging>
 		<log type="coverage-html" target="tests/coverage" lowUpperBound="35" highLowerBound="90"/>
+		<log type="coverage-clover" target="tests/coverage/clover.xml"/>
 	</logging>
 
 	<filter>

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -31,6 +31,7 @@
 	<coverage includeUncoveredFiles="true" ignoreDeprecatedCodeUnits="true">
 		<report>
 			<html outputDirectory="tests/coverage" lowUpperBound="35" highLowerBound="90"/>
+			<clover outputFile="tests/coverage/clover.xml"/>
 		</report>
 	</coverage>
 </phpunit>


### PR DESCRIPTION
This moves the clover code coverage config from the composer script to the `phpunit[10].xml.dist` config files.

It also moves the default location for the file from the project root to the `tests/coverage/` directory so all coverage files are in the same place (and automatically git ignored etc).

Includes updating the "upload to CodeCov" step to find the file in the new location.
