### PR TITLE
Add streaming support

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -25,6 +25,10 @@ Available Hooks
 
     Parameters: `string $data`, `int $response_bytes`, `int|bool $response_byte_limit`
 
+    When the [`stream`](usage-advanced.md#streaming-responses) option is enabled,
+    this hook fires once per `WpOrg\Requests\Response::read()` call as the caller
+    pulls the body, not while the transport receives the response.
+
 * **`requests.before_parse`**
 
     Alter the raw HTTP response before parsing.
@@ -94,6 +98,11 @@ Available Hooks
     When a non-blocking request was made (`$options['blocking'] = false`), both the `$headers` string as well as the `$info` array will be empty.
 
     Prior to Requests 2.1.0, the `$info` parameter was omitted for non-blocking requests.
+
+    When the [`stream`](usage-advanced.md#streaming-responses) option is enabled,
+    this hook fires once the response headers are in, so the `$info` array
+    reflects the transfer at that point (timing and size fields are not final
+    yet).
 
 * **`curl.before_multi_add`**
 

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -30,6 +30,67 @@ $session->useragent = 'My-Awesome-App';
 $session->options['useragent'] = 'My-Awesome-App';
 ```
 
+## Streaming Responses
+
+By default, Requests buffers the whole response body in memory before returning.
+For large downloads or long-lived responses, such as Server-Sent Events from an
+AI API, set the `stream` option to `true` instead. The request then returns as
+soon as the response headers are in, and you read the body yourself:
+
+```php
+$response = \WpOrg\Requests\Requests::get('https://example.org/events', array(), array('stream' => true));
+
+// The status code and headers are available right away.
+var_dump($response->status_code);
+
+// Pull the body off the wire in chunks.
+while (!$response->eof()) {
+  $chunk = $response->read();
+  // do something with $chunk
+}
+
+// Release the connection when done.
+$response->close();
+```
+
+The streaming API on `WpOrg\Requests\Response` is small:
+
+- `read($length = 8192)` reads up to `$length` bytes of the body, blocking until
+  data arrives. An empty string means the body has ended.
+- `eof()` tells you whether the body has been fully read.
+- `close()` releases the underlying connection. Also safe to call on responses
+  that are not streamed.
+- `is_streaming()` tells you whether the response is being streamed. Custom
+  transports without streaming support fall back to a normal buffered response,
+  which this lets you detect.
+
+For line-based protocols such as NDJSON or Server-Sent Events, buffer the chunks
+until a newline shows up. See
+[`examples/stream.php`](https://github.com/WordPress/Requests/blob/develop/examples/stream.php)
+for a runnable example.
+
+A few things change when streaming:
+
+- `$response->body` stays empty and `$response->raw` only contains the headers.
+  The body comes out of `read()` instead.
+- Bytes from `read()` are already de-chunked. Both transports ask the server for
+  an uncompressed (`identity`) body, and Requests never decompresses streamed
+  bytes, so what the server sends is what you get.
+- The `timeout` option turns into an idle timeout: the maximum wait for the next
+  chunk of data. A long-lived stream stays open as long as data keeps arriving.
+- `max_bytes` and redirects work as usual. Redirect responses along the way are
+  discarded; only the final response body is streamed.
+- The `request.progress` hook fires once per `read()` call.
+- `stream` needs a blocking request, and cannot be combined with `filename` or
+  with `WpOrg\Requests\Requests::request_multiple()`.
+
+Requests does not implement PSR-7, but `read()`, `eof()` and `close()` match the
+semantics of the corresponding PSR-7 `StreamInterface` methods, so a [PSR-18
+adapter][psr18-adapter] can wrap a streamed body as a readable PSR-7 stream
+without translation.
+
+[psr18-adapter]: https://github.com/Art4/requests-psr18-adapter
+
 
 Secure Requests with SSL
 ------------------------

--- a/examples/stream.php
+++ b/examples/stream.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @package   Requests\Examples
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
+
+require_once dirname(__DIR__) . '/src/Autoload.php';
+
+WpOrg\Requests\Autoload::register();
+
+$response = WpOrg\Requests\Requests::get(
+	'https://httpbin.dev/stream/100',
+	['Accept' => 'application/json'],
+	['stream' => true] // Enables streaming mode.
+);
+
+echo 'Status: ', $response->status_code, PHP_EOL;
+echo 'Content-Type: ', $response->headers['content-type'], PHP_EOL, PHP_EOL;
+
+$buffer = '';
+$lines  = 0;
+
+while (!$response->eof()) {
+	$buffer .= $response->read(8192);
+
+	while (($pos = strpos($buffer, "\n")) !== false) {
+		$line   = substr($buffer, 0, $pos);
+		$buffer = substr($buffer, $pos + 1);
+
+		if (trim($line) === '') {
+			continue;
+		}
+
+		var_dump(json_decode($line, true));
+		++$lines;
+	}
+}
+
+echo PHP_EOL, 'Processed ', $lines, ' streamed lines.', PHP_EOL;
+
+$response->close();

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -125,6 +125,7 @@ class Requests {
 		'blocking'         => true,
 		'type'             => self::GET,
 		'filename'         => false,
+		'stream'           => false,
 		'auth'             => false,
 		'proxy'            => false,
 		'cookies'          => false,
@@ -392,6 +393,14 @@ class Requests {
 	 *    (bool, default: true)
 	 * - `filename`: File to stream the body to instead.
 	 *    (string|bool, default: false)
+	 * - `stream`: Return once the response headers have been received and read
+	 *    the body incrementally via {@see \WpOrg\Requests\Response::read()}
+	 *    instead of buffering it into {@see \WpOrg\Requests\Response::$body}.
+	 *    Cannot be combined with `filename`, requires `blocking` and is not
+	 *    supported for multiple requests. In streaming mode, the `timeout`
+	 *    option acts as an idle timeout (the maximum wait for the next chunk of
+	 *    data) rather than as a total-transfer limit.
+	 *    (bool, default: false)
 	 * - `auth`: Authentication handler or array of user/password details to use
 	 *    for Basic authentication
 	 *    (\WpOrg\Requests\Auth|array|bool, default: false)
@@ -467,9 +476,14 @@ class Requests {
 
 		$response = $transport->request($url, $headers, $data, $options);
 
+		$stream = null;
+		if (!empty($options['stream']) && isset($transport->response_stream)) {
+			$stream = $transport->response_stream;
+		}
+
 		$options['hooks']->dispatch('requests.before_parse', [&$response, $url, $headers, $data, $type, $options]);
 
-		return self::parse_response($response, $url, $headers, $data, $options);
+		return self::parse_response($response, $url, $headers, $data, $options, $stream);
 	}
 
 	/**
@@ -515,6 +529,7 @@ class Requests {
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $requests argument is not an array or iterable object with array access.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $options argument is not an array.
+	 * @throws \WpOrg\Requests\Exception When the `stream` option is enabled for any of the requests.
 	 */
 	public static function request_multiple($requests, $options = []) {
 		if (InputValidator::has_array_access($requests) === false || InputValidator::is_iterable($requests) === false) {
@@ -556,6 +571,10 @@ class Requests {
 				}
 
 				$request['options'] = array_merge($options, $request['options']);
+			}
+
+			if (!empty($request['options']['stream'])) {
+				throw new Exception('The stream option is not supported for multiple requests', 'requests.stream.unsupported_multiple');
 			}
 
 			self::set_defaults($request['url'], $request['headers'], $request['data'], $request['type'], $request['options']);
@@ -651,10 +670,22 @@ class Requests {
 	 * @return void
 	 *
 	 * @throws \WpOrg\Requests\Exception When the $url is not an http(s) URL.
+	 * @throws \WpOrg\Requests\Exception When the `stream` option is enabled for a non-blocking request.
+	 * @throws \WpOrg\Requests\Exception When the `stream` option is combined with the `filename` option.
 	 */
 	protected static function set_defaults(&$url, &$headers, &$data, &$type, &$options) {
 		if (!preg_match('/^http(s)?:\/\//i', $url, $matches)) {
 			throw new Exception('Only HTTP(S) requests are handled.', 'nonhttp', $url);
+		}
+
+		if (!empty($options['stream'])) {
+			if (empty($options['blocking'])) {
+				throw new Exception('The stream option requires a blocking request', 'requests.stream.requires_blocking');
+			}
+
+			if ($options['filename'] !== false) {
+				throw new Exception('The stream and filename options cannot both be enabled for the same request', 'requests.stream.filename_conflict');
+			}
 		}
 
 		if (empty($options['hooks'])) {
@@ -713,13 +744,14 @@ class Requests {
 	 * @param array  $req_headers Original $headers array passed to {@link request()}, in case we need to follow redirects
 	 * @param array  $req_data    Original $data array passed to {@link request()}, in case we need to follow redirects
 	 * @param array  $options     Original $options array passed to {@link request()}, in case we need to follow redirects
+	 * @param \WpOrg\Requests\Response\Stream|null $stream Live response body stream when the `stream` option is enabled, null otherwise
 	 * @return \WpOrg\Requests\Response
 	 *
 	 * @throws \WpOrg\Requests\Exception On missing head/body separator (`requests.no_crlf_separator`)
 	 * @throws \WpOrg\Requests\Exception On missing head/body separator (`noversion`)
 	 * @throws \WpOrg\Requests\Exception On missing head/body separator (`toomanyredirects`)
 	 */
-	protected static function parse_response($headers, $url, $req_headers, $req_data, $options) {
+	protected static function parse_response($headers, $url, $req_headers, $req_data, $options, $stream = null) {
 		$return = new Response();
 		if (!$options['blocking']) {
 			return $return;
@@ -789,6 +821,12 @@ class Requests {
 					$options['type'] = self::GET;
 				}
 
+				// Close the stream if it was opened, as we are about to redirect and will not be using it anymore.
+				if ($stream !== null) {
+					$stream->close();
+					$stream = null;
+				}
+
 				++$options['redirected'];
 				$location = $return->headers['location'];
 				if (strpos($location, 'http://') !== 0 && strpos($location, 'https://') !== 0) {
@@ -814,6 +852,10 @@ class Requests {
 		}
 
 		$return->redirects = $options['redirected'];
+
+		if ($stream !== null) {
+			$return->set_stream($stream);
+		}
 
 		$options['hooks']->dispatch('requests.after_request', [&$return, $req_headers, $req_data, $options]);
 		return $return;

--- a/src/Response.php
+++ b/src/Response.php
@@ -13,6 +13,7 @@ use WpOrg\Requests\Cookie\Jar;
 use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\Http;
 use WpOrg\Requests\Response\Headers;
+use WpOrg\Requests\Response\Stream;
 
 /**
  * HTTP response class
@@ -94,6 +95,15 @@ class Response {
 	public $cookies = [];
 
 	/**
+	 * Response body stream.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var \WpOrg\Requests\Response\Stream|null
+	 */
+	protected $stream = null;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -163,5 +173,74 @@ class Response {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Set the response body stream.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param \WpOrg\Requests\Response\Stream $stream Response body stream.
+	 * @return void
+	 */
+	public function set_stream($stream) {
+		$this->stream = $stream;
+	}
+
+	/**
+	 * Check if the response body is being streamed.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return bool True when the request was made with the `stream` option.
+	 */
+	public function is_streaming() {
+		return $this->stream instanceof Stream;
+	}
+
+	/**
+	 * Read from the streamed response body.
+	 *
+	 * @param int $length Optional. Maximum number of bytes to read.
+	 * @return string Body bytes, already de-chunked. An empty string indicates
+	 *                the end of the body.
+	 *
+	 * @throws \WpOrg\Requests\Exception When the response is not being streamed (`response.not_streaming`).
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $length argument is not a positive integer.
+	 */
+	public function read($length = Stream::DEFAULT_CHUNK_SIZE) {
+		if ($this->is_streaming() === false) {
+			throw new Exception('Response is not being streamed', 'response.not_streaming', $this);
+		}
+
+		return $this->stream->read($length);
+	}
+
+	/**
+	 * Check if the end of the streamed response body has been reached.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return bool
+	 *
+	 * @throws \WpOrg\Requests\Exception When the response is not being streamed.
+	 */
+	public function eof() {
+		if ($this->is_streaming() === false) {
+			throw new Exception('Response is not being streamed', 'response.not_streaming', $this);
+		}
+
+		return $this->stream->eof();
+	}
+
+	/**
+	 * Close the streamed response body.
+	 *
+	 * @return void
+	 */
+	public function close() {
+		if ($this->stream instanceof Stream) {
+			$this->stream->close();
+		}
 	}
 }

--- a/src/Response/Stream.php
+++ b/src/Response/Stream.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
+
+namespace WpOrg\Requests\Response;
+
+use WpOrg\Requests\Exception\InvalidArgument;
+
+/**
+ * Readable response body stream.
+ *
+ * @package Requests
+ */
+abstract class Stream {
+
+	/**
+	 * Default number of bytes to request per read.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_CHUNK_SIZE = 8192;
+
+	/**
+	 * Hook dispatcher, used to fire `request.progress` as body data is read.
+	 *
+	 * @var \WpOrg\Requests\HookManager
+	 */
+	protected $hooks;
+
+	/**
+	 * Maximum number of body bytes to read, or false for no limit.
+	 *
+	 * @var int|false
+	 */
+	protected $max_bytes = false;
+
+	/**
+	 * Number of body bytes already returned to the caller.
+	 *
+	 * @var int
+	 */
+	protected $bytes_read = 0;
+
+	/**
+	 * Whether the end of the body has been reached.
+	 *
+	 * @var bool
+	 */
+	protected $reached_eof = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int|false                   $max_bytes Maximum number of body bytes to read, or false for no limit.
+	 * @param \WpOrg\Requests\HookManager $hooks     Hook dispatcher.
+	 */
+	protected function __construct($max_bytes, $hooks) {
+		$this->max_bytes = $max_bytes;
+		$this->hooks     = $hooks;
+	}
+
+	/**
+	 * Read up to a number of bytes from the body.
+	 *
+	 * @param int $length Optional. Maximum number of bytes to read.
+	 * @return string Body bytes, already de-chunked. An empty string indicates
+	 *                the end of the body.
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $length argument is not a positive integer.
+	 */
+	public function read($length = self::DEFAULT_CHUNK_SIZE) {
+		if (is_int($length) === false || $length < 1) {
+			throw InvalidArgument::create(1, '$length', 'positive integer', gettype($length));
+		}
+
+		if ($this->reached_eof === true) {
+			return '';
+		}
+
+		if ($this->max_bytes !== false) {
+			$remaining = $this->max_bytes - $this->bytes_read;
+			if ($remaining <= 0) {
+				$this->reached_eof = true;
+				return '';
+			}
+
+			if ($length > $remaining) {
+				$length = $remaining;
+			}
+		}
+
+		$data = $this->fetch($length);
+		if ($data === '') {
+			// A blocking read returned nothing, so the body is exhausted.
+			$this->reached_eof = true;
+			return '';
+		}
+
+		$this->hooks->dispatch('request.progress', [$data, $this->bytes_read, $this->max_bytes]);
+
+		$this->bytes_read += strlen($data);
+
+		if ($this->max_bytes !== false && $this->bytes_read >= $this->max_bytes) {
+			$this->reached_eof = true;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Whether the end of the body has been reached.
+	 *
+	 * @return bool
+	 */
+	public function eof() {
+		return $this->reached_eof;
+	}
+
+	/**
+	 * Release the underlying resources.
+	 *
+	 * @return void
+	 */
+	public function close() {
+		$this->free();
+		$this->reached_eof = true;
+	}
+
+	/**
+	 * Destructor: ensure the underlying resources are released.
+	 */
+	public function __destruct() {
+		$this->close();
+	}
+
+	/**
+	 * Pull up to a number of bytes from the backend.
+	 *
+	 * @param int $length Maximum number of bytes to read.
+	 * @return string
+	 */
+	abstract protected function fetch($length);
+
+	/**
+	 * Release the backend's resources (sockets, cURL handles, ...).
+	 *
+	 * @return void
+	 */
+	abstract protected function free();
+}

--- a/src/Response/Stream/Curl.php
+++ b/src/Response/Stream/Curl.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
+
+namespace WpOrg\Requests\Response\Stream;
+
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Response\Stream;
+
+/**
+ * Response body stream backed by a cURL multi handle.
+ *
+ * @internal
+ *
+ * @package Requests
+ */
+final class Curl extends Stream {
+
+	/**
+	 * Maximum time (in seconds) to wait for activity per `curl_multi_select()` call.
+	 *
+	 * @var float
+	 */
+	const SELECT_TIMEOUT = 1.0;
+
+	/**
+	 * cURL multi handle driving the transfer.
+	 *
+	 * @var resource|\CurlMultiHandle|null Resource in PHP < 8.0, instance of CurlMultiHandle in PHP >= 8.0.
+	 */
+	private $multi;
+
+	/**
+	 * cURL easy handle for the request.
+	 *
+	 * @var resource|\CurlHandle|null Resource in PHP < 8.0, instance of CurlHandle in PHP >= 8.0.
+	 */
+	private $handle;
+
+	/**
+	 * Maximum time (in seconds) to wait for body data per read.
+	 *
+	 * @var int|float
+	 */
+	private $idle_timeout;
+
+	/**
+	 * Body bytes received from cURL, but not yet returned to the caller.
+	 *
+	 * @var string
+	 */
+	private $buffer = '';
+
+	/**
+	 * Whether the underlying transfer has finished.
+	 *
+	 * @var bool
+	 */
+	private $complete = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param resource|\CurlMultiHandle   $multi        cURL multi handle with the easy handle already attached.
+	 * @param resource|\CurlHandle        $handle       cURL easy handle for the request.
+	 * @param string                      $prebuffered  Body bytes already received while reading the headers.
+	 * @param int|float                   $idle_timeout Maximum time (in seconds) to wait for body data per read.
+	 * @param int|false                   $max_bytes    Maximum number of body bytes to read, or false for no limit.
+	 * @param \WpOrg\Requests\HookManager $hooks        Hook dispatcher.
+	 */
+	public function __construct($multi, $handle, $prebuffered, $idle_timeout, $max_bytes, $hooks) {
+		parent::__construct($max_bytes, $hooks);
+
+		$this->multi        = $multi;
+		$this->handle       = $handle;
+		$this->buffer       = (string) $prebuffered;
+		$this->idle_timeout = $idle_timeout;
+
+		curl_setopt($handle, CURLOPT_WRITEFUNCTION, [$this, 'receive_body']);
+		curl_setopt($handle, CURLOPT_HEADERFUNCTION, [$this, 'receive_trailer']);
+	}
+
+	/**
+	 * Discard trailer headers received after the body started.
+	 *
+	 * @param resource|\CurlHandle $handle cURL easy handle.
+	 * @param string               $data   Header data received.
+	 * @return int Length of the provided data.
+	 */
+	public function receive_trailer($handle, $data) {
+		return strlen($data);
+	}
+
+	/**
+	 * Collect body data as cURL receives it.
+	 *
+	 * @param resource|\CurlHandle $handle cURL easy handle.
+	 * @param string               $data   Body data received.
+	 * @return int Number of bytes handled. Returning fewer bytes than received
+	 *             makes libcurl abort the transfer.
+	 */
+	public function receive_body($handle, $data) {
+		$length = strlen($data);
+
+		if ($this->max_bytes !== false) {
+			$buffered = $this->bytes_read + strlen($this->buffer);
+			if (($buffered + $length) > $this->max_bytes) {
+				$length = $this->max_bytes - $buffered;
+				$data   = substr($data, 0, $length);
+			}
+		}
+
+		$this->buffer .= $data;
+
+		return $length;
+	}
+
+	/**
+	 * Advance the transfer and return received body bytes.
+	 *
+	 * @param int $length Maximum number of bytes to return.
+	 * @return string
+	 *
+	 * @throws \WpOrg\Requests\Exception On a cURL error.
+	 * @throws \WpOrg\Requests\Exception When no data arrives within the timeout.
+	 */
+	protected function fetch($length) {
+		$deadline = microtime(true) + $this->idle_timeout;
+
+		while ($this->buffer === '' && $this->complete === false) {
+			$running = 0;
+			do {
+				$status = curl_multi_exec($this->multi, $running);
+			} while ($status === CURLM_CALL_MULTI_PERFORM);
+
+			while ($done = curl_multi_info_read($this->multi)) {
+				if ($done['handle'] !== $this->handle) {
+					continue;
+				}
+
+				$this->complete = true;
+
+				$bytes_received = $this->bytes_read + strlen($this->buffer);
+				if ($done['result'] === CURLE_WRITE_ERROR
+					&& $this->max_bytes !== false
+					&& $bytes_received >= $this->max_bytes
+				) {
+					continue;
+				}
+
+				if ($done['result'] !== CURLE_OK) {
+					$error = sprintf(
+						'cURL error %s: %s',
+						$done['result'],
+						curl_error($this->handle)
+					);
+					throw new Exception($error, 'curlerror', $this->handle);
+				}
+			}
+
+			if ($this->buffer !== '' || $this->complete === true) {
+				break;
+			}
+
+			if ($running === 0) {
+				$this->complete = true;
+				break;
+			}
+
+			$remaining = $deadline - microtime(true);
+			if ($remaining <= 0) {
+				throw new Exception('Stream timed out while waiting for body data', 'timeout', $this->handle);
+			}
+
+			if (curl_multi_select($this->multi, min(self::SELECT_TIMEOUT, $remaining)) === -1) {
+				// Some platforms return -1 with nothing to wait on; back off
+				// briefly to avoid a busy-wait.
+				usleep(1000);
+			}
+		}
+
+		// substr() can return false on PHP < 8.0, hence the casts.
+		$out          = (string) substr($this->buffer, 0, $length);
+		$this->buffer = (string) substr($this->buffer, strlen($out));
+
+		return $out;
+	}
+
+	/**
+	 * Release the cURL handles.
+	 *
+	 * @return void
+	 */
+	protected function free() {
+		if ($this->handle !== null) {
+			curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, null);
+			curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, null);
+
+			if ($this->multi !== null) {
+				curl_multi_remove_handle($this->multi, $this->handle);
+			}
+
+			// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated,Generic.PHP.DeprecatedFunctions.Deprecated
+			curl_close($this->handle);
+			$this->handle = null;
+		}
+
+		if ($this->multi !== null) {
+			curl_multi_close($this->multi);
+			$this->multi = null;
+		}
+	}
+}

--- a/src/Response/Stream/Curl.php
+++ b/src/Response/Stream/Curl.php
@@ -205,8 +205,11 @@ final class Curl extends Stream {
 				curl_multi_remove_handle($this->multi, $this->handle);
 			}
 
-			// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated,Generic.PHP.DeprecatedFunctions.Deprecated
-			curl_close($this->handle);
+			if (is_resource($this->handle)) {
+				// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated,Generic.PHP.DeprecatedFunctions.Deprecated
+				curl_close($this->handle);
+			}
+
 			$this->handle = null;
 		}
 

--- a/src/Response/Stream/Curl.php
+++ b/src/Response/Stream/Curl.php
@@ -180,7 +180,9 @@ final class Curl extends Stream {
 			if (curl_multi_select($this->multi, min(self::SELECT_TIMEOUT, $remaining)) === -1) {
 				// Some platforms return -1 with nothing to wait on; back off
 				// briefly to avoid a busy-wait.
+				// @codeCoverageIgnoreStart
 				usleep(1000);
+				// @codeCoverageIgnoreEnd
 			}
 		}
 

--- a/src/Response/Stream/Socket.php
+++ b/src/Response/Stream/Socket.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Requests for PHP, an HTTP library.
+ *
+ * @copyright 2012-2023 Requests Contributors
+ * @license   https://github.com/WordPress/Requests/blob/stable/LICENSE ISC
+ * @link      https://github.com/WordPress/Requests
+ */
+
+namespace WpOrg\Requests\Response\Stream;
+
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Response\Stream;
+
+/**
+ * Response body stream backed by a socket.
+ *
+ * @internal
+ *
+ * @package Requests
+ */
+final class Socket extends Stream {
+
+	/**
+	 * Socket to read from.
+	 *
+	 * @var resource|null
+	 */
+	private $socket;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param resource                    $socket    Open socket, positioned at the start of the body.
+	 * @param bool                        $chunked   Whether the response uses chunked transfer-encoding.
+	 * @param int|false                   $max_bytes Maximum number of body bytes to read, or false for no limit.
+	 * @param \WpOrg\Requests\HookManager $hooks     Hook dispatcher.
+	 */
+	public function __construct($socket, $chunked, $max_bytes, $hooks) {
+		parent::__construct($max_bytes, $hooks);
+
+		$this->socket = $socket;
+
+		if ($chunked === true) {
+			// Strip the chunked transfer-encoding framing while reading.
+			stream_filter_append($socket, 'dechunk', STREAM_FILTER_READ);
+		}
+	}
+
+	/**
+	 * Read from the socket.
+	 *
+	 * @param int $length Maximum number of bytes to read.
+	 * @return string
+	 *
+	 * @throws \WpOrg\Requests\Exception On socket timeout (`timeout`).
+	 */
+	protected function fetch($length) {
+		if (is_resource($this->socket) === false) {
+			return '';
+		}
+
+		while (true) {
+			// If PHP's stream buffer already holds data (body bytes pulled in
+			// while the headers were read), only ask for that much. Asking for
+			// more makes fread() block for a top-up instead of returning the
+			// buffered bytes right away.
+			$info = stream_get_meta_data($this->socket);
+			if (!empty($info['unread_bytes']) && $info['unread_bytes'] < $length) {
+				$length = $info['unread_bytes'];
+			}
+
+			$block = fread($this->socket, $length);
+
+			if ($block !== false && $block !== '') {
+				// On PHP < 8.3, a read which hits the socket timeout can still
+				// return the data received up to that point, with the timed_out
+				// flag set. Data wins; the next read gets a fresh timeout.
+				return $block;
+			}
+
+			$info = stream_get_meta_data($this->socket);
+			if (!empty($info['timed_out'])) {
+				throw new Exception('fsocket timed out', 'timeout');
+			}
+
+			if ($block === false) {
+				// Read error; treat as the end of the body.
+				return '';
+			}
+
+			if (feof($this->socket)) {
+				return '';
+			}
+
+			// Nothing came back but the connection is still open. This happens
+			// when a read filter (dechunk) swallows framing bytes without
+			// producing body bytes. Try again; fread() blocks until more data
+			// arrives, so this won't spin.
+		}
+	}
+
+	/**
+	 * Close the socket.
+	 *
+	 * @return void
+	 */
+	protected function free() {
+		if (is_resource($this->socket)) {
+			fclose($this->socket);
+		}
+
+		$this->socket = null;
+	}
+}

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -16,6 +16,7 @@ use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Exception\Transport\Curl as CurlException;
 use WpOrg\Requests\Requests;
+use WpOrg\Requests\Response\Stream\Curl as CurlStream;
 use WpOrg\Requests\Transport;
 use WpOrg\Requests\Utility\InputValidator;
 
@@ -99,9 +100,41 @@ final class Curl implements Transport {
 	private $response_byte_limit;
 
 	/**
+	 * The stream object for a streamed response.
+	 *
+	 * @var \WpOrg\Requests\Response\Stream|null
+	 */
+	public $response_stream = null;
+
+	/**
+	 * Are we currently streaming a response?
+	 *
+	 * @var bool
+	 */
+	private $streaming = false;
+
+	/**
+	 * Buffer for body data received while waiting for the final response headers.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var string
+	 */
+	private $stream_buffer = '';
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
+		$this->init_handle();
+	}
+
+	/**
+	 * Initialise a new cURL handle with the default options.
+	 *
+	 * @return void
+	 */
+	private function init_handle() {
 		$curl          = curl_version();
 		$this->version = $curl['version_number'];
 		$this->handle  = curl_init();
@@ -131,6 +164,8 @@ final class Curl implements Transport {
 			// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated,Generic.PHP.DeprecatedFunctions.Deprecated
 			curl_close($this->handle);
 		}
+
+		$this->handle = null;
 	}
 
 	/**
@@ -192,6 +227,9 @@ final class Curl implements Transport {
 		$this->response_data       = '';
 		$this->response_bytes      = 0;
 		$this->response_byte_limit = false;
+		$this->response_stream     = null;
+		$this->streaming           = false;
+		$this->stream_buffer       = '';
 		if ($options['max_bytes'] !== false) {
 			$this->response_byte_limit = $options['max_bytes'];
 		}
@@ -207,6 +245,10 @@ final class Curl implements Transport {
 
 		if (isset($options['verifyname']) && $options['verifyname'] === false) {
 			curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
+		}
+
+		if (!empty($options['stream'])) {
+			return $this->stream_response($options);
 		}
 
 		curl_exec($this->handle);
@@ -240,6 +282,106 @@ final class Curl implements Transport {
 		// Otherwise \WpOrg\Requests\Transport\Curl won't be garbage collected and the curl_close() will never be called.
 		curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, null);
 		curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, null);
+
+		return $this->headers;
+	}
+
+	/**
+	 * Stream a response.
+	 *
+	 * @param array $options Request options.
+	 * @return string Raw response headers.
+	 *
+	 * @throws \WpOrg\Requests\Exception On a cURL error.
+	 * @throws \WpOrg\Requests\Exception When no data arrives within the timeout.
+	 */
+	private function stream_response($options) {
+		$this->streaming = true;
+
+		// Clear header state from a previous request so we don't mistake stale headers for this response.
+		$this->headers      = '';
+		$this->done_headers = false;
+
+		// A streamed response has no meaningful total-transfer timeout, so disable CURLOPT_TIMEOUT.
+		// The configured timeout becomes an idle timeout instead and is enforced below (matching fsockopen's stream_set_timeout() behavior).
+		curl_setopt($this->handle, CURLOPT_TIMEOUT, 0);
+		$timeout = max($options['timeout'], 1);
+
+		// Request an uncompressed response since streamed data is passed through as received and never decompressed.
+		curl_setopt($this->handle, CURLOPT_ENCODING, 'identity');
+
+		// If the server still sends compressed data, prevent libcurl from decoding it so both transports deliver identical bytes.
+		if ($this->version >= self::CURL_7_16_2) {
+			curl_setopt($this->handle, CURLOPT_HTTP_CONTENT_DECODING, false);
+		}
+
+		$multi = curl_multi_init();
+		curl_multi_add_handle($multi, $this->handle);
+
+		// Continue until the final response headers arrive. Ignore interim 1xx responses since another header block will follow.
+		$seen     = 0;
+		$deadline = microtime(true) + $timeout;
+		do {
+			$running = 0;
+			do {
+				$status = curl_multi_exec($multi, $running);
+			} while ($status === CURLM_CALL_MULTI_PERFORM);
+
+			while ($done = curl_multi_info_read($multi)) {
+				if ($done['handle'] === $this->handle && $done['result'] !== CURLE_OK) {
+					$error = sprintf(
+						'cURL error %s: %s',
+						$done['result'],
+						curl_error($this->handle)
+					);
+					curl_multi_remove_handle($multi, $this->handle);
+					curl_multi_close($multi);
+					throw new Exception($error, 'curlerror', $this->handle);
+				}
+			}
+
+			if ($this->done_headers === true
+			&& !preg_match('#^HTTP/\d(\.\d)?[ \t]+1\d\d#i', $this->headers)
+			) {
+				break;
+			}
+
+			if ($running === 0) {
+				break;
+			}
+
+			// Reset the idle timeout whenever more header data arrives.
+			if (strlen($this->headers) !== $seen) {
+				$seen     = strlen($this->headers);
+				$deadline = microtime(true) + $timeout;
+			}
+
+			$remaining = $deadline - microtime(true);
+			if ($remaining <= 0) {
+				curl_multi_remove_handle($multi, $this->handle);
+				curl_multi_close($multi);
+				throw new Exception('Stream timed out while waiting for the response headers', 'timeout', $this->handle);
+			}
+
+			if (curl_multi_select($multi, min(1.0, $remaining)) === -1) {
+				// Some platforms return -1 when no file descriptors are ready. Sleep to avoid busy-waiting.
+				usleep(1000);
+			}
+		} while (true);
+
+		$options['hooks']->dispatch('curl.after_send', []);
+
+		$handle = $this->handle;
+
+		$this->info            = curl_getinfo($handle);
+		$this->response_stream = new CurlStream($multi, $handle, $this->stream_buffer, $timeout, $options['max_bytes'], $this->hooks);
+		$this->stream_buffer   = '';
+
+		// The stream now owns the cURL handle and callbacks.
+		// setup_handle() will create a fresh handle for the next request.
+		$this->handle = null;
+
+		$options['hooks']->dispatch('curl.after_request', [&$this->headers, &$this->info]);
 
 		return $this->headers;
 	}
@@ -383,6 +525,12 @@ final class Curl implements Transport {
 	 * @param array        $options Request options, see {@see \WpOrg\Requests\Requests::response()} for documentation
 	 */
 	private function setup_handle($url, $headers, $data, $options) {
+		if ($this->handle === null) {
+			// The previous request on this instance streamed its response and
+			// handed the cURL handle off to the stream; start a fresh one.
+			$this->init_handle();
+		}
+
 		$options['hooks']->dispatch('curl.before_request', [&$this->handle]);
 
 		// Force closing the connection for old versions of cURL (<7.22).
@@ -537,6 +685,15 @@ final class Curl implements Transport {
 	 * @return int Length of provided header
 	 */
 	public function stream_headers($handle, $headers) {
+		// cURL delivers trailer headers for chunked responses through this callback as well.
+		// Ignore them since the final response headers have already been captured.
+		if ($this->streaming === true
+			&& $this->done_headers === true
+			&& !preg_match('#^HTTP/\d(\.\d)?[ \t]+1\d\d#i', $this->headers)
+		) {
+			return strlen($headers);
+		}
+
 		// Why do we do this? cURL will send both the final response and any
 		// interim responses, such as a 100 Continue. We don't need that.
 		// (We may want to keep this somewhere just in case)
@@ -564,6 +721,13 @@ final class Curl implements Transport {
 	 * @return int Length of provided data
 	 */
 	public function stream_body($handle, $data) {
+		if ($this->streaming === true) {
+			// Buffer body bytes until the response headers arrive.
+			// Response\Stream takes over this write callback once the handle is handed off.
+			$this->stream_buffer .= $data;
+			return strlen($data);
+		}
+
 		$this->hooks->dispatch('request.progress', [$data, $this->response_bytes, $this->response_byte_limit]);
 		$data_length = strlen($data);
 

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -365,7 +365,9 @@ final class Curl implements Transport {
 
 			if (curl_multi_select($multi, min(1.0, $remaining)) === -1) {
 				// Some platforms return -1 when no file descriptors are ready. Sleep to avoid busy-waiting.
+				// @codeCoverageIgnoreStart
 				usleep(1000);
+				// @codeCoverageIgnoreEnd
 			}
 		} while (true);
 

--- a/src/Transport/Fsockopen.php
+++ b/src/Transport/Fsockopen.php
@@ -14,6 +14,7 @@ use WpOrg\Requests\Exception;
 use WpOrg\Requests\Exception\InvalidArgument;
 use WpOrg\Requests\Port;
 use WpOrg\Requests\Requests;
+use WpOrg\Requests\Response\Stream\Socket as SocketStream;
 use WpOrg\Requests\Ssl;
 use WpOrg\Requests\Transport;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
@@ -45,6 +46,13 @@ final class Fsockopen implements Transport {
 	 * @var array Associative array of properties, see {@link https://www.php.net/stream_get_meta_data}
 	 */
 	public $info;
+
+	/**
+	 * The stream object for a streamed response.
+	 *
+	 * @var \WpOrg\Requests\Response\Stream|null
+	 */
+	public $response_stream = null;
 
 	/**
 	 * What's the maximum number of bytes we should keep?
@@ -158,7 +166,8 @@ final class Fsockopen implements Transport {
 			$remote_socket = 'tcp://' . $host;
 		}
 
-		$this->max_bytes = $options['max_bytes'];
+		$this->max_bytes       = $options['max_bytes'];
+		$this->response_stream = null;
 
 		if (!isset($url_parts['port'])) {
 			$url_parts['port'] = Port::HTTP;
@@ -237,9 +246,16 @@ final class Fsockopen implements Transport {
 			$out .= sprintf("User-Agent: %s\r\n", $options['useragent']);
 		}
 
-		$accept_encoding = $this->accept_encoding();
-		if (!isset($case_insensitive_headers['Accept-Encoding']) && !empty($accept_encoding)) {
-			$out .= sprintf("Accept-Encoding: %s\r\n", $accept_encoding);
+		if (!isset($case_insensitive_headers['Accept-Encoding'])) {
+			if (!empty($options['stream'])) {
+				// Streamed bytes are handed over as they arrive and never decompressed, so ask for an uncompressed response.
+				$out .= "Accept-Encoding: identity\r\n";
+			} else {
+				$accept_encoding = $this->accept_encoding();
+				if (!empty($accept_encoding)) {
+					$out .= sprintf("Accept-Encoding: %s\r\n", $accept_encoding);
+				}
+			}
 		}
 
 		$headers = Requests::flatten($headers);
@@ -281,6 +297,10 @@ final class Fsockopen implements Transport {
 		}
 
 		stream_set_timeout($socket, $timeout_sec, $timeout_msec);
+
+		if (!empty($options['stream'])) {
+			return $this->stream_response($socket, $options);
+		}
 
 		$response   = '';
 		$body       = '';
@@ -356,6 +376,54 @@ final class Fsockopen implements Transport {
 		fclose($socket);
 
 		$options['hooks']->dispatch('fsockopen.after_request', [&$this->headers, &$this->info]);
+		return $this->headers;
+	}
+
+	/**
+	 * Stream a response.
+	 *
+	 * @param resource $socket  Connected socket, positioned after the request has been sent.
+	 * @param array    $options Request options.
+	 * @return string Raw response headers.
+	 *
+	 * @throws \WpOrg\Requests\Exception On socket timeout.
+	 */
+	private function stream_response($socket, $options) {
+		$headers = '';
+
+		while (true) {
+			$line       = fgets($socket);
+			$this->info = stream_get_meta_data($socket);
+			if ($this->info['timed_out']) {
+				throw new Exception('fsocket timed out', 'timeout');
+			}
+
+			if ($line === false) {
+				// The connection closed before the response headers were complete.
+				break;
+			}
+
+			$headers .= $line;
+
+			if ($line === "\r\n" || $line === "\n") {
+				// Ignore interim 1xx responses since another header block will follow.
+				if (preg_match('#^HTTP/\d(\.\d)?[ \t]+1\d\d#i', $headers)) {
+					$headers = '';
+					continue;
+				}
+
+				break;
+			}
+		}
+
+		$this->headers = $headers;
+
+		// SocketStream removes chunked transfer encoding itself. RFC 7230 defines chunked as the final transfer encoding, so only match it at the end of the header value.
+		$chunked               = (bool) preg_match('#^transfer-encoding:\s*(?:[^\r\n]*,\s*)?chunked\s*$#im', $headers);
+		$this->response_stream = new SocketStream($socket, $chunked, $options['max_bytes'], $options['hooks']);
+
+		$options['hooks']->dispatch('fsockopen.after_request', [&$this->headers, &$this->info]);
+
 		return $this->headers;
 	}
 

--- a/tests/Fixtures/TrickleStreamWrapper.php
+++ b/tests/Fixtures/TrickleStreamWrapper.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Fixtures;
+
+final class TrickleStreamWrapper {
+
+	const NAME = 'trickle';
+
+	public $context;
+	private $blocks = [];
+
+	public static $script = [];
+
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- Signature defined by the PHP stream wrapper API.
+	public function stream_open($path, $mode, $options, &$opened_path) {
+		$this->blocks = self::$script;
+		return true;
+	}
+
+	public function stream_read($count) {
+		if ($this->blocks === []) {
+			return '';
+		}
+
+		$block = array_shift($this->blocks);
+		if (strlen($block) > $count) {
+			// Return what fits and re-queue the remainder for the next read.
+			array_unshift($this->blocks, substr($block, $count));
+			$block = substr($block, 0, $count);
+		}
+
+		return $block;
+	}
+
+	public function stream_eof() {
+		return $this->blocks === [];
+	}
+
+	public function stream_stat() {
+		return [];
+	}
+
+	public function stream_close() {
+		$this->blocks = [];
+	}
+}

--- a/tests/Requests/RequestsTest.php
+++ b/tests/Requests/RequestsTest.php
@@ -147,6 +147,89 @@ final class RequestsTest extends TestCase {
 		Requests::request('ftp://128.0.0.1/');
 	}
 
+	/**
+	 * Tests receiving an exception when the `stream` option is combined with the `filename` option.
+	 *
+	 * @covers \WpOrg\Requests\Requests::set_defaults
+	 *
+	 * @return void
+	 */
+	public function testStreamCombinedWithFilenameRejected() {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('The stream and filename options cannot both be enabled for the same request');
+
+		Requests::get(
+			'http://example.com/',
+			[],
+			[
+				'stream'   => true,
+				'filename' => 'stream-conflict.tmp',
+			]
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when the `stream` option is enabled for a non-blocking request.
+	 *
+	 * @covers \WpOrg\Requests\Requests::set_defaults
+	 *
+	 * @return void
+	 */
+	public function testStreamCombinedWithNonBlockingRejected() {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('The stream option requires a blocking request');
+
+		Requests::get(
+			'http://example.com/',
+			[],
+			[
+				'stream'   => true,
+				'blocking' => false,
+			]
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when the `stream` option is enabled globally for multiple requests.
+	 *
+	 * @covers \WpOrg\Requests\Requests::request_multiple
+	 *
+	 * @return void
+	 */
+	public function testStreamNotSupportedForMultipleRequests() {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('The stream option is not supported for multiple requests');
+
+		Requests::request_multiple(
+			[
+				['url' => 'http://example.com/'],
+			],
+			['stream' => true]
+		);
+	}
+
+	/**
+	 * Tests receiving an exception when the `stream` option is enabled for an individual request
+	 * within a multiple requests call.
+	 *
+	 * @covers \WpOrg\Requests\Requests::request_multiple
+	 *
+	 * @return void
+	 */
+	public function testStreamNotSupportedForMultipleRequestsPerRequest() {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('The stream option is not supported for multiple requests');
+
+		Requests::request_multiple(
+			[
+				[
+					'url'     => 'http://example.com/',
+					'options' => ['stream' => true],
+				],
+			]
+		);
+	}
+
 	public function testDefaultTransport() {
 		$request = Requests::get(new Iri($this->httpbin('/get')));
 		$this->assertSame(200, $request->status_code);

--- a/tests/Response/CloseTest.php
+++ b/tests/Response/CloseTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Response;
+
+use WpOrg\Requests\Hooks;
+use WpOrg\Requests\Response;
+use WpOrg\Requests\Response\Stream\Socket;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Response::close
+ */
+final class CloseTest extends TestCase {
+
+	public function testCloseWithoutStreamIsNoop() {
+		$response = new Response();
+		$response->close();
+
+		$this->assertFalse($response->is_streaming());
+	}
+
+	public function testCloseClosesAttachedStream() {
+		$handle = fopen('php://temp', 'r+b');
+		fwrite($handle, 'abcdef');
+		rewind($handle);
+
+		$response = new Response();
+		$response->set_stream(new Socket($handle, false, false, new Hooks()));
+
+		$response->close();
+
+		$this->assertTrue($response->eof(), 'Stream should be at EOF after close()');
+		$this->assertFalse(is_resource($handle), 'Underlying socket should be closed');
+		$this->assertSame('', $response->read(), 'Reading a closed stream should return an empty string');
+	}
+}

--- a/tests/Response/EofTest.php
+++ b/tests/Response/EofTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Response;
+
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Hooks;
+use WpOrg\Requests\Response;
+use WpOrg\Requests\Response\Stream\Socket;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Response::eof
+ */
+final class EofTest extends TestCase {
+
+	public function testEofThrowsWhenNotStreaming() {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Response is not being streamed');
+
+		$response = new Response();
+		$response->eof();
+	}
+
+	public function testEofReflectsStreamState() {
+		$handle = fopen('php://temp', 'r+b');
+		fwrite($handle, 'abc');
+		rewind($handle);
+
+		$response = new Response();
+		$response->set_stream(new Socket($handle, false, false, new Hooks()));
+
+		$this->assertFalse($response->eof(), 'EOF should not be reached before reading');
+
+		while (!$response->eof()) {
+			$response->read();
+		}
+
+		$this->assertTrue($response->eof(), 'EOF should be reached once the body is drained');
+	}
+}

--- a/tests/Response/IsStreamingTest.php
+++ b/tests/Response/IsStreamingTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Response;
+
+use WpOrg\Requests\Hooks;
+use WpOrg\Requests\Response;
+use WpOrg\Requests\Response\Stream\Socket;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Response::is_streaming
+ * @covers \WpOrg\Requests\Response::set_stream
+ */
+final class IsStreamingTest extends TestCase {
+
+	public function testNotStreamingByDefault() {
+		$response = new Response();
+
+		$this->assertFalse($response->is_streaming());
+	}
+
+	public function testStreamingOnceStreamAttached() {
+		$handle = fopen('php://temp', 'r+b');
+
+		$response = new Response();
+		$response->set_stream(new Socket($handle, false, false, new Hooks()));
+
+		$this->assertTrue($response->is_streaming());
+	}
+}

--- a/tests/Response/ReadTest.php
+++ b/tests/Response/ReadTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Response;
+
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Hooks;
+use WpOrg\Requests\Response;
+use WpOrg\Requests\Response\Stream\Socket;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Response::read
+ */
+final class ReadTest extends TestCase {
+
+	public function testReadThrowsWhenNotStreaming() {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Response is not being streamed');
+
+		$response = new Response();
+		$response->read();
+	}
+
+	public function testReadReadsFromAttachedStream() {
+		$response = $this->streamingResponse('abcdef');
+
+		$this->assertSame('abc', $response->read(3));
+		$this->assertSame('def', $response->read(3));
+	}
+
+	public function testReadLeavesBodyUntouched() {
+		$response = $this->streamingResponse('abcdef');
+		$response->read();
+
+		$this->assertSame('', $response->body);
+	}
+
+	/**
+	 * Build a response with a socket-backed body stream attached.
+	 *
+	 * @param string $data Raw body bytes.
+	 *
+	 * @return \WpOrg\Requests\Response
+	 */
+	private function streamingResponse($data) {
+		$handle = fopen('php://temp', 'r+b');
+		fwrite($handle, $data);
+		rewind($handle);
+
+		$response = new Response();
+		$response->set_stream(new Socket($handle, false, false, new Hooks()));
+
+		return $response;
+	}
+}

--- a/tests/Response/Stream/CloseTest.php
+++ b/tests/Response/Stream/CloseTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Response\Stream;
+
+use WpOrg\Requests\Hooks;
+use WpOrg\Requests\Response\Stream\Socket;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Response\Stream::close
+ * @covers \WpOrg\Requests\Response\Stream::__destruct
+ * @covers \WpOrg\Requests\Response\Stream\Socket::free
+ */
+final class CloseTest extends TestCase {
+
+	public function testCloseStopsReads() {
+		$stream = $this->streamFromString('abcdef');
+
+		$this->assertSame('abc', $stream->read(3), 'Pre-condition failed: first read should succeed');
+
+		$stream->close();
+
+		$this->assertTrue($stream->eof(), 'Stream should be at EOF after close()');
+		$this->assertSame('', $stream->read(3), 'Reading a closed stream should return an empty string');
+	}
+
+	public function testCloseReleasesTheSocket() {
+		$handle = fopen('php://temp', 'r+b');
+		$stream = new Socket($handle, false, false, new Hooks());
+
+		$stream->close();
+
+		$this->assertFalse(is_resource($handle), 'Underlying socket should be closed');
+	}
+
+	public function testCloseIsIdempotent() {
+		$stream = $this->streamFromString('abc');
+
+		$stream->close();
+		$stream->close();
+
+		$this->assertTrue($stream->eof());
+	}
+
+	public function testDestructorReleasesTheSocket() {
+		$handle = fopen('php://temp', 'r+b');
+		$stream = new Socket($handle, false, false, new Hooks());
+
+		unset($stream);
+
+		$this->assertFalse(is_resource($handle), 'Underlying socket should be closed on destruct');
+	}
+
+	/**
+	 * Build a socket-backed stream serving a fixed string from memory.
+	 *
+	 * @param string $data Raw body bytes.
+	 *
+	 * @return \WpOrg\Requests\Response\Stream\Socket
+	 */
+	private function streamFromString($data) {
+		$handle = fopen('php://temp', 'r+b');
+		fwrite($handle, $data);
+		rewind($handle);
+
+		return new Socket($handle, false, false, new Hooks());
+	}
+}

--- a/tests/Response/Stream/Curl/CloseTest.php
+++ b/tests/Response/Stream/Curl/CloseTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Response\Stream\Curl;
+
+use WpOrg\Requests\Hooks;
+use WpOrg\Requests\Response\Stream\Curl;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Response\Stream\Curl::free
+ * @covers \WpOrg\Requests\Response\Stream::close
+ * @covers \WpOrg\Requests\Response\Stream::__destruct
+ */
+final class CloseTest extends TestCase {
+
+	public function testCloseStopsReads() {
+		$stream = $this->makeStream('abc');
+
+		$stream->close();
+
+		$this->assertTrue($stream->eof(), 'Stream should be at EOF after close()');
+		$this->assertSame('', $stream->read(3), 'Reading a closed stream should return an empty string');
+	}
+
+	public function testCloseIsIdempotent() {
+		$stream = $this->makeStream('abc');
+
+		$stream->close();
+		$stream->close();
+
+		$this->assertTrue($stream->eof());
+	}
+
+	public function testDestructorReleasesTheHandles() {
+		$stream = $this->makeStream('abc');
+
+		unset($stream);
+
+		// The destructor ran without errors; nothing observable remains.
+		$this->assertTrue(true);
+	}
+
+	/**
+	 * Build a stream around freshly initialised cURL handles.
+	 *
+	 * @param string $prebuffered Body bytes received before the handoff.
+	 *
+	 * @return \WpOrg\Requests\Response\Stream\Curl
+	 */
+	private function makeStream($prebuffered = '') {
+		$handle = curl_init('http://127.0.0.1:1/');
+		$multi  = curl_multi_init();
+		curl_multi_add_handle($multi, $handle);
+
+		return new Curl($multi, $handle, $prebuffered, 1, false, new Hooks());
+	}
+}

--- a/tests/Response/Stream/Curl/FetchTest.php
+++ b/tests/Response/Stream/Curl/FetchTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Response\Stream\Curl;
+
+use WpOrg\Requests\Exception;
+use WpOrg\Requests\Hooks;
+use WpOrg\Requests\Response\Stream\Curl;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Response\Stream\Curl::fetch
+ */
+final class FetchTest extends TestCase {
+
+	public function testReadThrowsTimeoutWhenNoDataArrives() {
+		// A listener which accepts the connection but never responds.
+		$server = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+		$stream = $this->makeStream('http://' . stream_socket_get_name($server, false) . '/');
+
+		try {
+			$this->expectException(Exception::class);
+			$this->expectExceptionMessage('Stream timed out while waiting for body data');
+
+			$stream->read();
+		} finally {
+			$stream->close();
+			fclose($server);
+		}
+	}
+
+	public function testReadThrowsCurlerrorWhenTheTransferFails() {
+		// Grab a free port, then close the listener so connecting to it fails.
+		$server = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+		$url    = 'http://' . stream_socket_get_name($server, false) . '/';
+		fclose($server);
+
+		$stream = $this->makeStream($url);
+
+		try {
+			$this->expectException(Exception::class);
+			$this->expectExceptionMessage('cURL error');
+
+			$stream->read();
+		} finally {
+			$stream->close();
+		}
+	}
+
+	/**
+	 * Build a stream driving a not-yet-started transfer to the given URL.
+	 *
+	 * @param string $url URL to request.
+	 *
+	 * @return \WpOrg\Requests\Response\Stream\Curl
+	 */
+	private function makeStream($url) {
+		$handle = curl_init($url);
+		curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, 5);
+		$multi = curl_multi_init();
+		curl_multi_add_handle($multi, $handle);
+
+		return new Curl($multi, $handle, '', 1, false, new Hooks());
+	}
+}

--- a/tests/Response/Stream/Curl/ReceiveBodyTest.php
+++ b/tests/Response/Stream/Curl/ReceiveBodyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Response\Stream\Curl;
+
+use WpOrg\Requests\Hooks;
+use WpOrg\Requests\Response\Stream\Curl;
+use WpOrg\Requests\Tests\TestCase;
+
+/**
+ * @covers \WpOrg\Requests\Response\Stream\Curl::__construct
+ * @covers \WpOrg\Requests\Response\Stream\Curl::receive_body
+ * @covers \WpOrg\Requests\Response\Stream\Curl::receive_trailer
+ */
+final class ReceiveBodyTest extends TestCase {
+
+	public function testReceiveBodyBuffersData() {
+		$stream = $this->makeStream();
+
+		$this->assertSame(5, $stream->receive_body(null, 'hello'), 'All bytes should be accepted');
+		$this->assertSame('hello', $stream->read(5), 'Buffered bytes should be served by read()');
+	}
+
+	public function testReceiveBodyRespectsMaxBytes() {
+		$stream = $this->makeStream(8);
+
+		$this->assertSame(8, $stream->receive_body(null, 'hello world'), 'Only the bytes within max_bytes should be accepted');
+		$this->assertSame('hello wo', $stream->read(100));
+		$this->assertTrue($stream->eof(), 'Stream should be at EOF once max_bytes is reached');
+	}
+
+	public function testReceiveTrailerDiscardsData() {
+		$stream = $this->makeStream(false, 'abc');
+
+		$this->assertSame(16, $stream->receive_trailer(null, "X-Trailer: yes\r\n"), 'Trailer length should be acknowledged');
+		$this->assertSame('abc', $stream->read(100), 'Trailer data should not reach the body');
+	}
+
+	public function testPrebufferedBytesAreServedFirst() {
+		$stream = $this->makeStream(false, 'early');
+
+		$this->assertSame('early', $stream->read(5));
+	}
+
+	/**
+	 * Build a stream around freshly initialised cURL handles.
+	 *
+	 * The transfer is never started, so tests can drive the callbacks directly.
+	 *
+	 * @param int|false $max_bytes   Maximum number of body bytes to read.
+	 * @param string    $prebuffered Body bytes received before the handoff.
+	 *
+	 * @return \WpOrg\Requests\Response\Stream\Curl
+	 */
+	private function makeStream($max_bytes = false, $prebuffered = '') {
+		$handle = curl_init('http://127.0.0.1:1/');
+		$multi  = curl_multi_init();
+		curl_multi_add_handle($multi, $handle);
+
+		return new Curl($multi, $handle, $prebuffered, 1, $max_bytes, new Hooks());
+	}
+}

--- a/tests/Response/Stream/ReadTest.php
+++ b/tests/Response/Stream/ReadTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Response\Stream;
+
+use WpOrg\Requests\Exception\InvalidArgument;
+use WpOrg\Requests\Hooks;
+use WpOrg\Requests\Response\Stream\Socket;
+use WpOrg\Requests\Tests\Fixtures\TrickleStreamWrapper;
+use WpOrg\Requests\Tests\TestCase;
+use WpOrg\Requests\Tests\TypeProviderHelper;
+
+/**
+ * @covers \WpOrg\Requests\Response\Stream::read
+ * @covers \WpOrg\Requests\Response\Stream::eof
+ * @covers \WpOrg\Requests\Response\Stream\Socket::__construct
+ * @covers \WpOrg\Requests\Response\Stream\Socket::fetch
+ */
+final class ReadTest extends TestCase {
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		stream_wrapper_register(TrickleStreamWrapper::NAME, TrickleStreamWrapper::class);
+	}
+
+	public static function tear_down_after_class() {
+		stream_wrapper_unregister(TrickleStreamWrapper::NAME);
+		parent::tear_down_after_class();
+	}
+
+	public function testReadReturnsFullBodyAcrossMultipleReads() {
+		$stream = $this->streamFromString('Hello, streaming world!');
+
+		$body = '';
+		while (!$stream->eof()) {
+			$chunk = $stream->read(8);
+			$this->assertLessThanOrEqual(8, strlen($chunk), 'read() returned more bytes than requested');
+			$body .= $chunk;
+		}
+
+		$this->assertSame('Hello, streaming world!', $body);
+	}
+
+	public function testEofIsReachedOnceDrained() {
+		$stream = $this->streamFromString('abc');
+
+		$this->assertFalse($stream->eof(), 'Stream should not be at EOF before reading');
+
+		$stream->read(1024);
+		$this->assertSame('', $stream->read(1024), 'Reading past the end should return an empty string');
+		$this->assertTrue($stream->eof(), 'Stream should be at EOF once drained');
+	}
+
+	public function testReadDecodesChunkedBody() {
+		$stream = $this->streamFromString("4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n", true);
+
+		$this->assertSame('Wikipedia', $this->drain($stream));
+	}
+
+	public function testReadDecodesChunkedBodyDeliveredInFragments() {
+		// First read yields framing only (no body bytes), later reads split a
+		// chunk's data section.
+		$stream = $this->streamFromBlocks(["4\r\n", 'Wi', "ki\r\n", "5\r\npedia\r\n", "0\r\n\r\n"], true);
+		$this->assertSame('Wikipedia', $this->drain($stream), 'Body should survive framing-only reads');
+
+		// The chunk-size line itself is torn in the middle of its CRLF.
+		$stream = $this->streamFromBlocks(["9\r", "\nstreaming", "\r\n0\r\n\r\n"], true);
+		$this->assertSame('streaming', $this->drain($stream), 'Body should survive a torn chunk-size line');
+	}
+
+	public function testReadDoesNotTreatEmptyReadAsEndOfBody() {
+		$stream = $this->streamFromBlocks(['Hello', '', ' world']);
+
+		$this->assertSame('Hello world', $this->drain($stream));
+	}
+
+	public function testReadRespectsMaxBytes() {
+		$stream = $this->streamFromString(str_repeat('x', 1000), false, 100);
+
+		$this->assertSame(100, strlen($this->drain($stream)));
+		$this->assertTrue($stream->eof(), 'Stream should be at EOF once max_bytes is reached');
+	}
+
+	public function testReadFiresProgressHook() {
+		$captured = [];
+		$hooks    = new Hooks();
+		$hooks->register(
+			'request.progress',
+			function ($data, $bytes_so_far, $max_bytes) use (&$captured) {
+				$captured[] = [$data, $bytes_so_far, $max_bytes];
+			}
+		);
+
+		$stream = $this->streamFromString('abcdefghij', false, false, $hooks);
+		$stream->read(4);
+		$stream->read(4);
+
+		$this->assertSame(
+			[
+				['abcd', 0, false],
+				['efgh', 4, false],
+			],
+			$captured
+		);
+	}
+
+	/**
+	 * @dataProvider dataReadInvalidLength
+	 */
+	public function testReadInvalidLength($input) {
+		$this->expectException(InvalidArgument::class);
+		$this->expectExceptionMessage('::read(): Argument #1 ($length) must be of type positive integer');
+
+		$this->streamFromString('abc')->read($input);
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public static function dataReadInvalidLength() {
+		return array_merge(
+			TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT),
+			TypeProviderHelper::getSelection(['integer 0', 'negative integer'])
+		);
+	}
+
+	/**
+	 * Build a socket-backed stream serving a fixed string from memory.
+	 *
+	 * @param string                      $data      Raw body bytes.
+	 * @param bool                        $chunked   Whether to treat the body as chunked.
+	 * @param int|false                   $max_bytes Maximum number of bytes to read.
+	 * @param \WpOrg\Requests\Hooks|null  $hooks     Optional. Hook dispatcher.
+	 *
+	 * @return \WpOrg\Requests\Response\Stream\Socket
+	 */
+	private function streamFromString($data, $chunked = false, $max_bytes = false, $hooks = null) {
+		$handle = fopen('php://temp', 'r+b');
+		fwrite($handle, $data);
+		rewind($handle);
+
+		if ($hooks === null) {
+			$hooks = new Hooks();
+		}
+
+		return new Socket($handle, $chunked, $max_bytes, $hooks);
+	}
+
+	/**
+	 * Build a socket-backed stream serving predefined blocks one read at a time.
+	 *
+	 * @param array<string> $blocks  Blocks to serve, one per read.
+	 * @param bool          $chunked Whether to treat the body as chunked.
+	 *
+	 * @return \WpOrg\Requests\Response\Stream\Socket
+	 */
+	private function streamFromBlocks($blocks, $chunked = false) {
+		TrickleStreamWrapper::$script = $blocks;
+		$handle                       = fopen(TrickleStreamWrapper::NAME . '://body', 'rb');
+
+		return new Socket($handle, $chunked, false, new Hooks());
+	}
+
+	/**
+	 * Read a stream to the end and return the collected body.
+	 *
+	 * @param \WpOrg\Requests\Response\Stream $stream Stream to drain.
+	 *
+	 * @return string
+	 */
+	private function drain($stream) {
+		$body = '';
+		while (!$stream->eof()) {
+			$body .= $stream->read(4096);
+		}
+
+		return $body;
+	}
+}

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -10,6 +10,7 @@ use WpOrg\Requests\Hooks;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
+use WpOrg\Requests\Session;
 use WpOrg\Requests\Tests\Fixtures\TransportMock;
 use WpOrg\Requests\Tests\TestCase;
 use WpOrg\Requests\Tests\TypeProviderHelper;
@@ -1204,6 +1205,216 @@ abstract class BaseTestCase extends TestCase {
 
 		$this->assertSame(200, $request->status_code);
 		$this->assertSame('/get', substr($request->url, -4));
+	}
+
+	public function testStreamRetrievesFullBody() {
+		$buffered = Requests::get($this->httpbin('/bytes/8192'), [], $this->getOptions());
+		$expected = $buffered->body;
+
+		$response = Requests::get($this->httpbin('/bytes/8192'), [], $this->getOptions(['stream' => true]));
+
+		$this->assertTrue($response->is_streaming(), 'Response should be in streaming mode');
+		$this->assertSame(200, $response->status_code);
+		$this->assertSame('', $response->body, 'Body should not be buffered while streaming');
+
+		$body = '';
+		while (!$response->eof()) {
+			$body .= $response->read(1024);
+		}
+
+		$response->close();
+
+		$this->assertSame($expected, $body);
+	}
+
+	public function testStreamHeadersAvailableBeforeBodyIsRead() {
+		$response = Requests::get($this->httpbin('/get'), [], $this->getOptions(['stream' => true]));
+
+		$this->assertSame(200, $response->status_code);
+		$this->assertNotEmpty($response->headers['content-type']);
+		$this->assertSame('', $response->body);
+
+		$response->close();
+	}
+
+	public function testStreamBodyMatchesContent() {
+		$response = Requests::get($this->httpbin('/get'), [], $this->getOptions(['stream' => true]));
+
+		$body = '';
+		while (!$response->eof()) {
+			$body .= $response->read();
+		}
+
+		$response->close();
+
+		$result = json_decode($body, true);
+		$this->assertSame($this->httpbin('/get'), $result['url']);
+	}
+
+	public function testStreamDecodesChunkedResponse() {
+		$response = Requests::get($this->httpbin('/stream/3'), [], $this->getOptions(['stream' => true]));
+
+		$body = '';
+		while (!$response->eof()) {
+			$body .= $response->read(16);
+		}
+
+		$response->close();
+
+		$this->assertSame(200, $response->status_code);
+		$this->assertSame(3, substr_count($body, '"id"'), 'All three streamed objects should be received');
+		$this->assertStringNotContainsString("\r\n", $body, 'Chunked framing should not leak into the body');
+	}
+
+	public function testStreamDeliversRawBytesWhenServerCompressesAnyway() {
+		if (!function_exists('gzdecode')) {
+			$this->markTestSkipped('zlib is not available');
+		}
+
+		// The /gzip route compresses no matter what Accept-Encoding says.
+		$response = Requests::get($this->httpbin('/gzip'), [], $this->getOptions(['stream' => true]));
+
+		$body = '';
+		while (!$response->eof()) {
+			$body .= $response->read();
+		}
+
+		$response->close();
+
+		$this->assertSame('gzip', $response->headers['content-encoding']);
+
+		$decoded = gzdecode($body);
+		$this->assertNotFalse($decoded, 'Streamed bytes should be the raw gzip payload');
+
+		$result = json_decode($decoded, true);
+		$this->assertTrue($result['gzipped']);
+	}
+
+	public function testStreamRespectsMaxBytes() {
+		$limit    = 100;
+		$options  = [
+			'stream'    => true,
+			'max_bytes' => $limit,
+			'hooks'     => $this->getMaxBytesAssertionHooks(),
+		];
+		$response = Requests::get($this->httpbin('/bytes/10240'), [], $this->getOptions($options));
+
+		$body = '';
+		while (!$response->eof()) {
+			$body .= $response->read(4096);
+		}
+
+		$response->close();
+
+		$this->assertSame($limit, strlen($body));
+	}
+
+	public function testStreamFollowsRedirects() {
+		$response = Requests::get($this->httpbin('/redirect/2'), [], $this->getOptions(['stream' => true]));
+
+		$this->assertSame(200, $response->status_code);
+		$this->assertSame(2, $response->redirects);
+		$this->assertNotEmpty($response->history);
+		$this->assertTrue($response->is_streaming(), 'Final response should be in streaming mode');
+
+		$body = '';
+		while (!$response->eof()) {
+			$body .= $response->read();
+		}
+
+		$response->close();
+
+		$result = json_decode($body, true);
+		$this->assertSame($this->httpbin('/get'), $result['url'], 'Streamed body should be that of the final response');
+	}
+
+	public function testStreamFiresProgressHook() {
+		$mock = $this->getMockedStdClassWithMethods(['progress']);
+		$mock->expects($this->atLeastOnce())->method('progress');
+
+		$hooks = new Hooks();
+		$hooks->register('request.progress', [$mock, 'progress']);
+
+		$response = Requests::get($this->httpbin('/bytes/2048'), [], $this->getOptions(['stream' => true, 'hooks' => $hooks]));
+
+		while (!$response->eof()) {
+			$response->read(512);
+		}
+
+		$response->close();
+	}
+
+	public function testStreamCloseStopsReading() {
+		$response = Requests::get($this->httpbin('/bytes/10240'), [], $this->getOptions(['stream' => true]));
+
+		$this->assertNotSame('', $response->read(128), 'Pre-condition failed: first read should return data');
+
+		$response->close();
+
+		$this->assertTrue($response->eof(), 'Stream should be at EOF after close()');
+		$this->assertSame('', $response->read(128), 'Reading a closed stream should return an empty string');
+	}
+
+	public function testStreamHEADRequestReachesEofImmediately() {
+		$response = Requests::head($this->httpbin('/get'), [], $this->getOptions(['stream' => true]));
+
+		$this->assertSame(200, $response->status_code);
+		$this->assertSame('', $response->read(), 'A HEAD response has no body to read');
+		$this->assertTrue($response->eof());
+
+		$response->close();
+	}
+
+	public function testStreamWithPOSTRequest() {
+		$data     = ['test' => 'true', 'test2' => 'test'];
+		$response = Requests::post($this->httpbin('/post'), [], $data, $this->getOptions(['stream' => true]));
+
+		$body = '';
+		while (!$response->eof()) {
+			$body .= $response->read();
+		}
+
+		$response->close();
+
+		$result = json_decode($body, true);
+		$this->assertSame($data, $result['form']);
+	}
+
+	public function testStreamWorksWithSession() {
+		$session  = new Session($this->httpbin(), [], [], $this->getOptions(['stream' => true]));
+		$response = $session->get('/get');
+
+		$this->assertTrue($response->is_streaming());
+
+		$body = '';
+		while (!$response->eof()) {
+			$body .= $response->read();
+		}
+
+		$response->close();
+
+		$result = json_decode($body, true);
+		$this->assertSame($this->httpbin('/get'), $result['url']);
+	}
+
+	public function testStreamThenReuseTransport() {
+		$transport = new $this->transport();
+
+		// Stream a request to completion on a shared transport instance.
+		$first = Requests::get($this->httpbin('/get'), [], $this->getOptions(['transport' => $transport, 'stream' => true]));
+		while (!$first->eof()) {
+			$first->read();
+		}
+
+		$first->close();
+
+		// The same transport instance must remain usable afterwards for a
+		// regular buffered request (for cURL, the handle is re-initialised
+		// after having been handed off to the stream).
+		$second = Requests::get($this->httpbin('/get'), [], $this->getOptions(['transport' => $transport]));
+
+		$this->assertSame(200, $second->status_code);
+		$this->assertNotEmpty($second->body);
 	}
 
 	/**

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -1417,6 +1417,21 @@ abstract class BaseTestCase extends TestCase {
 		$this->assertNotEmpty($second->body);
 	}
 
+	public function testStreamTimesOutWhenServerStalls() {
+		// A listener which accepts the connection but never responds.
+		$server = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+		$url    = 'http://' . stream_socket_get_name($server, false) . '/';
+
+		try {
+			$this->expectException(Exception::class);
+			$this->expectExceptionMessage('timed out');
+
+			Requests::get($url, [], $this->getOptions(['stream' => true, 'timeout' => 1]));
+		} finally {
+			fclose($server);
+		}
+	}
+
 	/**
 	 * Get a Hooks instance that asserts correct enforcement for max_bytes.
 	 *

--- a/tests/Transport/Curl/CurlTest.php
+++ b/tests/Transport/Curl/CurlTest.php
@@ -137,4 +137,17 @@ final class CurlTest extends BaseTestCase {
 
 		$this->assertFalse(isset($result['headers']['Expect']));
 	}
+
+	public function testStreamThrowsWhenTheConnectionFails() {
+		// Grab a free port, then close the listener so connecting to it fails
+		// while the transfer is being advanced to receive the headers.
+		$server = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+		$url    = 'http://' . stream_socket_get_name($server, false) . '/';
+		fclose($server);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('cURL error');
+
+		Requests::get($url, [], $this->getOptions(['stream' => true, 'timeout' => 2]));
+	}
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/Requests/issues/1056

<!--
Thank you for creating this pull request!

Provide a general summary of your changes in the Title above.
And please provide enough information in the description below, so that others can review your pull request (PR).
-->

## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [x] New feature
- [ ] Documentation improvement
- [ ] Code quality improvement

## Context
Adds opt-in support for reading HTTP response bodies incrementally as they arrive instead of buffering the entire response before returning. This provides the low-level primitive needed for streaming consumers while preserving the existing behavior for all non-streaming requests.


## Detailed Description

- Adds an opt-in streaming mode for Requests responses.
- Introduces a readable response body that can be consumed incrementally while the transfer is still in progress.
- Updates the cURL and fsockopen transports to expose response data without eagerly buffering the complete body when streaming is enabled.
- Preserves the existing buffered behavior by default, so there are no changes for existing callers.
- Lays the foundation for `WP_Http` to expose streaming responses and for higher-level consumers, such as the AI client SDK, to process streamed HTTP responses using a pull-based API.



## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added unit tests to accompany this PR.
- [x] The (new/existing) tests cover this PR 100%.
- [x] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.

## Documentation

For new features:
- [x] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [x] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!
I.e. code style complies with the project standard, the unit tests pass, code coverage has not gone down.

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make reviewing your changes easier for the maintainers.
============================================================================================
-->
