### PR TITLE
Tighten up the GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -13,10 +13,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   actionlint: #----------------------------------------------------------------------
     name: 'Check GHA workflows'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -41,6 +45,8 @@ jobs:
   phpcs: #----------------------------------------------------------------------
     name: 'PHPCS'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -13,6 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -20,7 +22,7 @@ jobs:
     name: 'Check GHA workflows'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Needed to clone the repo.
 
     steps:
       - name: Checkout code
@@ -46,7 +48,7 @@ jobs:
     name: 'PHPCS'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Needed to clone the repo.
 
     steps:
       - name: Checkout code

--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -13,10 +13,14 @@ on:
       - synchronize
       - reopened
 
+permissions: {}
+
 jobs:
   check-prs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'WordPress'
+    permissions:
+      pull-requests: write
 
     name: Check PRs for merge conflicts
 

--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -13,6 +13,8 @@ on:
       - synchronize
       - reopened
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -20,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'WordPress'
     permissions:
-      pull-requests: write
+      pull-requests: write # Needed to add and remove labels on the PR.
 
     name: Check PRs for merge conflicts
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   lint: #----------------------------------------------------------------------
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,13 +13,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   lint: #----------------------------------------------------------------------
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Needed to clone the repo.
 
     strategy:
       matrix:

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -13,6 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -21,7 +23,7 @@ jobs:
   quicktest:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Needed to clone the repo.
 
     strategy:
       matrix:

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -13,11 +13,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   #### QUICK TEST STAGE ####
   # Runs the tests against select PHP versions for pushes to arbitrary branches.
   quicktest:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/reusable-update-cacert.yml
+++ b/.github/workflows/reusable-update-cacert.yml
@@ -3,6 +3,8 @@ name: Certificates
 on:
   workflow_call:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -11,8 +13,8 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Needed to push commits to a branch in the repo.
+      pull-requests: write # Needed to create a PR.
 
     steps:
       - name: Determine branches to use

--- a/.github/workflows/reusable-update-cacert.yml
+++ b/.github/workflows/reusable-update-cacert.yml
@@ -3,11 +3,17 @@ name: Certificates
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   certificate-check:
     name: "Check for updated certificate bundle"
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Determine branches to use
         id: branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   #### TEST STAGE ####
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       # Keys:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -21,7 +23,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Needed to clone the repo.
 
     strategy:
       # Keys:

--- a/.github/workflows/update-cacert-cron.yml
+++ b/.github/workflows/update-cacert-cron.yml
@@ -11,6 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -18,7 +20,7 @@ jobs:
     # Don't run the cron job on forks.
     if: ${{ github.event.repository.fork == false }}
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Needed to push commits to a branch in the repo.
+      pull-requests: write # Needed to create a PR.
 
     uses: ./.github/workflows/reusable-update-cacert.yml

--- a/.github/workflows/update-cacert-cron.yml
+++ b/.github/workflows/update-cacert-cron.yml
@@ -11,9 +11,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   certificate-check:
     # Don't run the cron job on forks.
     if: ${{ github.event.repository.fork == false }}
+    permissions:
+      contents: write
+      pull-requests: write
 
     uses: ./.github/workflows/reusable-update-cacert.yml

--- a/.github/workflows/update-cacert.yml
+++ b/.github/workflows/update-cacert.yml
@@ -24,12 +24,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   certificate-check:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Needed to push commits to a branch in the repo.
+      pull-requests: write # Needed to create a PR.
 
     uses: ./.github/workflows/reusable-update-cacert.yml

--- a/.github/workflows/update-cacert.yml
+++ b/.github/workflows/update-cacert.yml
@@ -24,6 +24,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   certificate-check:
+    permissions:
+      contents: write
+      pull-requests: write
+
     uses: ./.github/workflows/reusable-update-cacert.yml

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -21,9 +21,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  pull-requests: write
-  contents: write
+permissions: {}
 
 jobs:
   prepare:
@@ -32,6 +30,9 @@ jobs:
     if: github.repository == 'WordPress/Requests'
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       # By default use the `stable` branch as the published docs should always
       # reflect the latest release.
@@ -91,6 +92,10 @@ jobs:
     if: github.repository == 'WordPress/Requests'
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       # PRs based on the "pull request" event trigger will contain changes from the
       # current `develop` branch, so should not be published as the website should

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -21,6 +21,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -31,7 +33,7 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Needed to clone the repo.
 
     steps:
       # By default use the `stable` branch as the published docs should always
@@ -93,8 +95,8 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Needed to push commits to a branch in the repo.
+      pull-requests: write # Needed to create a PR.
 
     steps:
       # PRs based on the "pull request" event trigger will contain changes from the


### PR DESCRIPTION
This change uses the principal of least privilege to tighten up the permissions that are granted to the `GITHUB_TOKEN` access tokens that get granted and used during GitHub Actions workflow runs.

This minimises the impact that a token leak can have and allows the "Workflow permissions" setting on https://github.com/WordPress/Requests/settings/actions to be switched to read-only from its current read and write setting.

Further reading:

- https://github.com/johnbillion/awesome-github-actions-security
- https://developer.wordpress.org/coding-standards/wordpress-coding-standards/github-actions/

## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [x] Code quality improvement

## Context

The security team are working on publishing full guidance, standards, and tools for GitHub Actions workflow hardening across the WordPress organisation on GitHub. This is a hardening measure while that's all being worked on.