### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -70,7 +70,7 @@ This project uses [PHP_CodeSniffer][] to detect coding standard violations and a
 * All files can be checked for coding standard violations by running `composer checkcs`.
 * Any automatically applicable fixes can be applied by running `composer fixcs`.
 
-[PHP_CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer
+[PHP_CodeSniffer]: https://github.com/PHPCSStandards/PHP_CodeSniffer
 
 ## Unit Tests
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,7 +8,7 @@
 	<!--
 	#############################################################################
 	COMMAND LINE ARGUMENTS
-	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset
 	#############################################################################
 	-->
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932