### PR TITLE
GH Actions/website: update PHP version used by phpDocumentor

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
-          php-version: '8.1'
+          php-version: '8.4'
           ini-values: display_errors=On, display_startup_errors=On
           coverage: none
           tools: phpdoc


### PR DESCRIPTION
As of phpDocumentor 3.9.0, the recommended PHP version to run phpDocumentor on is PHP 8.4.

Ref: https://github.com/phpDocumentor/phpDocumentor/releases/tag/v3.9.0
